### PR TITLE
[R/writeFormula] write array formula

### DIFF
--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -30,7 +30,8 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
   dims_to_df(
     rows = rows,
     cols = cols,
-    fill = fill)
+    fill = fill
+  )
 }
 
 # # similar to all, simply check if most of the values match the condition
@@ -631,7 +632,7 @@ wb_to_df <- function(
 #'
 #' @export
 update_cell <- function(x, wb, sheet, cell, data_class,
-                        colNames = FALSE, removeCellStyle = FALSE, ref = "") {
+                        colNames = FALSE, removeCellStyle = FALSE) {
 
   dimensions <- unlist(strsplit(cell, ":"))
   rows <- gsub("[[:upper:]]","", dimensions)
@@ -763,17 +764,17 @@ update_cell <- function(x, wb, sheet, cell, data_class,
 
         cc[sel, c(c_s, "c_t", "v", "f", "f_t", "f_ref", "f_ca", "f_si", "is")] <- "_openxlsx_NA_"
 
-        assign("dc", data_class, globalenv())
         # for now convert all R-characters to inlineStr (e.g. names() of a dataframe)
         if (celltyp(data_class[m]) == 4 | (colNames == TRUE & n == 1)) {
           cc[sel, "c_t"] <- "inlineStr"
           cc[sel, "is"]   <- paste0("<is><t>", as.character(value), "</t></is>")
         } else if (celltyp(data_class[m]) == 5) {
+          cc[sel, "c_t"] <- "str"
           cc[sel, "f"] <- as.character(value)
         } else if (celltyp(data_class[m]) == 11) {
           cc[sel, "f"] <- as.character(value)
           cc[sel, "f_t"] <- "array"
-          cc[sel, "f_ref"] <- ref
+          cc[sel, "f_ref"] <- cell
         }else if (celltyp(data_class[m]) == 10) {
           cc[sel, "f"] <- as.character(value)
           # FIXME assign the hyperlinkstyle if no style found. This might not be
@@ -899,7 +900,6 @@ nmfmt_df <- function(x) {
 #' @param startRow row to place it
 #' @param startCol col to place it
 #' @param removeCellStyle keep the cell style?
-#' @param ref A reference vector for array formulas "A1:A2"
 #' @details
 #' The string `"_openxlsx_NA"` is reserved for `openxlsx2`. If the data frame
 #' contains this string, the output will be broken.
@@ -930,15 +930,13 @@ nmfmt_df <- function(x) {
 writeData2 <-function(wb, sheet, data, name = NULL,
                       colNames = TRUE, rowNames = FALSE,
                       startRow = 1, startCol = 1,
-                      removeCellStyle = FALSE,
-                      ref = "") {
+                      removeCellStyle = FALSE) {
 
 
   is_data_frame <- FALSE
   #### prepare the correct data formats for openxml
   data_class <- as.data.frame(Map(class, data))
   dc <- numfmt_class(data)
-  assign("dc", dc, globalenv())
 
   # if hyperlinks are found, Excel sets something like the following font
   # blue with underline
@@ -1008,10 +1006,11 @@ writeData2 <-function(wb, sheet, data, name = NULL,
   endRow <- (startRow -1) + data_nrow
   endCol <- (startCol -1) + data_ncol
 
-
-  dims <- paste0(int2col(startCol), startRow,
+  dims <- paste0(
+    int2col(startCol), startRow,
     ":",
-    int2col(endCol), endRow)
+    int2col(endCol), endRow
+  )
 
   # TODO writing defined name should handle global and local: localSheetId
   # this requires access to wb$workbook.
@@ -1186,7 +1185,7 @@ writeData2 <-function(wb, sheet, data, name = NULL,
       ColNames = colNames,
       start_col = startCol,
       start_row = startRow,
-      ref = ref
+      ref = dims
     )
 
     # if any v is missing, set typ to 'e'. v is only filled for non character
@@ -1223,8 +1222,7 @@ writeData2 <-function(wb, sheet, data, name = NULL,
       dims,
       data_class,
       colNames,
-      removeCellStyle,
-      ref
+      removeCellStyle
     )
   }
 

--- a/R/writeData.R
+++ b/R/writeData.R
@@ -7,7 +7,6 @@
 #' @param startCol A vector specifying the starting column to write to.
 #' @param startRow A vector specifying the starting row to write to.
 #' @param array A bool if the function written is of type array
-#' @param ref A reference vector for array formulas "A1:A2"
 #' @param xy An alternative to specifying `startCol` and
 #' `startRow` individually.  A vector of the form
 #' `c(startCol, startRow)`.
@@ -101,7 +100,6 @@ writeData <- function(wb,
   startCol = 1,
   startRow = 1,
   array = FALSE,
-  ref = "",
   xy = NULL,
   colNames = TRUE,
   rowNames = FALSE,
@@ -254,8 +252,6 @@ writeData <- function(wb,
     }
   }
 
-  assign("x", x, globalenv())
-
   # actual driver, the rest should not create data used for writing
   wb <- writeData2(
     wb = wb,
@@ -266,8 +262,7 @@ writeData <- function(wb,
     rowNames = FALSE,
     startRow = startRow,
     startCol = startCol,
-    removeCellStyle = removeCellStyle,
-    ref = ref
+    removeCellStyle = removeCellStyle
   )
 
   invisible(0)
@@ -294,7 +289,6 @@ writeData <- function(wb,
 #' @param startCol A vector specifying the starting column to write to.
 #' @param startRow A vector specifying the starting row to write to.
 #' @param array A bool if the function written is of type array
-#' @param ref A reference vector for array formulas "A1:A2"
 #' @param xy An alternative to specifying `startCol` and
 #' `startRow` individually.  A vector of the form
 #' `c(startCol, startRow)`.
@@ -361,7 +355,7 @@ writeData <- function(wb,
 #' wb_save(wb, "writeFormulaHyperlinkExample.xlsx", overwrite = TRUE)
 #' }
 #'
-#' ## write array formulas
+#' ## 5. - Writing array formulas
 #' set.seed(123)
 #' df <- data.frame(C = rnorm(10), D = rnorm(10))
 #'
@@ -371,7 +365,7 @@ writeData <- function(wb,
 #' writeData(wb, "df", df, startCol = "C")
 #'
 #' writeFormula(wb, "df", startCol = "E", startRow = "2",
-#'              x = "SUM(C2:C11*D2:D11)", ref = "C2:D11",
+#'              x = "SUM(C2:C11*D2:D11)",
 #'              array = TRUE)
 #'
 writeFormula <- function(wb,
@@ -380,13 +374,10 @@ writeFormula <- function(wb,
   startCol = 1,
   startRow = 1,
   array = FALSE,
-  ref = "",
   xy = NULL) {
   assert_class(x, "character")
   dfx <- data.frame("X" = x, stringsAsFactors = FALSE)
   class(dfx$X) <- c("character", if (array) "array_formula" else "formula")
-
-  assign("dfx", dfx, globalenv())
 
   if (any(grepl("^(=|)HYPERLINK\\(", x, ignore.case = TRUE))) {
     class(dfx$X) <- c("character", "formula", "hyperlink")
@@ -399,7 +390,6 @@ writeFormula <- function(wb,
     startCol = startCol,
     startRow = startRow,
     array = array,
-    ref = ref,
     xy = xy,
     colNames = FALSE,
     rowNames = FALSE

--- a/man/update_cell.Rd
+++ b/man/update_cell.Rd
@@ -11,8 +11,7 @@ update_cell(
   cell,
   data_class,
   colNames = FALSE,
-  removeCellStyle = FALSE,
-  ref = ""
+  removeCellStyle = FALSE
 )
 }
 \arguments{

--- a/man/writeData.Rd
+++ b/man/writeData.Rd
@@ -11,7 +11,6 @@ writeData(
   startCol = 1,
   startRow = 1,
   array = FALSE,
-  ref = "",
   xy = NULL,
   colNames = TRUE,
   rowNames = FALSE,
@@ -35,8 +34,6 @@ writeData(
 \item{startRow}{A vector specifying the starting row to write to.}
 
 \item{array}{A bool if the function written is of type array}
-
-\item{ref}{A reference vector for array formulas "A1:A2"}
 
 \item{xy}{An alternative to specifying \code{startCol} and
 \code{startRow} individually.  A vector of the form

--- a/man/writeData2.Rd
+++ b/man/writeData2.Rd
@@ -13,8 +13,7 @@ writeData2(
   rowNames = FALSE,
   startRow = 1,
   startCol = 1,
-  removeCellStyle = FALSE,
-  ref = ""
+  removeCellStyle = FALSE
 )
 }
 \arguments{
@@ -35,8 +34,6 @@ writeData2(
 \item{startCol}{col to place it}
 
 \item{removeCellStyle}{keep the cell style?}
-
-\item{ref}{A reference vector for array formulas "A1:A2"}
 }
 \description{
 dummy function to write data

--- a/man/writeFormula.Rd
+++ b/man/writeFormula.Rd
@@ -11,7 +11,6 @@ writeFormula(
   startCol = 1,
   startRow = 1,
   array = FALSE,
-  ref = "",
   xy = NULL
 )
 }
@@ -27,8 +26,6 @@ writeFormula(
 \item{startRow}{A vector specifying the starting row to write to.}
 
 \item{array}{A bool if the function written is of type array}
-
-\item{ref}{A reference vector for array formulas "A1:A2"}
 
 \item{xy}{An alternative to specifying \code{startCol} and
 \code{startRow} individually.  A vector of the form
@@ -109,7 +106,7 @@ writeFormula(wb, "Sheet1", x = '=HYPERLINK("#Sheet2!B3", "Text to Display - Link
 wb_save(wb, "writeFormulaHyperlinkExample.xlsx", overwrite = TRUE)
 }
 
-## write array formulas
+## 5. - Writing array formulas
 set.seed(123)
 df <- data.frame(C = rnorm(10), D = rnorm(10))
 
@@ -119,7 +116,7 @@ wb <- wb_add_worksheet(wb, "df")
 writeData(wb, "df", df, startCol = "C")
 
 writeFormula(wb, "df", startCol = "E", startRow = "2",
-             x = "SUM(C2:C11*D2:D11)", ref = "C2:D11",
+             x = "SUM(C2:C11*D2:D11)",
              array = TRUE)
 
 }

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -240,7 +240,6 @@ void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame 
         cell.f   = vals;
         break;
       case array_formula:
-        cell.c_t = "str";
         cell.f   = vals;
         cell.f_t = "array";
         cell.f_ref = ref[i];
@@ -252,14 +251,15 @@ void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame 
 
       Rcpp::as<Rcpp::CharacterVector>(zz["row_r"])[pos] = row;
       Rcpp::as<Rcpp::CharacterVector>(zz["c_r"])[pos]   = col;
-      if (cell.v   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["v"])[pos]   = cell.v;
-      if (cell.c_s != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["c_s"])[pos] = cell.c_s;
-      if (cell.c_t != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["c_t"])[pos] = cell.c_t;
-      if (cell.is  != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["is"])[pos]  = cell.is;
-      if (cell.f   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f"])[pos]   = cell.f;
-      if (cell.f_t != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f_t"])[pos] = cell.f_t;
-      if (cell.typ != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["typ"])[pos] = cell.typ;
-      if (cell.r   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["r"])[pos]   = cell.r;
+      if (cell.v     != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["v"])[pos]     = cell.v;
+      if (cell.c_s   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["c_s"])[pos]   = cell.c_s;
+      if (cell.c_t   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["c_t"])[pos]   = cell.c_t;
+      if (cell.is    != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["is"])[pos]    = cell.is;
+      if (cell.f     != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f"])[pos]     = cell.f;
+      if (cell.f_t   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f_t"])[pos]   = cell.f_t;
+      if (cell.f_ref != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f_ref"])[pos] = cell.f_ref;
+      if (cell.typ   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["typ"])[pos]   = cell.typ;
+      if (cell.r     != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["r"])[pos]     = cell.r;
 
       ++startrow;
     }

--- a/tests/testthat/test-writeData.R
+++ b/tests/testthat/test-writeData.R
@@ -1,0 +1,41 @@
+test_that("writeFormula", {
+
+  set.seed(123)
+  df <- data.frame(C = rnorm(10), D = rnorm(10))
+
+  # array formula for a single cell
+  exp <- structure(
+    list(row_r = "2", c_r = "E", c_s = "_openxlsx_NA_",
+         c_t = "_openxlsx_NA_", v = "_openxlsx_NA_",
+         f = "SUM(C2:C11*D2:D11)",  f_t = "array", f_ref = "E2:E2",
+         f_ca = "_openxlsx_NA_", f_si = "_openxlsx_NA_",
+         is = "_openxlsx_NA_", typ = NA_character_, r = "E2"),
+    row.names = "3", class = "data.frame")
+
+  # write data add array formula later
+  wb <- wb_workbook()
+  wb <- wb_add_worksheet(wb, "df")
+  writeData(wb, "df", df, startCol = "C")
+  writeFormula(wb, "df", startCol = "E", startRow = "2",
+               x = "SUM(C2:C11*D2:D11)",
+               array = TRUE)
+
+  cc <- wb$worksheets[[1]]$sheet_data$cc
+  got <- cc[cc$row_r == "2" & cc$c_r == "E",]
+  expect_equal(exp[1:11], got[1:11])
+
+
+  rownames(exp) <- "31"
+  # write formula first add data later
+  wb <- wb_workbook()
+  wb <- wb_add_worksheet(wb, "df")
+  writeFormula(wb, "df", startCol = "E", startRow = "2",
+               x = "SUM(C2:C11*D2:D11)",
+               array = TRUE)
+  writeData(wb, "df", df, startCol = "C")
+
+  cc <- wb$worksheets[[1]]$sheet_data$cc
+  got <- cc[cc$row_r == "2" & cc$c_r == "E",]
+  expect_equal(exp[1:11], got[1:11])
+
+})


### PR DESCRIPTION
Allows writing single cell array formulas. Will require fixes for `length(formula) > 1`. For now this always sets `ref` to the cell we are writing to. This might not cover all possible array formulas in Excel. There might be a few, that take some other `ref` (like regression functions, were coefficients are written to different cells).