### PR TITLE
Empty cell information

### DIFF
--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -516,15 +516,15 @@ wbWorksheet <- R6::R6Class(
       if (NROW(cc) == 0) return (invisible(self))
 
       if (numbers)
-        cc[cc$c_t %in% c("n", "_openxlsx_NA_"), # imported values might be _NA_
-          c("c_t", "v", "f", "f_t", "f_ref", "f_ca", "f_si", "is")] <- "_openxlsx_NA_"
+        cc[cc$c_t %in% c("n", ""),
+          c("c_t", "v", "f", "f_t", "f_ref", "f_ca", "f_si", "is")] <- ""
 
       if (characters)
         cc[cc$c_t %in% c("inlineStr", "s"),
           c("v", "f", "f_t", "f_ref", "f_ca", "f_si", "is")] <- ""
 
       if (styles)
-        cc[c("c_s")] <- "_openxlsx_NA_"
+        cc[c("c_s")] <- ""
 
       self$sheet_data$cc <- cc
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -436,11 +436,11 @@ wb_to_df <- function(
       cc$is_string <- cc$c_t %in% c("s", "str", "b", "inlineStr")
 
     if (detectDates) {
-      sel <- (cc$c_s %in% xlsx_date_style) & !cc$is_string & cc$v != "_openxlsx_NA_"
+      sel <- (cc$c_s %in% xlsx_date_style) & !cc$is_string & cc$v != ""
       cc$val[sel] <- suppressWarnings(as.character(convert_date(cc$v[sel])))
       cc$typ[sel]  <- "d"
 
-      sel <- (cc$c_s %in% xlsx_posix_style) & !cc$is_string & cc$v != "_openxlsx_NA_"
+      sel <- (cc$c_s %in% xlsx_posix_style) & !cc$is_string & cc$v != ""
       cc$val[sel] <- suppressWarnings(as.character(convert_datetime(cc$v[sel])))
       cc$typ[sel]  <- "p"
     }
@@ -461,7 +461,7 @@ wb_to_df <- function(
   zz$rows <- match(cc$row_r, rownames(z)) - 1
 
   zz <- zz[order(zz[, "cols"], zz[,"rows"]),]
-  zz <- zz[zz$val != "_openxlsx_NA_",]
+  zz <- zz[zz$val != "",]
   long_to_wide(z, tt, zz)
 
   # prepare colnames object
@@ -682,7 +682,7 @@ update_cell <- function(x, wb, sheet, cell, data_class,
       total_cols <- int2col(sort(col2int(total_cols)))
 
       # create candidate
-      cc_row_new <- data.frame(matrix("_openxlsx_NA_", nrow = length(total_cols), ncol = 2))
+      cc_row_new <- data.frame(matrix("", nrow = length(total_cols), ncol = 2))
       names(cc_row_new) <- names(cc)[1:2]
       cc_row_new$row_r <- row
       cc_row_new$c_r <- total_cols
@@ -702,7 +702,7 @@ update_cell <- function(x, wb, sheet, cell, data_class,
 
   # update cc
   # TODO this was not supposed to happen, caused by delete? clean?
-  cc <- cc[cc$row_r != "_openxlsx_NA_" & cc$c_r != "_openxlsx_NA_",]
+  cc <- cc[cc$row_r != "" & cc$c_r != "",]
 
   # update dimensions
   cc$r <- paste0(cc$c_r, cc$row_r)
@@ -741,7 +741,7 @@ update_cell <- function(x, wb, sheet, cell, data_class,
         c_s <- NULL
         if (removeCellStyle) c_s <- "c_s"
 
-        cc[sel, c(c_s, "c_t", "c_cm", "c_ph", "c_vm", "v", "f", "f_t", "f_ref", "f_ca", "f_si", "is")] <- "_openxlsx_NA_"
+        cc[sel, c(c_s, "c_t", "c_cm", "c_ph", "c_vm", "v", "f", "f_t", "f_ref", "f_ca", "f_si", "is")] <- ""
 
         # for now convert all R-characters to inlineStr (e.g. names() of a dataframe)
         if ((data_class[m] == openxlsx2_celltype[["character"]]) || ((colNames == TRUE) && (n == 1))) {
@@ -758,7 +758,7 @@ update_cell <- function(x, wb, sheet, cell, data_class,
           cc[sel, "f"] <- as.character(value)
           # FIXME assign the hyperlinkstyle if no style found. This might not be
           # desired. We should provide an option to prevent this.
-          if (cc[sel, "c_s"] == "_openxlsx_NA_")
+          if (cc[sel, "c_s"] == "")
             cc[sel, "c_s"] <- wb$styles_mgr$get_xf_id("hyperlinkstyle")
         } else {
           cc[sel, "v"]   <- as.character(value)
@@ -952,7 +952,7 @@ write_data2 <-function(wb, sheet, data, name = NULL,
               "f_ref", "f_ca", "f_si", "is", "typ",
               "r")
     cc <- as.data.frame(
-      matrix(data = "_openxlsx_NA_",
+      matrix(data = "",
              nrow = nrow(data) * ncol(data),
              ncol = length(nams))
     )
@@ -1148,7 +1148,7 @@ delete_data <- function(wb, sheet, cols, rows, gridExpand) {
     sel <- cc$row_r %in% as.character(rows) & cc$c_r %in% cols
   }
 
-  cc[sel, ] <- "_openxlsx_NA_"
+  cc[sel, ] <- ""
 
   wb$worksheets[[sheet_id]]$sheet_data$cc <- cc
 

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -21,7 +21,7 @@ cloneSheetStyle <- function(wb, from_sheet, to_sheet) {
   org_style <- org_style[c("row_r", "c_r", "c_s")]
 
   merged_style <- merge(org_style, wb_style, all = TRUE)
-  merged_style[is.na(merged_style)] <- "_openxlsx_NA_"
+  merged_style[is.na(merged_style)] <- ""
 
   # TODO order this as well?
   wb$worksheets[[id_new]]$sheet_data$cc <- merged_style

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -285,15 +285,6 @@ void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame 
 
       // create struct
       celltyp cell;
-      cell.v     = openxlsxNA;
-      cell.c_s   = openxlsxNA;
-      cell.c_t   = openxlsxNA;
-      cell.is    = openxlsxNA;
-      cell.f     = openxlsxNA;
-      cell.f_t   = openxlsxNA;
-      cell.f_ref = openxlsxNA;
-      cell.typ   = openxlsxNA;
-      cell.r     = openxlsxNA;
 
       switch(vtyp)
       {
@@ -332,15 +323,15 @@ void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame 
 
       Rcpp::as<Rcpp::CharacterVector>(zz["row_r"])[pos] = row;
       Rcpp::as<Rcpp::CharacterVector>(zz["c_r"])[pos]   = col;
-      if (cell.v     != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["v"])[pos]     = cell.v;
-      if (cell.c_s   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["c_s"])[pos]   = cell.c_s;
-      if (cell.c_t   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["c_t"])[pos]   = cell.c_t;
-      if (cell.is    != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["is"])[pos]    = cell.is;
-      if (cell.f     != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f"])[pos]     = cell.f;
-      if (cell.f_t   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f_t"])[pos]   = cell.f_t;
-      if (cell.f_ref != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["f_ref"])[pos] = cell.f_ref;
-      if (cell.typ   != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["typ"])[pos]   = cell.typ;
-      if (cell.r     != openxlsxNA) Rcpp::as<Rcpp::CharacterVector>(zz["r"])[pos]     = cell.r;
+      if (!cell.v.empty())     Rcpp::as<Rcpp::CharacterVector>(zz["v"])[pos]     = cell.v;
+      if (!cell.c_s.empty())   Rcpp::as<Rcpp::CharacterVector>(zz["c_s"])[pos]   = cell.c_s;
+      if (!cell.c_t.empty())   Rcpp::as<Rcpp::CharacterVector>(zz["c_t"])[pos]   = cell.c_t;
+      if (!cell.is.empty())    Rcpp::as<Rcpp::CharacterVector>(zz["is"])[pos]    = cell.is;
+      if (!cell.f.empty())     Rcpp::as<Rcpp::CharacterVector>(zz["f"])[pos]     = cell.f;
+      if (!cell.f_t.empty())   Rcpp::as<Rcpp::CharacterVector>(zz["f_t"])[pos]   = cell.f_t;
+      if (!cell.f_ref.empty()) Rcpp::as<Rcpp::CharacterVector>(zz["f_ref"])[pos] = cell.f_ref;
+      if (!cell.typ.empty())   Rcpp::as<Rcpp::CharacterVector>(zz["typ"])[pos]   = cell.typ;
+      if (!cell.r.empty())     Rcpp::as<Rcpp::CharacterVector>(zz["r"])[pos]     = cell.r;
 
       ++startrow;
     }

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -227,22 +227,7 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
     for (auto col : worksheet.children("c")) {
 
       // contains all values of a col
-      xml_col single_xml_col {
-        openxlsxNA, // row_r
-        openxlsxNA, // c_r
-        openxlsxNA, // c_s
-        openxlsxNA, // c_t
-        openxlsxNA, // c_cm
-        openxlsxNA, // c_ph
-        openxlsxNA, // c_vm
-        openxlsxNA, // v
-        openxlsxNA, // f
-        openxlsxNA, // f_t
-        openxlsxNA, // f_ref
-        openxlsxNA, // f_ca
-        openxlsxNA, // f_si
-        openxlsxNA  // is
-      };
+      xml_col single_xml_col;
 
       // get number of children and attributes
       auto nn = std::distance(col.children().begin(), col.children().end());

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -185,11 +185,8 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
 
   auto ws = doc->child("worksheet").child("sheetData");
 
-  size_t n = std::distance(ws.begin(), ws.end());
-
   // character
   Rcpp::DataFrame row_attributes;
-  Rcpp::Shield<SEXP> rownames(Rf_allocVector(STRSXP, n));
 
   std::vector<xml_col> xml_cols;
 

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -7,8 +7,6 @@
 /* create custom Rcpp::wrap function to be used with std::vector<xml_col> */
 #include <RcppCommon.h>
 
-const std::string openxlsxNA = "_openxlsx_NA_";
-
 typedef struct {
   std::string row_r;
   std::string c_r;   // CellReference

--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -111,23 +111,23 @@ std::string xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) {
     // append attributes <c r="A1" ...>
     cell.append_attribute("r") = to_string(cc_r[i]).c_str();
 
-    if (to_string(cc_c_s[i]).compare(openxlsxNA.c_str()) != 0)
+    if (!to_string(cc_c_s[i]).empty())
       cell.append_attribute("s") = to_string(cc_c_s[i]).c_str();
 
     // assign type if not <v> aka numeric
-    if (to_string(cc_c_t[i]).compare(openxlsxNA.c_str()) != 0)
+    if (!to_string(cc_c_t[i]).empty())
       cell.append_attribute("t") = to_string(cc_c_t[i]).c_str();
 
     // CellMetaIndex: suppress curly brackets in spreadsheet software
-    if (to_string(cc_c_cm[i]).compare(openxlsxNA.c_str()) != 0)
+    if (!to_string(cc_c_cm[i]).empty())
       cell.append_attribute("cm") = to_string(cc_c_cm[i]).c_str();
 
     // phonetics spelling
-    if (to_string(cc_c_ph[i]).compare(openxlsxNA.c_str()) != 0)
+    if (!to_string(cc_c_ph[i]).empty())
       cell.append_attribute("ph") = to_string(cc_c_ph[i]).c_str();
 
     // suppress curly brackets in spreadsheet software
-    if (to_string(cc_c_vm[i]).compare(openxlsxNA.c_str()) != 0)
+    if (!to_string(cc_c_vm[i]).empty())
       cell.append_attribute("vm") = to_string(cc_c_vm[i]).c_str();
 
     // append nodes <c r="A1" ...><v>...</v></c>
@@ -136,18 +136,18 @@ std::string xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) {
 
     // <f> ... </f>
     // f node: formula to be evaluated
-    if (to_string(cc_f[i]).compare(openxlsxNA.c_str()) != 0 || to_string(cc_f_t[i]).compare(openxlsxNA.c_str()) != 0 || to_string(cc_f_si[i]).compare(openxlsxNA.c_str()) != 0) {
+    if (!to_string(cc_f[i]).empty() || !to_string(cc_f_t[i]).empty() || !to_string(cc_f_si[i]).empty()) {
       pugi::xml_node f = cell.append_child("f");
-      if (to_string(cc_f_t[i]).compare(openxlsxNA.c_str()) != 0) {
+      if (!to_string(cc_f_t[i]).empty()) {
         f.append_attribute("t") = to_string(cc_f_t[i]).c_str();
       }
-      if (to_string(cc_f_ref[i]).compare(openxlsxNA.c_str()) != 0) {
+      if (!to_string(cc_f_ref[i]).empty()) {
         f.append_attribute("ref") = to_string(cc_f_ref[i]).c_str();
       }
-      if (to_string(cc_f_ca[i]).compare(openxlsxNA.c_str()) != 0) {
+      if (!to_string(cc_f_ca[i]).empty()) {
         f.append_attribute("ca") = to_string(cc_f_ca[i]).c_str();
       }
-      if (to_string(cc_f_si[i]).compare(openxlsxNA.c_str()) != 0) {
+      if (!to_string(cc_f_si[i]).empty()) {
         f.append_attribute("si") = to_string(cc_f_si[i]).c_str();
         f_si = true;
       }
@@ -156,7 +156,7 @@ std::string xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) {
     }
 
     // v node: value stored from evaluated formula
-    if (to_string(cc_v[i]).compare(openxlsxNA.c_str()) != 0) {
+    if (!to_string(cc_v[i]).empty()) {
       if (!f_si & (to_string(cc_v[i]).compare(xml_preserver.c_str()) == 0)) {
         cell.append_child("v").append_attribute("xml:space").set_value("preserve");
         cell.child("v").append_child(pugi::node_pcdata).set_value(" ");
@@ -167,7 +167,7 @@ std::string xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) {
 
     // <is><t> ... </t></is>
     if (to_string(cc_c_t[i]).compare("inlineStr") == 0) {
-      if (to_string(cc_is[i]).compare(openxlsxNA.c_str()) != 0) {
+      if (!to_string(cc_is[i]).empty()) {
 
         pugi::xml_document is_node;
         pugi::xml_parse_result result = is_node.load_string(to_string(cc_is[i]).c_str(), pugi_parse_flags);

--- a/tests/testthat/test-clean_sheet.R
+++ b/tests/testthat/test-clean_sheet.R
@@ -9,7 +9,7 @@ test_that("clean_sheet", {
 
   # remove styles
   wb <- wb_clean_sheet(wb = wb, sheet = 1, numbers = FALSE, characters = FALSE, styles = TRUE)
-  expect_true(all(wb$worksheets[[1]]$sheet_data$cc$c_s == "_openxlsx_NA_"))
+  expect_true(all(wb$worksheets[[1]]$sheet_data$cc$c_s == ""))
 
   # remove numbers
   wb$worksheets[[1]]$clean_sheet(numbers = TRUE)

--- a/tests/testthat/test-writeData.R
+++ b/tests/testthat/test-writeData.R
@@ -5,13 +5,13 @@ test_that("write_formula", {
 
   # array formula for a single cell
   exp <- structure(
-    list(row_r = "2", c_r = "E", c_s = "_openxlsx_NA_",
-         c_t = "_openxlsx_NA_", c_cm = "_openxlsx_NA_",
-         c_ph = "_openxlsx_NA_", c_vm = "_openxlsx_NA_",
-         v = "_openxlsx_NA_", f = "SUM(C2:C11*D2:D11)",
+    list(row_r = "2", c_r = "E", c_s = "",
+         c_t = "", c_cm = "",
+         c_ph = "", c_vm = "",
+         v = "", f = "SUM(C2:C11*D2:D11)",
          f_t = "array", f_ref = "E2:E2",
-         f_ca = "_openxlsx_NA_", f_si = "_openxlsx_NA_",
-         is = "_openxlsx_NA_", typ = NA_character_, r = "E2"),
+         f_ca = "", f_si = "",
+         is = "", typ = NA_character_, r = "E2"),
     row.names = "3", class = "data.frame")
 
   # write data add array formula later


### PR DESCRIPTION
[c++/empty cells] Empty cell information is now displayed with "" instead of "_openxlsx_NA_" as before. Previously this variable was used to help various `wbWorkbook` functions to distinguish between empty cells, missing cells and cells to be ignored. Fortunately, this is no longer needed. Either a cell contains useful information or it can be ignored. Empty strings are written as `<is><t></t></is>` or they are still sharedstrings. Row and column information cannot be empty, similarly openxml has no empty attributes (as far as I know).

This relieves us of the time-consuming burden of initializing each field of cc with the long string "_openxlsx_NA_" (it was intentionally that long to prevent someone from randomly selecting it in an xlsx file). However, since this string was used fundamentally in several places, this change should be monitored closely. Especially for files that are known to be strange (missing lines, missing data, empty strings, or uninitialized cells).

There is another string called "_openxlsx_NA". This string has another use that is still required, and writing this string from openxlsx2 will still corrupt the workbook as indicated in the description.

This is more of a heads up for you on who to blame @jmbarbone, I don't expect any negative effects from this PR (just positive, cleaner `cc` table and slight speedups due to skipping the initialization, and our tests and verifications have indicated no problem 😃 ).