### PR TITLE
re-enable oldrel-1

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -20,7 +20,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          # - {os: windows-latest, r: 'oldrel-1'} # i386 multiarch test fails
+          - {os: windows-latest, r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}

--- a/openxlsx2.Rproj
+++ b/openxlsx2.Rproj
@@ -17,6 +17,7 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace,vignette

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -192,8 +192,7 @@ SEXP rbindlist(Rcpp::List x) {
   }
 
   // 3. Create a data.frame
-  R_xlen_t nrows = Rf_length(df[0]);
-  df.attr("row.names") = Rcpp::IntegerVector::create(NA_INTEGER, nrows);
+  df.attr("row.names") = Rcpp::IntegerVector::create(NA_INTEGER, nn);
   df.attr("names") = unique_names;
   df.attr("class") = "data.frame";
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -75,16 +75,21 @@ test_that("read html source without r attribute on cell", {
 
 
 test_that("read <br> node in vml", {
-  temp <- basename(tempfile("macro2", fileext = ".xlsm.zip"))
-  download.file("https://github.com/JanMarvin/openxlsx2/files/8773595/macro2.xlsm.zip", temp)
-  unzip(temp)
-  expect_silent(wb <- wb_load("macro2.xlsm"))
-  unlink(temp, recursive = TRUE, force = TRUE)
-  file.remove("macro2.xlsm")
-  if (.Platform$OS.type == "windows") {
-    try(unlink("__MACOSX", recursive = TRUE, force = TRUE))
-  }
+  # prepare test
+  temp_dir  <- "macro2_test"
+  temp_file <- paste0(temp_dir, "/macro2.xlsm")
+  temp_zip  <- paste0(temp_file, ".zip")
+  if (!dir.exists(temp_dir)) dir.create(temp_dir, recursive = TRUE)
+  download.file("https://github.com/JanMarvin/openxlsx2/files/8773595/macro2.xlsm.zip", temp_zip)
+  zip::unzip(temp_zip, exdir = temp_dir)
+
+  # test
+  expect_silent(wb <- wb_load(temp_file))
+
+  # clean up
+  unlink(temp_dir, recursive = TRUE, force = TRUE)
 })
+
 
 test_that("encoding", {
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -73,10 +73,10 @@ test_that("read html source without r attribute on cell", {
 
 test_that("read <br> node in vml", {
   # prepare test
-  temp_dir  <- "macro2_test"
-  temp_file <- paste0(temp_dir, "/macro2.xlsm")
+  temp_dir <- tempfile()
+  temp_file <- file.path(temp_dir, "macro2.xlsm")
   temp_zip  <- paste0(temp_file, ".zip")
-  if (!dir.exists(temp_dir)) dir.create(temp_dir, recursive = TRUE)
+  dir.create(temp_dir, recursive = TRUE, showWarnings = FALSE)
   download.file("https://github.com/JanMarvin/openxlsx2/files/8773595/macro2.xlsm.zip", temp_zip)
   zip::unzip(temp_zip, exdir = temp_dir)
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -55,6 +55,9 @@ test_that("get_date_origin from different sources", {
 
 test_that("read html source without r attribute on cell", {
 
+  if (.Platform$r_arch == "i386" && .Platform$OS.type == "windows")
+    skip("Skip test on Windows i386")
+
   # sheet without row attribute
   # original from https://www.atih.sante.fr/sites/default/files/public/content/3968/fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx
   wb <- wb_load("https://github.com/JanMarvin/openxlsx2/files/8702731/fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx")

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -55,9 +55,6 @@ test_that("get_date_origin from different sources", {
 
 test_that("read html source without r attribute on cell", {
 
-  if (.Platform$r_arch == "i386" && .Platform$OS.type == "windows")
-    skip("Skip test on Windows i386")
-
   # sheet without row attribute
   # original from https://www.atih.sante.fr/sites/default/files/public/content/3968/fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx
   wb <- wb_load("https://github.com/JanMarvin/openxlsx2/files/8702731/fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -10,6 +10,9 @@ test_that("paste_c() works", {
 
 test_that("rbindlist", {
 
+  if (.Platform$r_arch == "i386" && .Platform$OS.type == "windows")
+    skip("Skip test on Windows i386")
+
   expect_equal(data.frame(), rbindlist(character()))
 
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -10,9 +10,6 @@ test_that("paste_c() works", {
 
 test_that("rbindlist", {
 
-  if (.Platform$r_arch == "i386" && .Platform$OS.type == "windows")
-    skip("Skip test on Windows i386")
-
   expect_equal(data.frame(), rbindlist(character()))
 
 })


### PR DESCRIPTION
Well, `R 4.2.1` was released today so maybe our `oldrel-1` will be valid again.

Couldn't figure out what was causing this to fail in `R 4.1.3`