### PR TITLE
[R/conditional_formatting] fix multiple databar entries per sheet

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # openxlsx2 (development version)
 
+* fix writing xlsx file with multiple entries of conditional formatting type databar on any sheet. [174](https://github.com/JanMarvin/openxlsx2/pull/174) 
+
 * Cell fields cm, ph and vm are now implemented for reading and writing. This is the first step to handle functions that use metadata. [173](https://github.com/JanMarvin/openxlsx2/pull/173)
 
 * `openxlsx2Coerce()` (which was called on `x` objects when adding data to a workbook) has been removed.  Users can no longer pass some arbitrary objects and will need to format these objects appropriately or rely on `as.data.frame` methods  [167](https://github.com/JanMarvin/openxlsx2/issues/167)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -193,8 +193,16 @@ xml_node_create <- function(xml_name, xml_children = NULL, xml_attributes = NULL
     .Call(`_openxlsx2_xml_node_create`, xml_name, xml_children, xml_attributes, escapes, declaration)
 }
 
-xml_append_child <- function(node, child, pointer, escapes) {
-    .Call(`_openxlsx2_xml_append_child`, node, child, pointer, escapes)
+xml_append_child1 <- function(node, child, pointer, escapes) {
+    .Call(`_openxlsx2_xml_append_child1`, node, child, pointer, escapes)
+}
+
+xml_append_child2 <- function(node, child, level1, pointer, escapes) {
+    .Call(`_openxlsx2_xml_append_child2`, node, child, level1, pointer, escapes)
+}
+
+xml_append_child3 <- function(node, child, level1, level2, pointer, escapes) {
+    .Call(`_openxlsx2_xml_append_child3`, node, child, level1, level2, pointer, escapes)
 }
 
 si_to_txt <- function(doc) {

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -250,15 +250,24 @@ write_file <- function(head = "", body = "", tail = "", fl = "", escapes = FALSE
 #' append xml child to node
 #' @param xml_node xml_node
 #' @param xml_child xml_child
+#' @param level optional level, if missing the first child is picked
 #' @param pointer pointer
 #' @param escapes escapes
 #' @examples
-#' xml_node <- "<node><child1/><child2/></node>"
-#' xml_child <- "<new_child/>"
+#' xml_node <- "<a><b/></a>"
+#' xml_child <- "<c/>"
 #'
+#' # add child to first level node
 #' xml_add_child(xml_node, xml_child)
+#'
+#' # add child to second level node as request
+#' xml_node <- xml_add_child(xml_node, xml_child, level = c("b"))
+#'
+#' # add child to third level node as request
+#' xml_node <- xml_add_child(xml_node, "<d/>", level = c("b", "c"))
+#'
 #' @export
-xml_add_child <- function(xml_node, xml_child, pointer = FALSE, escapes = FALSE) {
+xml_add_child <- function(xml_node, xml_child, level, pointer = FALSE, escapes = FALSE) {
 
   if (missing(xml_node))
     stop("need xml_node")
@@ -269,7 +278,17 @@ xml_add_child <- function(xml_node, xml_child, pointer = FALSE, escapes = FALSE)
   xml_node <- read_xml(xml_node)
   xml_child <- read_xml(xml_child)
 
-  z <- xml_append_child(xml_node, xml_child, pointer, escapes)
+  if (missing(level)) {
+    z <- xml_append_child1(xml_node, xml_child, pointer, escapes)
+  } else {
+
+    if (length(level) == 1)
+      z <- xml_append_child2(xml_node, xml_child, level[[1]], pointer, escapes)
+
+    if (length(level) == 2)
+      z <- xml_append_child3(xml_node, xml_child, level[[1]], level[[2]], pointer, escapes)
+ 
+  }
 
   return(z)
 }

--- a/man/xml_add_child.Rd
+++ b/man/xml_add_child.Rd
@@ -4,12 +4,14 @@
 \alias{xml_add_child}
 \title{append xml child to node}
 \usage{
-xml_add_child(xml_node, xml_child, pointer = FALSE, escapes = FALSE)
+xml_add_child(xml_node, xml_child, level, pointer = FALSE, escapes = FALSE)
 }
 \arguments{
 \item{xml_node}{xml_node}
 
 \item{xml_child}{xml_child}
+
+\item{level}{optional level, if missing the first child is picked}
 
 \item{pointer}{pointer}
 
@@ -19,8 +21,16 @@ xml_add_child(xml_node, xml_child, pointer = FALSE, escapes = FALSE)
 append xml child to node
 }
 \examples{
-xml_node <- "<node><child1/><child2/></node>"
-xml_child <- "<new_child/>"
+xml_node <- "<a><b/></a>"
+xml_child <- "<c/>"
 
+# add child to first level node
 xml_add_child(xml_node, xml_child)
+
+# add child to second level node as request
+xml_node <- xml_add_child(xml_node, xml_child, level = c("b"))
+
+# add child to third level node as request
+xml_node <- xml_add_child(xml_node, "<d/>", level = c("b", "c"))
+
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -431,9 +431,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// xml_append_child
-SEXP xml_append_child(XPtrXML node, XPtrXML child, bool pointer, bool escapes);
-RcppExport SEXP _openxlsx2_xml_append_child(SEXP nodeSEXP, SEXP childSEXP, SEXP pointerSEXP, SEXP escapesSEXP) {
+// xml_append_child1
+SEXP xml_append_child1(XPtrXML node, XPtrXML child, bool pointer, bool escapes);
+RcppExport SEXP _openxlsx2_xml_append_child1(SEXP nodeSEXP, SEXP childSEXP, SEXP pointerSEXP, SEXP escapesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -441,7 +441,38 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< XPtrXML >::type child(childSEXP);
     Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
     Rcpp::traits::input_parameter< bool >::type escapes(escapesSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_append_child(node, child, pointer, escapes));
+    rcpp_result_gen = Rcpp::wrap(xml_append_child1(node, child, pointer, escapes));
+    return rcpp_result_gen;
+END_RCPP
+}
+// xml_append_child2
+SEXP xml_append_child2(XPtrXML node, XPtrXML child, std::string level1, bool pointer, bool escapes);
+RcppExport SEXP _openxlsx2_xml_append_child2(SEXP nodeSEXP, SEXP childSEXP, SEXP level1SEXP, SEXP pointerSEXP, SEXP escapesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
+    Rcpp::traits::input_parameter< XPtrXML >::type child(childSEXP);
+    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
+    Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
+    Rcpp::traits::input_parameter< bool >::type escapes(escapesSEXP);
+    rcpp_result_gen = Rcpp::wrap(xml_append_child2(node, child, level1, pointer, escapes));
+    return rcpp_result_gen;
+END_RCPP
+}
+// xml_append_child3
+SEXP xml_append_child3(XPtrXML node, XPtrXML child, std::string level1, std::string level2, bool pointer, bool escapes);
+RcppExport SEXP _openxlsx2_xml_append_child3(SEXP nodeSEXP, SEXP childSEXP, SEXP level1SEXP, SEXP level2SEXP, SEXP pointerSEXP, SEXP escapesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
+    Rcpp::traits::input_parameter< XPtrXML >::type child(childSEXP);
+    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
+    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
+    Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
+    Rcpp::traits::input_parameter< bool >::type escapes(escapesSEXP);
+    rcpp_result_gen = Rcpp::wrap(xml_append_child3(node, child, level1, level2, pointer, escapes));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -751,7 +782,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_write_xml_file", (DL_FUNC) &_openxlsx2_write_xml_file, 3},
     {"_openxlsx2_xml_attr_mod", (DL_FUNC) &_openxlsx2_xml_attr_mod, 4},
     {"_openxlsx2_xml_node_create", (DL_FUNC) &_openxlsx2_xml_node_create, 5},
-    {"_openxlsx2_xml_append_child", (DL_FUNC) &_openxlsx2_xml_append_child, 4},
+    {"_openxlsx2_xml_append_child1", (DL_FUNC) &_openxlsx2_xml_append_child1, 4},
+    {"_openxlsx2_xml_append_child2", (DL_FUNC) &_openxlsx2_xml_append_child2, 5},
+    {"_openxlsx2_xml_append_child3", (DL_FUNC) &_openxlsx2_xml_append_child3, 6},
     {"_openxlsx2_si_to_txt", (DL_FUNC) &_openxlsx2_si_to_txt, 1},
     {"_openxlsx2_txt_to_si", (DL_FUNC) &_openxlsx2_txt_to_si, 3},
     {"_openxlsx2_is_to_txt", (DL_FUNC) &_openxlsx2_is_to_txt, 1},

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -640,19 +640,74 @@ Rcpp::CharacterVector xml_node_create(
   return xml_return;
 }
 
-// xml_append_child
+// xml_append_child1
 // @param node xml_node a child is appended to
 // @param child the xml_node appended to node
 // @param escapes bool if escapes should be used
 // @export
 // [[Rcpp::export]]
-SEXP xml_append_child(XPtrXML node, XPtrXML child, bool pointer, bool escapes) {
+SEXP xml_append_child1(XPtrXML node, XPtrXML child, bool pointer, bool escapes) {
 
   unsigned int pugi_format_flags = pugi::format_raw;
   if (!escapes) pugi_format_flags |= pugi::format_no_escapes;
 
   for (auto cld: child->children()) {
     node->first_child().append_copy(cld);
+  }
+
+  if (pointer) {
+    return (node);
+  } else {
+    std::ostringstream oss;
+    node->print(oss, " ", pugi_format_flags);
+    std::string xml_return = oss.str();
+
+    return Rcpp::wrap(xml_return);
+  }
+}
+
+// xml_append_child2
+// @param node xml_node a child is appended to
+// @param child the xml_node appended to node
+// @param level1 level the child will be added to
+// @param escapes bool if escapes should be used
+// @export
+// [[Rcpp::export]]
+SEXP xml_append_child2(XPtrXML node, XPtrXML child, std::string level1, bool pointer, bool escapes) {
+
+  unsigned int pugi_format_flags = pugi::format_raw;
+  if (!escapes) pugi_format_flags |= pugi::format_no_escapes;
+
+  for (auto cld: child->children()) {
+    node->first_child().child(level1.c_str()).append_copy(cld);
+  }
+
+  if (pointer) {
+    return (node);
+  } else {
+    std::ostringstream oss;
+    node->print(oss, " ", pugi_format_flags);
+    std::string xml_return = oss.str();
+
+    return Rcpp::wrap(xml_return);
+  }
+}
+
+// xml_append_child3
+// @param node xml_node a child is appended to
+// @param child the xml_node appended to node
+// @param level1 level the child will be added to
+// @param level2 level the child will be added to
+// @param escapes bool if escapes should be used
+// @export
+// [[Rcpp::export]]
+SEXP xml_append_child3(XPtrXML node, XPtrXML child, std::string level1, std::string level2, bool pointer, bool escapes) {
+
+  unsigned int pugi_format_flags = pugi::format_raw;
+  if (!escapes) pugi_format_flags |= pugi::format_no_escapes;
+
+  for (auto cld: child->children()) {
+    node->first_child().child(level1.c_str()).child(level2.c_str()).append_copy(cld);
   }
 
   if (pointer) {

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -101,15 +101,49 @@ test_that("xml_append_child", {
   xml_node <- read_xml("<node><child1/><child2/></node>")
   xml_child <- read_xml("<new_child>&</new_child>")
   exp <- "<node><child1/><child2/><new_child>&</new_child></node>"
-  expect_equal(exp, xml_append_child(xml_node, xml_child, pointer = FALSE, escapes = FALSE))
+  expect_equal(exp, xml_append_child1(xml_node, xml_child, pointer = FALSE, escapes = FALSE))
 
   xml_node <- read_xml("<node><child1/><child2/></node>")
   xml_child <- read_xml("<new_child>&</new_child>")
   exp <- "<node><child1/><child2/><new_child>&amp;</new_child></node>"
-  expect_equal(exp, xml_append_child(xml_node, xml_child, pointer = FALSE, escapes = TRUE))
+  expect_equal(exp, xml_append_child1(xml_node, xml_child, pointer = FALSE, escapes = TRUE))
 
-  expect_true(inherits(xml_append_child(xml_node, xml_child, pointer = TRUE, escapes = FALSE), "pugi_xml"))
-  expect_true(inherits(xml_append_child(xml_node, xml_child, pointer = TRUE, escapes = TRUE), "pugi_xml"))
+
+  xml_node <- "<a><b/></a>"
+  xml_child <- read_xml("<c/>")
+
+  xml_node <- xml_append_child1(read_xml(xml_node), xml_child, pointer = FALSE, escapes = FALSE)
+  expect_equal("<a><b/><c/></a>", xml_node)
+
+  xml_node <- xml_append_child2(read_xml(xml_node), xml_child, level1 = "b", pointer = FALSE, escapes = FALSE)
+  expect_equal("<a><b><c/></b><c/></a>", xml_node)
+
+  xml_node <- xml_append_child3(read_xml(xml_node), read_xml("<d/>"), level1 = "b", level2 = "c", pointer = FALSE, escapes = FALSE)
+  expect_equal("<a><b><c><d/></c></b><c/></a>", xml_node)
+
+
+  # check that escapes does not throw a warning
+  xml_node <- "<a><b/></a>"
+  xml_child <- read_xml("<c>a&b</c>", escapes = FALSE)
+
+  xml_node <- xml_append_child1(read_xml(xml_node), xml_child, pointer = FALSE, escapes = TRUE)
+  expect_equal("<a><b/><c>a&amp;b</c></a>", xml_node)
+
+  xml_node <- xml_append_child2(read_xml(xml_node, escapes = TRUE), xml_child, level1 = "b", pointer = FALSE, escapes = TRUE)
+  expect_equal("<a><b><c>a&amp;b</c></b><c>a&amp;b</c></a>", xml_node)
+
+  xml_node <- xml_append_child3(read_xml(xml_node, escapes = TRUE), read_xml("<d/>"), level1 = "b", level2 = "c", pointer = FALSE, escapes = TRUE)
+  expect_equal("<a><b><c>a&amp;b<d/></c></b><c>a&amp;b</c></a>", xml_node)
+
+  # check that pointer is valid
+  expect_true(inherits(xml_append_child1(read_xml(xml_node), xml_child, pointer = TRUE, escapes = FALSE), "pugi_xml"))
+  expect_true(inherits(xml_append_child1(read_xml(xml_node), xml_child, pointer = TRUE, escapes = TRUE), "pugi_xml"))
+
+  expect_true(inherits(xml_append_child2(read_xml(xml_node), xml_child, level1 = "a", pointer = TRUE, escapes = FALSE), "pugi_xml"))
+  expect_true(inherits(xml_append_child2(read_xml(xml_node), xml_child, level1 = "a", pointer = TRUE, escapes = TRUE), "pugi_xml"))
+
+  expect_true(inherits(xml_append_child3(read_xml(xml_node), xml_child, level1 = "a", level2 = "b", pointer = TRUE, escapes = FALSE), "pugi_xml"))
+  expect_true(inherits(xml_append_child3(read_xml(xml_node), xml_child, level1 = "a", level2 = "b", pointer = TRUE, escapes = TRUE), "pugi_xml"))
 
 })
 

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -191,6 +191,18 @@ test_that("xml_add_child", {
   expect_error(xml_add_child(xml_node))
   expect_error(xml_add_child(xml_child = xml_child))
 
+  xml_node <- "<a><b/></a>"
+  xml_child <- "<c/>"
+
+  xml_node <- xml_add_child(xml_node, xml_child)
+  expect_equal("<a><b/><c/></a>", xml_node)
+
+  xml_node <- xml_add_child(xml_node, xml_child, level = c("b"))
+  expect_equal("<a><b><c/></b><c/></a>", xml_node)
+
+  xml_node <- xml_add_child(xml_node, "<d/>", level = c("b", "c"))
+  expect_equal("<a><b><c><d/></c></b><c/></a>", xml_node)
+
 })
 
 


### PR DESCRIPTION
Tested with:

```R
library(openxlsx2)

wb <- wb_workbook()
wb$add_worksheet("databar")
## Databars
wb$add_data("databar", -5:5, startCol = 1)
wb_conditional_formatting(
  wb,
  "databar",
  cols = 1,
  rows = 1:11,
  type = "databar"
) ## Default colours

wb$add_data("databar", -5:5, startCol = 3)
wb_conditional_formatting(
  wb,
  "databar",
  cols = 3,
  rows = 1:11,
  type = "databar",
  showValue = FALSE,
  gradient = FALSE
) ## Default colours

wb$add_data("databar", -5:5, startCol = 5)
wb_conditional_formatting(
  wb, 
  "databar",
  cols = 5,
  rows = 1:11,
  type = "databar",
  style = c("#a6a6a6"),
  showValue = FALSE
)

wb$add_data("databar", -5:5, startCol = 7)
wb_conditional_formatting(
  wb,
  "databar",
  cols = 7,
  rows = 1:11,
  type = "databar",
  style = c("red"),
  showValue = TRUE,
  gradient = FALSE
)

wb$add_data("databar", -5:5, startCol = 9)
wb_conditional_formatting(
  wb,
  "databar",
  cols = 9,
  rows = 1:11,
  type = "databar",
  style = c("#a6a6a6", "#a6a6a6"),
  showValue = FALSE, 
  gradient = FALSE
)

wb$open()
```