### PR TITLE
[R/load] remove references to printerSettings.bin. Closes #184

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Fixes
 
+* remove reference to `printerSettings.bin` when loading. This binary blob is not included and the reference caused file corruption warnings[185](https://github.com/JanMarvin/openxlsx2/pull/185)
+
 * fix loading and writing xlsx files with with `workbook$extLst`. Previously if the loaded sheet contains a slicer, a second `extLst` was added which confused spreadsheet software. Now both are combined into a single node.
 
 * fix writing xlsx file with multiple entries of conditional formatting type databar on any sheet. [174](https://github.com/JanMarvin/openxlsx2/pull/174) 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -594,7 +594,16 @@ wb_load <- function(file, xlsxFile = NULL, sheet) {
       # wb$worksheets[[i]]$mergeCells <- xml_node(worksheet_xml, "worksheet", "mergeCells")
       wb$worksheets[[i]]$oleObjects <- xml_node(worksheet_xml, "worksheet", "oleObjects")
       wb$worksheets[[i]]$pageMargins <- xml_node(worksheet_xml, "worksheet", "pageMargins")
+      # Keep pageSetup, but remove r:Id. This r:Id references the entry in
+      # worksheets/_rels/ which points to printerSetup_.bin. We do not ship
+      # this printer specific binary. Excel does not seem to complain if we keep
+      # the reference, but it is pointing to a non existing file.
       wb$worksheets[[i]]$pageSetup <- xml_node(worksheet_xml, "worksheet", "pageSetup")
+      if (length(wb$worksheets[[i]]$pageSetup))
+          wb$worksheets[[i]]$pageSetup <- xml_attr_mod(
+            wb$worksheets[[i]]$pageSetup,
+            xml_attributes = c(`r:id`="")
+          )
       wb$worksheets[[i]]$phoneticPr <- xml_node(worksheet_xml, "worksheet", "phoneticPr")
       wb$worksheets[[i]]$picture <- xml_node(worksheet_xml, "worksheet", "picture")
       wb$worksheets[[i]]$printOptions <- xml_node(worksheet_xml, "worksheet", "printOptions")
@@ -730,7 +739,14 @@ wb_load <- function(file, xlsxFile = NULL, sheet) {
         xml_relship$Target[basename(xml_relship$Type) == "vmlDrawing"] <- sprintf("../drawings/vmlDrawing%s.vml", i)
 
         if (is.null(xml_relship$TargetMode)) xml_relship$TargetMode <- ""
-        xml <- df_to_xml("Relationship", xml_relship[c("Id", "Type", "Target", "TargetMode")])
+
+        # we do not ship this binary blob, therefore spreadsheet software may
+        # stumble over this non existent reference. In the future we might want
+        # to check if the references are valid pre file saving.
+        sel_row <- !grepl("printerSettings", basename(xml_relship$Target))
+        sel_col <- c("Id", "Type", "Target", "TargetMode")
+        # return as xml
+        xml <- df_to_xml("Relationship", xml_relship[sel_row, sel_col])
       } else {
         xml <- character()
       }


### PR DESCRIPTION
Removes the printer setting and the reference in pageSetup. This fixes the following on my work laptop with Windows 10 and Excel 2016:

```R
wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))$open()
```

This is one of the ids, @jmbarbone, that I have always wanted to document:

The reference is in sheet2 (`xl/worksheets/sheet2.xml`) and matches a reference in `xl/worksheets/_rels/sheet2.xml.rels` that points to an external file: `xl/printerSettings/printerSettings1.bin`. The other references here are hyperlinks and a drawing. Even if we remove `r:Id="6"`, Excel does not complain because the other references are still valid. I haven't checked, but I suspect Excel would complain or, worse, abort altogether if we assigned `r:Id="6"` to something else without removing the reference in `sheet2.xml`.

Ideally, we would collect all `r:Id`s of a sheet and keep track of them. So far `openxlsx` has done something like this, trying to find and replace specific `r:Ids` with regexpr and change them (Excel does not really seem to care). However, if you change the reference in `sheetsX.xml`, you also have to change `_rels/sheetsX.xml.rels`. I was never happy with how this was done in `openxlsx` because so many references were changed (here as well as in styles). Although if properly implemented in a reference manager, I can see the benefits.