### PR TITLE
update theme

### DIFF
--- a/R/baseXML.R
+++ b/R/baseXML.R
@@ -301,20 +301,54 @@ genBasePic <- function(imageNo) {
 
 genBaseTheme <- function() {
   '<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
-  <a:themeElements><a:clrScheme name="Office">
-  <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
-  <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
-  <a:dk2><a:srgbClr val="1F497D"/></a:dk2>
-  <a:lt2><a:srgbClr val="EEECE1"/></a:lt2>
-  <a:accent1><a:srgbClr val="4F81BD"/></a:accent1><a:accent2><a:srgbClr val="C0504D"/></a:accent2>
-  <a:accent3><a:srgbClr val="9BBB59"/></a:accent3><a:accent4><a:srgbClr val="8064A2"/></a:accent4>
-  <a:accent5><a:srgbClr val="4BACC6"/></a:accent5><a:accent6><a:srgbClr val="F79646"/></a:accent6>
-  <a:hlink><a:srgbClr val="0000FF"/></a:hlink><a:folHlink><a:srgbClr val="800080"/></a:folHlink>
-  </a:clrScheme><a:fontScheme name="Office">
+  <a:themeElements>
+  <a:clrScheme name="Office">
+  <a:dk1>
+  <a:sysClr val="windowText" lastClr="000000"/>
+  </a:dk1>
+  <a:lt1>
+  <a:sysClr val="window" lastClr="FFFFFF"/>
+  </a:lt1>
+  <a:dk2>
+  <a:srgbClr val="44546A"/>
+  </a:dk2>
+  <a:lt2>
+  <a:srgbClr val="E7E6E6"/>
+  </a:lt2>
+  <a:accent1>
+  <a:srgbClr val="4472C4"/>
+  </a:accent1>
+  <a:accent2>
+  <a:srgbClr val="ED7D31"/>
+  </a:accent2>
+  <a:accent3>
+  <a:srgbClr val="A5A5A5"/>
+  </a:accent3>
+  <a:accent4>
+  <a:srgbClr val="FFC000"/>
+  </a:accent4>
+  <a:accent5>
+  <a:srgbClr val="5B9BD5"/>
+  </a:accent5>
+  <a:accent6>
+  <a:srgbClr val="70AD47"/>
+  </a:accent6>
+  <a:hlink>
+  <a:srgbClr val="0563C1"/>
+  </a:hlink>
+  <a:folHlink>
+  <a:srgbClr val="954F72"/>
+  </a:folHlink>
+  </a:clrScheme>
+  <a:fontScheme name="Office">
   <a:majorFont>
-  <a:latin typeface="Cambria"/>
+  <a:latin typeface="Calibri Light" panose="020F0302020204030204"/>
   <a:ea typeface=""/>
   <a:cs typeface=""/>
+  <a:font script="Jpan" typeface="游ゴシック Light"/>
+  <a:font script="Hang" typeface="맑은 고딕"/>
+  <a:font script="Hans" typeface="等线 Light"/>
+  <a:font script="Hant" typeface="新細明體"/>
   <a:font script="Arab" typeface="Times New Roman"/>
   <a:font script="Hebr" typeface="Times New Roman"/>
   <a:font script="Thai" typeface="Tahoma"/>
@@ -341,11 +375,32 @@ genBaseTheme <- function() {
   <a:font script="Viet" typeface="Times New Roman"/>
   <a:font script="Uigh" typeface="Microsoft Uighur"/>
   <a:font script="Geor" typeface="Sylfaen"/>
+  <a:font script="Armn" typeface="Arial"/>
+  <a:font script="Bugi" typeface="Leelawadee UI"/>
+  <a:font script="Bopo" typeface="Microsoft JhengHei"/>
+  <a:font script="Java" typeface="Javanese Text"/>
+  <a:font script="Lisu" typeface="Segoe UI"/>
+  <a:font script="Mymr" typeface="Myanmar Text"/>
+  <a:font script="Nkoo" typeface="Ebrima"/>
+  <a:font script="Olck" typeface="Nirmala UI"/>
+  <a:font script="Osma" typeface="Ebrima"/>
+  <a:font script="Phag" typeface="Phagspa"/>
+  <a:font script="Syrn" typeface="Estrangelo Edessa"/>
+  <a:font script="Syrj" typeface="Estrangelo Edessa"/>
+  <a:font script="Syre" typeface="Estrangelo Edessa"/>
+  <a:font script="Sora" typeface="Nirmala UI"/>
+  <a:font script="Tale" typeface="Microsoft Tai Le"/>
+  <a:font script="Talu" typeface="Microsoft New Tai Lue"/>
+  <a:font script="Tfng" typeface="Ebrima"/>
   </a:majorFont>
   <a:minorFont>
-  <a:latin typeface="Calibri"/>
+  <a:latin typeface="Calibri" panose="020F0502020204030204"/>
   <a:ea typeface=""/>
   <a:cs typeface=""/>
+  <a:font script="Jpan" typeface="游ゴシック"/>
+  <a:font script="Hang" typeface="맑은 고딕"/>
+  <a:font script="Hans" typeface="等线"/>
+  <a:font script="Hant" typeface="新細明體"/>
   <a:font script="Arab" typeface="Arial"/>
   <a:font script="Hebr" typeface="Arial"/>
   <a:font script="Thai" typeface="Tahoma"/>
@@ -372,81 +427,171 @@ genBaseTheme <- function() {
   <a:font script="Viet" typeface="Arial"/>
   <a:font script="Uigh" typeface="Microsoft Uighur"/>
   <a:font script="Geor" typeface="Sylfaen"/>
+  <a:font script="Armn" typeface="Arial"/>
+  <a:font script="Bugi" typeface="Leelawadee UI"/>
+  <a:font script="Bopo" typeface="Microsoft JhengHei"/>
+  <a:font script="Java" typeface="Javanese Text"/>
+  <a:font script="Lisu" typeface="Segoe UI"/>
+  <a:font script="Mymr" typeface="Myanmar Text"/>
+  <a:font script="Nkoo" typeface="Ebrima"/>
+  <a:font script="Olck" typeface="Nirmala UI"/>
+  <a:font script="Osma" typeface="Ebrima"/>
+  <a:font script="Phag" typeface="Phagspa"/>
+  <a:font script="Syrn" typeface="Estrangelo Edessa"/>
+  <a:font script="Syrj" typeface="Estrangelo Edessa"/>
+  <a:font script="Syre" typeface="Estrangelo Edessa"/>
+  <a:font script="Sora" typeface="Nirmala UI"/>
+  <a:font script="Tale" typeface="Microsoft Tai Le"/>
+  <a:font script="Talu" typeface="Microsoft New Tai Lue"/>
+  <a:font script="Tfng" typeface="Ebrima"/>
   </a:minorFont>
   </a:fontScheme>
   <a:fmtScheme name="Office">
   <a:fillStyleLst>
-  <a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+  <a:solidFill>
+  <a:schemeClr val="phClr"/>
+  </a:solidFill>
   <a:gradFill rotWithShape="1">
   <a:gsLst>
-  <a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="50000"/><a:satMod val="300000"/></a:schemeClr></a:gs>
-  <a:gs pos="35000"><a:schemeClr val="phClr"><a:tint val="37000"/><a:satMod val="300000"/></a:schemeClr></a:gs>
-  <a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="15000"/><a:satMod val="350000"/></a:schemeClr></a:gs>
+  <a:gs pos="0">
+  <a:schemeClr val="phClr">
+  <a:lumMod val="110000"/>
+  <a:satMod val="105000"/>
+  <a:tint val="67000"/>
+  </a:schemeClr>
+  </a:gs>
+  <a:gs pos="50000">
+  <a:schemeClr val="phClr">
+  <a:lumMod val="105000"/>
+  <a:satMod val="103000"/>
+  <a:tint val="73000"/>
+  </a:schemeClr>
+  </a:gs>
+  <a:gs pos="100000">
+  <a:schemeClr val="phClr">
+  <a:lumMod val="105000"/>
+  <a:satMod val="109000"/>
+  <a:tint val="81000"/>
+  </a:schemeClr>
+  </a:gs>
   </a:gsLst>
-  <a:lin ang="16200000" scaled="1"/>
+  <a:lin ang="5400000" scaled="0"/>
   </a:gradFill>
   <a:gradFill rotWithShape="1">
   <a:gsLst>
-  <a:gs pos="0"><a:schemeClr val="phClr"><a:shade val="51000"/><a:satMod val="130000"/></a:schemeClr></a:gs>
-  <a:gs pos="80000"><a:schemeClr val="phClr"><a:shade val="93000"/><a:satMod val="130000"/></a:schemeClr></a:gs>
-  <a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="94000"/><a:satMod val="135000"/></a:schemeClr></a:gs>
+  <a:gs pos="0">
+  <a:schemeClr val="phClr">
+  <a:satMod val="103000"/>
+  <a:lumMod val="102000"/>
+  <a:tint val="94000"/>
+  </a:schemeClr>
+  </a:gs>
+  <a:gs pos="50000">
+  <a:schemeClr val="phClr">
+  <a:satMod val="110000"/>
+  <a:lumMod val="100000"/>
+  <a:shade val="100000"/>
+  </a:schemeClr>
+  </a:gs>
+  <a:gs pos="100000">
+  <a:schemeClr val="phClr">
+  <a:lumMod val="99000"/>
+  <a:satMod val="120000"/>
+  <a:shade val="78000"/>
+  </a:schemeClr>
+  </a:gs>
   </a:gsLst>
-  <a:lin ang="16200000" scaled="0"/>
+  <a:lin ang="5400000" scaled="0"/>
   </a:gradFill>
   </a:fillStyleLst>
   <a:lnStyleLst>
-  <a:ln w="9525" cap="flat" cmpd="sng" algn="ctr">
-  <a:solidFill><a:schemeClr val="phClr"><a:shade val="95000"/><a:satMod val="105000"/></a:schemeClr>
+  <a:ln w="6350" cap="flat" cmpd="sng" algn="ctr">
+  <a:solidFill>
+  <a:schemeClr val="phClr"/>
   </a:solidFill>
-  <a:prstDash val="solid"/></a:ln><a:ln w="25400" cap="flat" cmpd="sng" algn="ctr">
-  <a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
-  <a:prstDash val="solid"/></a:ln>
-  <a:ln w="38100" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln>
+  <a:prstDash val="solid"/>
+  <a:miter lim="800000"/>
+  </a:ln>
+  <a:ln w="12700" cap="flat" cmpd="sng" algn="ctr">
+  <a:solidFill>
+  <a:schemeClr val="phClr"/>
+  </a:solidFill>
+  <a:prstDash val="solid"/>
+  <a:miter lim="800000"/>
+  </a:ln>
+  <a:ln w="19050" cap="flat" cmpd="sng" algn="ctr">
+  <a:solidFill>
+  <a:schemeClr val="phClr"/>
+  </a:solidFill>
+  <a:prstDash val="solid"/>
+  <a:miter lim="800000"/>
+  </a:ln>
   </a:lnStyleLst>
   <a:effectStyleLst>
   <a:effectStyle>
-  <a:effectLst>
-  <a:outerShdw blurRad="40000" dist="20000" dir="5400000" rotWithShape="0">
-  <a:srgbClr val="000000">
-  <a:alpha val="38000"/>
-  </a:srgbClr>
-  </a:outerShdw>
-  </a:effectLst>
+  <a:effectLst/>
+  </a:effectStyle>
+  <a:effectStyle>
+  <a:effectLst/>
   </a:effectStyle>
   <a:effectStyle>
   <a:effectLst>
-  <a:outerShdw blurRad="40000" dist="23000" dir="5400000" rotWithShape="0">
+  <a:outerShdw blurRad="57150" dist="19050" dir="5400000" algn="ctr" rotWithShape="0">
   <a:srgbClr val="000000">
-  <a:alpha val="35000"/>
+  <a:alpha val="63000"/>
   </a:srgbClr>
   </a:outerShdw>
   </a:effectLst>
-  </a:effectStyle>
-  <a:effectStyle><a:effectLst><a:outerShdw blurRad="40000" dist="23000" dir="5400000" rotWithShape="0"><a:srgbClr val="000000"><a:alpha val="35000"/>
-  </a:srgbClr>
-  </a:outerShdw>
-  </a:effectLst>
-  <a:scene3d>
-  <a:camera prst="orthographicFront">
-  <a:rot lat="0" lon="0" rev="0"/>
-  </a:camera>
-  <a:lightRig rig="threePt" dir="t"><a:rot lat="0" lon="0" rev="1200000"/></a:lightRig>
-  </a:scene3d>
-  <a:sp3d><a:bevelT w="63500" h="25400"/></a:sp3d>
   </a:effectStyle>
   </a:effectStyleLst>
-  <a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1">
+  <a:bgFillStyleLst>
+  <a:solidFill>
+  <a:schemeClr val="phClr"/>
+  </a:solidFill>
+  <a:solidFill>
+  <a:schemeClr val="phClr">
+  <a:tint val="95000"/>
+  <a:satMod val="170000"/>
+  </a:schemeClr>
+  </a:solidFill>
+  <a:gradFill rotWithShape="1">
   <a:gsLst>
-  <a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="40000"/><a:satMod val="350000"/></a:schemeClr></a:gs>
-  <a:gs pos="40000"><a:schemeClr val="phClr"><a:tint val="45000"/> <a:shade val="99000"/><a:satMod val="350000"/></a:schemeClr></a:gs>
-  <a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="20000"/><a:satMod val="255000"/></a:schemeClr></a:gs>
+  <a:gs pos="0">
+  <a:schemeClr val="phClr">
+  <a:tint val="93000"/>
+  <a:satMod val="150000"/>
+  <a:shade val="98000"/>
+  <a:lumMod val="102000"/>
+  </a:schemeClr>
+  </a:gs>
+  <a:gs pos="50000">
+  <a:schemeClr val="phClr">
+  <a:tint val="98000"/>
+  <a:satMod val="130000"/>
+  <a:shade val="90000"/>
+  <a:lumMod val="103000"/>
+  </a:schemeClr>
+  </a:gs>
+  <a:gs pos="100000">
+  <a:schemeClr val="phClr">
+  <a:shade val="63000"/>
+  <a:satMod val="120000"/>
+  </a:schemeClr>
+  </a:gs>
   </a:gsLst>
-  <a:path path="circle"><a:fillToRect l="50000" t="-80000" r="50000" b="180000"/></a:path></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst>
-  <a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="80000"/><a:satMod val="300000"/></a:schemeClr></a:gs>
-  <a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="30000"/><a:satMod val="200000"/></a:schemeClr></a:gs>
-  </a:gsLst>
-  <a:path path="circle"><a:fillToRect l="50000" t="50000" r="50000" b="50000"/></a:path>
-  </a:gradFill></a:bgFillStyleLst></a:fmtScheme></a:themeElements><a:objectDefaults/><a:extraClrSchemeLst/></a:theme>'
+  <a:lin ang="5400000" scaled="0"/>
+  </a:gradFill>
+  </a:bgFillStyleLst>
+  </a:fmtScheme>
+  </a:themeElements>
+  <a:objectDefaults/>
+  <a:extraClrSchemeLst/>
+  <a:extLst>
+  <a:ext uri="{05A4C25C-085E-4340-85A3-A5531E510DB2}">
+  <thm15:themeFamily xmlns:thm15="http://schemas.microsoft.com/office/thememl/2012/main" name="Office Theme" id="{62F939B6-93AF-4DB8-9C6B-D6C7DFDC589F}" vid="{4A3C46E8-61CC-4603-A589-7422A47A8E4A}"/>
+  </a:ext>
+  </a:extLst>
+  </a:theme>'
 }
 
 gen_databar_extlst <- function(guid, sqref, posColour, negColour, values, border, gradient) {


### PR DESCRIPTION
Updates the theme used in newly created workbooks. Seen some stackoverflow that we apply older table styles, when writing xlsx files. ~~This is the single use case I checked. Maybe some other color schemes are different too.~~

Old:
<img width="530" alt="Screenshot 2022-05-29 at 12 15 04" src="https://user-images.githubusercontent.com/1645626/170863088-00482306-e23f-4489-b166-1f7afcccf102.png">

<img width="212" alt="Screenshot 2022-05-29 at 12 26 46" src="https://user-images.githubusercontent.com/1645626/170863446-4d0ed1dc-8e19-415a-ac70-191a72f2bb3d.png">


New:
<img width="558" alt="Screenshot 2022-05-29 at 12 14 49" src="https://user-images.githubusercontent.com/1645626/170863091-34f76b8b-38aa-4540-a462-853cc9bf8ce5.png">

<img width="203" alt="Screenshot 2022-05-29 at 12 27 00" src="https://user-images.githubusercontent.com/1645626/170863450-53cc0820-489d-4226-b132-79452f485fbe.png">

