### PR TITLE
explicitly use "sh" for shQuote()

### DIFF
--- a/R/openXL.R
+++ b/R/openXL.R
@@ -56,7 +56,7 @@ openXL <- function(file = NULL) {
     myCommand <- paste(app, file, "&", sep = " ")
     system(command = myCommand)
   } else if ("Windows" == userSystem) {
-    shell(shQuote(string = file), wait = FALSE) # nolint
+    shell(shQuote(file, "sh"), wait = FALSE) # nolint
   } else if ("Darwin" == userSystem) {
     myCommand <- paste0("open ", file)
     system(command = myCommand)

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -916,7 +916,7 @@ writeData2 <-function(wb, sheet, data, name = NULL,
   if (!is.null(name)) {
 
     sheet_name <- wb$sheet_names[[sheetno]]
-    if (grepl(" ", sheet_name)) sheet_name <- shQuote(sheet_name)
+    if (grepl(" ", sheet_name)) sheet_name <- shQuote(sheet_name, "sh")
 
     sheet_dim <- paste0(sheet_name, "!", dims)
 


### PR DESCRIPTION
resolves #119 

Luckily, `shQuote()` only seems to be in two places.