### PR TITLE
[c++/load] load file without row attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Fixes
 
-* remove reference to `printerSettings.bin` when loading. This binary blob is not included and the reference caused file corruption warnings[185](https://github.com/JanMarvin/openxlsx2/pull/185)
+* fix reading file without row attribute. [187](https://github.com/JanMarvin/openxlsx2/pull/187)
+
+* remove reference to `printerSettings.bin` when loading. This binary blob is not included and the reference caused file corruption warnings. [185](https://github.com/JanMarvin/openxlsx2/pull/185)
 
 * fix loading and writing xlsx files with with `workbook$extLst`. Previously if the loaded sheet contains a slicer, a second `extLst` was added which confused spreadsheet software. Now both are combined into a single node.
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -652,6 +652,7 @@ wb_load <- function(file, xlsxFile = NULL, sheet) {
 
       # load the data. This function reads sheet_data and returns cc and row_attr
       loadvals(wb$worksheets[[i]]$sheet_data, worksheet_xml)
+      assign("cc", wb$worksheets[[1]]$sheet_data$cc, globalenv())
     }
   }
 

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -273,8 +273,7 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
       // some files have no colnames. in this case we need to add c_r and row_r
       // if the file provides dimensions, they could be fixed later
       if (!has_colname) {
-        std::string tmp_colname= int_to_col(itr_cols);
-        single_xml_col.c_r = tmp_colname;
+        single_xml_col.c_r = int_to_col(itr_cols + 1);
         single_xml_col.row_r = std::to_string(itr_rows + 1);
       }
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -51,3 +51,16 @@ test_that("get_date_origin from different sources", {
   expect_equal(origin_url, origin_file)
   expect_equal(origin_url, "1900-01-01")
 })
+
+
+test_that("read html source without r attribute on cell", {
+
+  # sheet without row attribute
+  # original from https://www.atih.sante.fr/sites/default/files/public/content/3968/fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx
+  wb <- wb_load("https://github.com/JanMarvin/openxlsx2/files/8702731/fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx")
+
+  expect_equal(c(46, 1), dim(wb_to_df(wb, sheet = 1)))
+  expect_equal(c(31564, 52), dim(wb_to_df(wb, sheet = 2)))
+  expect_equal("PRÉSENTATION DU DOCUMENT", names(wb_to_df(wb, sheet = 1)))
+
+})


### PR DESCRIPTION
```R
wb_load(xlsx)$open()
```

There is some issue with sharedStrings. So far I'm unaware to locate the problem. Maybe something to do with the encoding? Sadly it was always in xlsx files with many many shared strings.