### PR TITLE
[R/load] fix duplicates in example file with missing r attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Instruct parser to import nodes with whitespaces. This fixes a complaint in spreadsheet software. [189](https://github.com/JanMarvin/openxlsx2/pull/189)
 
-* Fix reading file without row attribute. [187](https://github.com/JanMarvin/openxlsx2/pull/187)
+* Fix reading file without row attribute. [187](https://github.com/JanMarvin/openxlsx2/pull/187) [190](https://github.com/JanMarvin/openxlsx2/pull/190)
 
 * Remove reference to `printerSettings.bin` when loading. This binary blob is not included and the reference caused file corruption warnings. [185](https://github.com/JanMarvin/openxlsx2/pull/185)
 

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -95,6 +95,21 @@ std::string int_to_col(uint32_t cell) {
   return col_name;
 }
 
+// driver function for col_to_int
+uint32_t uint_col_to_int(std::string& a) {
+  
+  char A = 'A';
+  int aVal = (int)A - 1;
+  int sum = 0;
+  int k = a.length();
+
+  for (int j = 0; j < k; j++) {
+    sum *= 26;
+    sum += (a[j] - aVal);
+  }
+
+  return sum;
+}
 
 // [[Rcpp::export]]
 Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x ) {
@@ -103,12 +118,9 @@ Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x ) {
 
   std::vector<std::string> r = Rcpp::as<std::vector<std::string> >(x);
   int n = r.size();
-  int k;
 
   std::string a;
   Rcpp::IntegerVector colNums(n);
-  char A = 'A';
-  int aVal = (int)A - 1;
 
   for (int i = 0; i < n; i++) {
     a = r[i];
@@ -126,15 +138,8 @@ Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x ) {
     a.erase(std::remove_if(a.begin()+1, a.end(), ::isdigit), a.end());
     transform(a.begin(), a.end(), a.begin(), ::toupper);
 
-    int sum = 0;
-    k = a.length();
-
-    for (int j = 0; j < k; j++) {
-      sum *= 26;
-      sum += (a[j] - aVal);
-
-    }
-    colNums[i] = sum;
+    // return index from column name
+    colNums[i] = uint_col_to_int(a);
   }
 
   return colNums;

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -159,7 +159,7 @@ Rcpp::DataFrame row_to_df(XPtrXML doc) {
 
     // some files have no row name in this case, we add one
     if (!has_rowname) {
-      std::string attr_name = {"r"};
+      std::string attr_name = "r";
       auto find_res = row_nams.find(attr_name);
       auto mtc = std::distance(row_nams.begin(), find_res);
       Rcpp::as<Rcpp::CharacterVector>(df[mtc])[itr] = std::to_string(itr + 1);
@@ -234,7 +234,6 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
 
       // typ: attribute ------------------------------------------------------
       bool has_colname = false;
-      auto attr_itr = 0;
       for (auto attr : col.attributes()) {
 
         buffer = attr.value();
@@ -260,6 +259,10 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
                                       colrow.end());
           single_xml_col.row_r = colrow;
 
+          // if some cells of the workbook have colnames but other dont,
+          // this will increase itr_cols and avoid duplicates in cc
+          itr_cols = uint_col_to_int(single_xml_col.c_r) - 1;
+
         }
 
         if (attr_name == s_str) single_xml_col.c_s = buffer;
@@ -268,7 +271,6 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
         if (attr_name == ph_str) single_xml_col.c_ph = buffer;
         if (attr_name == vm_str) single_xml_col.c_vm = buffer;
 
-        ++attr_itr;
       }
       // some files have no colnames. in this case we need to add c_r and row_r
       // if the file provides dimensions, they could be fixed later

--- a/src/openxlsx2.h
+++ b/src/openxlsx2.h
@@ -1,6 +1,7 @@
 #include "openxlsx2_types.h"
 
 std::string int_to_col(uint32_t cell);
+uint32_t uint_col_to_int(std::string& a);
 Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x);
 
 SEXP si_to_txt(XPtrXML doc);

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -63,4 +63,9 @@ test_that("read html source without r attribute on cell", {
   expect_equal(c(31564, 52), dim(wb_to_df(wb, sheet = 2)))
   expect_equal("PRÉSENTATION DU DOCUMENT", names(wb_to_df(wb, sheet = 1)))
 
+  # This file has a few cells with row names, the majority has none. check that
+  # we did not create duplicates while loading
+  expect_true(!any(duplicated(wb$worksheets[[1]]$sheet_data$cc)))
+  expect_true(!any(duplicated(wb$worksheets[[2]]$sheet_data$cc)))
+
 })


### PR DESCRIPTION
fix reading example file with missing `r=` attribute. This file has a few columns with this attribute, but most do not have it. Previously we were simply counting the columns, this lead to duplicates which confused a certain spreadsheet software. Reading the example file is now fixed. Though this is a single known case of such a file, I would not state that it works for every case.