### PR TITLE
[WIP] Attempt to write UTF-8 from non UTF-8 systems. Did not test this

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -305,7 +305,7 @@ set_sst <- function(sharedStrings) {
     .Call(`_openxlsx2_set_sst`, sharedStrings)
 }
 
-write_worksheet <- function(prior, post, sheet_data, cols_attr, R_fileName = "output") {
-    invisible(.Call(`_openxlsx2_write_worksheet`, prior, post, sheet_data, cols_attr, R_fileName))
+write_worksheet <- function(prior, post, sheet_data, cols_attr, R_fileName, is_utf8) {
+    invisible(.Call(`_openxlsx2_write_worksheet`, prior, post, sheet_data, cols_attr, R_fileName, is_utf8))
 }
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4367,7 +4367,8 @@ wbWorkbook <- R6::R6Class(
             post = post,
             sheet_data = ws$sheet_data,
             cols_attr = ws$cols_attr,
-            R_fileName = file.path(xlworksheetsDir, sprintf("sheet%s.xml", i))
+            R_fileName = file.path(xlworksheetsDir, sprintf("sheet%s.xml", i)),
+            is_utf8 = l10n_info()[["UTF-8"]]
           )
 
           ## write worksheet rels

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -759,8 +759,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // write_worksheet
-void write_worksheet(std::string prior, std::string post, Rcpp::Environment sheet_data, Rcpp::CharacterVector cols_attr, std::string R_fileName);
-RcppExport SEXP _openxlsx2_write_worksheet(SEXP priorSEXP, SEXP postSEXP, SEXP sheet_dataSEXP, SEXP cols_attrSEXP, SEXP R_fileNameSEXP) {
+void write_worksheet(std::string prior, std::string post, Rcpp::Environment sheet_data, Rcpp::CharacterVector cols_attr, std::string R_fileName, bool is_utf8);
+RcppExport SEXP _openxlsx2_write_worksheet(SEXP priorSEXP, SEXP postSEXP, SEXP sheet_dataSEXP, SEXP cols_attrSEXP, SEXP R_fileNameSEXP, SEXP is_utf8SEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type prior(priorSEXP);
@@ -768,7 +768,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::Environment >::type sheet_data(sheet_dataSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type cols_attr(cols_attrSEXP);
     Rcpp::traits::input_parameter< std::string >::type R_fileName(R_fileNameSEXP);
-    write_worksheet(prior, post, sheet_data, cols_attr, R_fileName);
+    Rcpp::traits::input_parameter< bool >::type is_utf8(is_utf8SEXP);
+    write_worksheet(prior, post, sheet_data, cols_attr, R_fileName, is_utf8);
     return R_NilValue;
 END_RCPP
 }
@@ -835,7 +836,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_read_colors", (DL_FUNC) &_openxlsx2_read_colors, 1},
     {"_openxlsx2_write_colors", (DL_FUNC) &_openxlsx2_write_colors, 1},
     {"_openxlsx2_set_sst", (DL_FUNC) &_openxlsx2_set_sst, 1},
-    {"_openxlsx2_write_worksheet", (DL_FUNC) &_openxlsx2_write_worksheet, 5},
+    {"_openxlsx2_write_worksheet", (DL_FUNC) &_openxlsx2_write_worksheet, 6},
     {NULL, NULL, 0}
 };
 

--- a/src/openxlsx2.h
+++ b/src/openxlsx2.h
@@ -8,3 +8,16 @@ SEXP si_to_txt(XPtrXML doc);
 SEXP is_to_txt(Rcpp::CharacterVector is_vec);
 
 std::string txt_to_is(std::string txt, bool no_escapes, bool raw);
+
+
+template <typename T>
+inline T Riconv(T &mystring) {
+  Rcpp::Environment base("package:base");
+  Rcpp::Function iconv = base["iconv"];
+
+  mystring = Rcpp::as<T>(
+    iconv(mystring, Rcpp::Named("from", ""), Rcpp::Named("to","UTF-8"))
+  );
+
+  return(mystring);
+}


### PR DESCRIPTION
The idea is to use R's iconv in Rcpp pre writing, if the system indicated that it does not use UTF-8. Always. No matter what. For some reason `write_file()` worked fine, but the worksheet contained broken unicode:

```R
# to test
wb <- wb_workbook()$
  add_worksheet("höhö")$
  add_data("höhö", "bää", colNames = FALSE)
```