### PR TITLE
[c++/pugi] use parse_ws_pcdata. closes #188

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1282,7 +1282,7 @@ wbWorkbook <- R6::R6Class(
             length(self$sharedStrings),
             attr(self$sharedStrings, "uniqueCount")
           ),
-          #body = stri_join(set_sst(attr(sharedStrings, "text")), collapse = "", sep = " "),
+          #body = stri_join(set_sst(attr(self$sharedStrings, "text")), collapse = "", sep = " "),
           body = stri_join(self$sharedStrings, collapse = "", sep = ""),
           tail = "</sst>",
           fl = file.path(xlDir, "sharedStrings.xml")

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -7,7 +7,7 @@ SEXP readXMLPtr(std::string path, bool isfile, bool escapes, bool declaration) {
   pugi::xml_parse_result result;
 
   // pugi::parse_default without escapes flag
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata| pugi::parse_eol;
   if (escapes) pugi_parse_flags |= pugi::parse_escapes;
   if (declaration) pugi_parse_flags |= pugi::parse_declaration;
 
@@ -34,7 +34,7 @@ SEXP readXML(std::string path, bool isfile, bool escapes, bool declaration) {
   pugi::xml_parse_result result;
 
   // pugi::parse_default without escapes flag
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   if (escapes) pugi_parse_flags |= pugi::parse_escapes;
   if (declaration) pugi_parse_flags |= pugi::parse_declaration;
 
@@ -491,7 +491,6 @@ void write_xml_file(std::string xml_content, std::string fl, bool escapes) {
 
   unsigned int pugi_format_flags = pugi::format_raw;
   if (!escapes) pugi_format_flags |= pugi::format_no_escapes;
-  pugi_format_flags |= pugi::format_no_empty_element_tags;
 
   // load and validate node
   if (xml_content != "") {

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -486,7 +486,7 @@ void write_xml_file(std::string xml_content, std::string fl, bool escapes) {
   pugi::xml_parse_result result;
 
   // pugi::parse_default without escapes flag
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   if (escapes) pugi_parse_flags |= pugi::parse_escapes;
 
   unsigned int pugi_format_flags = pugi::format_raw;
@@ -549,7 +549,7 @@ Rcpp::CharacterVector xml_attr_mod(std::string xml_content, Rcpp::CharacterVecto
   pugi::xml_document doc;
   pugi::xml_parse_result result;
 
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   if (escapes) pugi_parse_flags |= pugi::parse_escapes;
   if (declaration) pugi_parse_flags |= pugi::parse_declaration;
 
@@ -625,7 +625,7 @@ Rcpp::CharacterVector xml_node_create(
   pugi::xml_document doc;
   pugi::xml_parse_result result;
 
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   if (escapes) pugi_parse_flags |= pugi::parse_escapes;
   if (declaration) pugi_parse_flags |= pugi::parse_declaration;
 

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -491,6 +491,7 @@ void write_xml_file(std::string xml_content, std::string fl, bool escapes) {
 
   unsigned int pugi_format_flags = pugi::format_raw;
   if (!escapes) pugi_format_flags |= pugi::format_no_escapes;
+  pugi_format_flags |= pugi::format_no_empty_element_tags;
 
   // load and validate node
   if (xml_content != "") {

--- a/src/strings_xml.cpp
+++ b/src/strings_xml.cpp
@@ -86,7 +86,7 @@ SEXP is_to_txt(Rcpp::CharacterVector is_vec) {
     std::string tmp = Rcpp::as<std::string>(is_vec[i]);
 
     pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load_string(tmp.c_str(), pugi::parse_default | pugi::parse_escapes);
+    pugi::xml_parse_result result = doc.load_string(tmp.c_str(), pugi::parse_default | pugi::parse_ws_pcdata | pugi::parse_escapes);
 
     if (!result) {
       Rcpp::stop("inlineStr xml import unsuccessfull");

--- a/src/styles_xml.cpp
+++ b/src/styles_xml.cpp
@@ -368,7 +368,7 @@ Rcpp::CharacterVector write_font(Rcpp::DataFrame df_font) {
 
   auto n = df_font.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
   for (auto i = 0; i < n; ++i) {
@@ -589,7 +589,7 @@ Rcpp::CharacterVector write_border(Rcpp::DataFrame df_border) {
 
   auto n = df_border.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
 
@@ -733,7 +733,7 @@ Rcpp::CharacterVector write_fill(Rcpp::DataFrame df_fill) {
 
   auto n = df_fill.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
   for (auto i = 0; i < n; ++i) {
@@ -862,7 +862,7 @@ Rcpp::CharacterVector write_cellStyle(Rcpp::DataFrame df_cellstyle) {
 
   auto n = df_cellstyle.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
 
@@ -1028,7 +1028,7 @@ Rcpp::CharacterVector write_tableStyle(Rcpp::DataFrame df_tablestyle) {
 
   auto n = df_tablestyle.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
 
@@ -1175,7 +1175,7 @@ Rcpp::CharacterVector write_dxf(Rcpp::DataFrame df_dxf) {
 
   auto n = df_dxf.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
   for (auto i = 0; i < n; ++i) {
@@ -1282,7 +1282,7 @@ Rcpp::CharacterVector write_colors(Rcpp::DataFrame df_colors) {
 
   auto n = df_colors.nrow();
   Rcpp::CharacterVector z(n);
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
   for (auto i = 0; i < n; ++i) {

--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -46,7 +46,7 @@ std::string xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) {
   std::string xml_preserver = "";
 
   // non optional: treat input as valid at this stage
-  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_eol;
+  unsigned int pugi_parse_flags = pugi::parse_cdata | pugi::parse_wconv_attribute | pugi::parse_ws_pcdata | pugi::parse_eol;
   // unsigned int pugi_format_flags = pugi::format_raw | pugi::format_no_escapes;
 
   // we cannot access rows directly in the dataframe.

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -29,6 +29,16 @@ test_that("read_xml", {
   # read declaration
   expect_equal(xml, read_xml(xml, declaration = TRUE, pointer = FALSE))
 
+  exp <- '<t xml:space="preserve"> </t>'
+  expect_equal(exp, read_xml(exp, pointer = FALSE))
+
+  tmp <- tempfile(fileext = ".xml")
+  write_file(body = exp, fl = tmp)
+
+  exp <- "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><t xml:space=\"preserve\"> </t>"
+  got <- readLines(tmp, warn = FALSE)
+  expect_equal(exp, got)
+
 })
 
 test_that("xml_node", {


### PR DESCRIPTION
Previously pugi would reduce `<si><t xml:space="preserve"> </t>` to this `<si><t xml:space="preserve"/></si>`. This confused a certain spreadsheet software.