### PR TITLE
[R/write] fixes for NA, NaN, and Inf. Closes #254

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* Improve writing `NA`, `NaN`, and `-Inf`/`Inf`. `NA` will be converted to `#N/A`; `NaN` will be converted to `#VALUE!`; `Inf` will be converted to `#NUM!`. The same conversion is not applied when reading from a workbook.
+
 * Many `wbWorkbook` methods now contain default sheet values of `current_sheet()` or `next_sheet()` (e.g., `$add_worksheet(sheet = next_sheet())`, `$write_data(sheet = curret_sheet()`).  These internal waiver functions allow the `wbWorkbook` object to use default expectations for what sheet to interact with.  This allows the easier workflow of `wb$add_worksheet()$add_data(x = data.frame())` where `$add_worksheet()` knows to add a new worksheet (with a default name), sets that new worksheet to the current worksheet, and then `$add_data()` picks up the new sheet and places the data there. [165](https://github.com/JanMarvin/openxlsx2/issues/165), [179](https://github.com/JanMarvin/openxlsx2/pull/179)
 
 * New functions `wb_add_border()` and `wb$add_border()` to simplify the creation of fills for cells on the sheet. This provides a fast way to create color filled regions on the worksheet. The cells for which the border is to be created must already exist on the worksheet. If the cells already contain a cell style, it will be preserved, except for the filled color, which will always be created. The function is applied to a continuous cell of the worksheet and allows to change the color of every n-th column or row. [222](https://github.com/JanMarvin/openxlsx2/pull/222)

--- a/R/write.R
+++ b/R/write.R
@@ -167,8 +167,13 @@ update_cell <- function(x, wb, sheet, cell, data_class,
 
         # for now convert all R-characters to inlineStr (e.g. names() of a data frame)
         if ((data_class[m] == openxlsx2_celltype[["character"]]) || ((colNames == TRUE) && (n == 1))) {
-          cc[sel, "c_t"] <- "inlineStr"
-          cc[sel, "is"]   <- paste0("<is><t>", as.character(value), "</t></is>")
+          if (is.na(value)) {
+            cc[sel, "v"] <- "#N/A"
+            cc[sel, "c_t"] <- "e"
+          } else {
+            cc[sel, "c_t"] <- "inlineStr"
+            cc[sel, "is"]   <- paste0("<is><t>", as.character(value), "</t></is>")
+          }
         } else if (data_class[m] == openxlsx2_celltype[["formula"]]) {
           cc[sel, "c_t"] <- "str"
           cc[sel, "f"] <- as.character(value)
@@ -185,6 +190,12 @@ update_cell <- function(x, wb, sheet, cell, data_class,
         } else {
           if (is.na(value)) {
             cc[sel, "v"] <- "#N/A"
+            cc[sel, "c_t"] <- "e"
+          } else if (value == "NaN") {
+            cc[sel, "v"] <- "#VALUE!"
+            cc[sel, "c_t"] <- "e"
+          } else if (value == "-Inf" | value == "Inf") {
+            cc[sel, "v"] <- "#NUM!"
             cc[sel, "c_t"] <- "e"
           } else {
             cc[sel, "v"]   <- as.character(value)
@@ -503,7 +514,7 @@ write_data2 <-function(wb, sheet, data, name = NULL,
     }
 
     sel <- which(dc == openxlsx2_celltype[["character"]]) # character
-    for (i in sel) {
+    if (length(sel)) {
       data[sel][is.na(data[sel])] <- "_openxlsx_NA"
     }
 
@@ -521,13 +532,25 @@ write_data2 <-function(wb, sheet, data, name = NULL,
     # values, but contains a string. To avoid issues, set it to the missing
     # value expression
 
-    ## fix missing characters (Otherwise NA cannot be differentiated from "NA")
-    sel <- cc$is == "<is><t>_openxlsx_NA</t></is>"
-    cc$v[sel] <- "NA"
-    cc$is[sel] <- "_openxlsx_NA"
+    ## replace NA, NaN, and Inf
+    is_na <- which(cc$is == "<is><t>_openxlsx_NA</t></is>" | cc$v == "NA")
+    if (length(is_na)) {
+      cc[is_na, "v"]   <- "#N/A"
+      cc[is_na, "c_t"] <- "e"
+      cc[is_na, "is"]  <- ""
+    }
 
-    cc$v[cc$v == "NA"] <- "#N/A"
-    cc$c_t[cc$v == "#N/A"] <- "e"
+    is_nan <- which(cc$v == "NaN")
+    if (length(is_nan)) {
+      cc[is_nan, "v"]   <- "#VALUE!"
+      cc[is_nan, "c_t"] <- "e"
+    }
+
+    is_inf <- which(cc$v == "-Inf" | cc$v == "Inf")
+    if (length(is_inf)) {
+      cc[is_inf, "v"]   <- "#NUM!"
+      cc[is_inf, "c_t"] <- "e"
+    }
 
     cc$c_s[cc$typ == "0"]  <- wb$styles_mgr$get_xf_id(short_date_fmtid)
     cc$c_s[cc$typ == "1"]  <- wb$styles_mgr$get_xf_id(long_date_fmtid)

--- a/tests/testthat/test-read_from_created_wb.R
+++ b/tests/testthat/test-read_from_created_wb.R
@@ -40,8 +40,10 @@ test_that("Reading NAs and NaN values", {
   fileName <- file.path(tempdir(), "NaN.xlsx")
   na.string <- "*"
 
+  wb <- wb_workbook()
+
   ## data
-  a <- data.frame(
+  A <- data.frame(
     X  = c(-pi / 0, NA, NaN),
     Y  = letters[1:3],
     Z  = c(pi / 0, 99, NaN),
@@ -49,30 +51,36 @@ test_that("Reading NAs and NaN values", {
     stringsAsFactors = FALSE
   )
 
-  b <- a
-  b[b == -Inf] <- NaN
-  b[b == Inf] <- NaN
+  wb$add_worksheet("Sheet 1")$add_data(1, A)
 
-  c <- b
-  is_na <- sapply(c, is.na)
-  is_nan <- sapply(c, is.nan)
-  c[is_na & !is_nan] <- na.string
-  is_nan_after <- sapply(c, is.nan)
-  c[is_nan & !is_nan_after] <- NA
+  # not used
+  B <- A
+  B[B == -Inf] <- NaN
+  B[B == Inf] <- NaN
 
-  wb <- wb_workbook()
+  wb$add_worksheet("Sheet 2")$add_data(2, B)
 
-  wb$add_worksheet("Sheet 1")
-  wb$add_data(1, a)
+  # not used
+  C <- B
+  is_na <- sapply(C, is.na)
+  is_nan <- sapply(C, is.nan)
+  C[is_na & !is_nan] <- na.string
+  is_nan_after <- sapply(C, is.nan)
+  C[is_nan & !is_nan_after] <- NA
 
-  wb$add_worksheet("Sheet 2")
-  wb$add_data(2, a)
+  wb$add_worksheet("Sheet 3")$add_data(3, C)
 
-  wb$add_worksheet("Sheet 3")
-  wb$add_data(3, a)
-
+  # write file
   wb_save(wb, path = fileName, overwrite = TRUE)
 
-  expect_equal(read_xlsx(fileName), a, ignore_attr = TRUE)
+  exp <- data.frame(
+    X  = c("#NUM!", NA, "#VALUE!"),
+    Y  = letters[1:3],
+    Z  = c("#NUM!", 99, "#VALUE!"),
+    Z2 = c(1, "#VALUE!", "#VALUE!"),
+    stringsAsFactors = FALSE
+  )
+
+  expect_equal(read_xlsx(fileName), exp, ignore_attr = TRUE)
   unlink(fileName, recursive = TRUE, force = TRUE)
 })

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -174,3 +174,34 @@ test_that("example", {
   expect_silent(write_xlsx(l, tmp, colWidths = list(rep(10, 5), rep(8, 11), rep(5, 5))))
 
 })
+
+test_that("writing NA, NaN and Inf", {
+
+  tmp <- temp_xlsx()
+  wb <- wb_workbook()
+
+  x <- data.frame(x = c(NA, Inf, -Inf, NaN))
+  wb$add_worksheet("Test1")$add_data(x = x)$save(tmp)
+
+  # we wont get the same input back
+  exp <- c(NA_character_, "#NUM!", "#NUM!", "#VALUE!")
+  got <- unname(unlist(wb_to_df(tmp)))
+  expect_equal(exp, got)
+
+  wb$clone_worksheet(old = "Test1", new = "Clone1")$add_data(x = x)$save(tmp)
+  got <- unname(unlist(wb_to_df(tmp, "Clone1")))
+  expect_equal(exp, got)
+
+  # distinguish between "NA" and NA_character_
+  x <- data.frame(x = c(NA, "NA"))
+  wb$add_worksheet("Test2")$add_data(x = x)$save(tmp)
+
+  exp <- c(NA_character_, "NA")
+  got <- unname(unlist(wb_to_df(tmp, "Test2")))
+  expect_equal(exp, got)
+
+  wb$clone_worksheet(old = "Test2", new = "Clone2")$add_data(x = x)$save(tmp)
+  got <- unname(unlist(wb_to_df(tmp, "Clone2")))
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
This fixes the read/write of NA, NaN and Inf. I'm not sure yet if it's a good idea to always convert `#NUM!` and/or `#VALUE!` and maybe more openxml exceptions to R's NaN, NA or Inf. All these exceptions have special meaning in R and must not match their openxml counterparts. I am open to arguments as to why we should or should not do this.