### PR TITLE
[R/write] add na.strings argument to write functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## New features
 
-* Improve writing `NA`, `NaN`, and `-Inf`/`Inf`. `NA` will be converted to `#N/A`; `NaN` will be converted to `#VALUE!`; `Inf` will be converted to `#NUM!`. The same conversion is not applied when reading from a workbook.
+* Provide optional `na.strings` argument when writing data to sheets. It can be used to add a custom character string when writing numeric data.
+
+* Improve writing `NA`, `NaN`, and `-Inf`/`Inf`. `NA` will be converted to `#N/A`; `NaN` will be converted to `#VALUE!`; `Inf` will be converted to `#NUM!`. The same conversion is not applied when reading from a workbook. [256](https://github.com/JanMarvin/openxlsx2/pull/256)
 
 * Many `wbWorkbook` methods now contain default sheet values of `current_sheet()` or `next_sheet()` (e.g., `$add_worksheet(sheet = next_sheet())`, `$write_data(sheet = curret_sheet()`).  These internal waiver functions allow the `wbWorkbook` object to use default expectations for what sheet to interact with.  This allows the easier workflow of `wb$add_worksheet()$add_data(x = data.frame())` where `$add_worksheet()` knows to add a new worksheet (with a default name), sets that new worksheet to the current worksheet, and then `$add_data()` picks up the new sheet and places the data there. [165](https://github.com/JanMarvin/openxlsx2/issues/165), [179](https://github.com/JanMarvin/openxlsx2/pull/179)
 

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -92,6 +92,7 @@ wb_save <- function(wb, path = NULL, overwrite = TRUE) {
 #' @param name If not NULL, a named region is defined.
 #' @param sep Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).
 #' @param removeCellStyle keep the cell style?
+#' @param na.strings na.strings
 #' @export
 #' @details Formulae written using write_formula to a Workbook object will not get picked up by read_xlsx().
 #' This is because only the formula is written and left to Excel to evaluate the formula when the file is opened in Excel.
@@ -112,9 +113,13 @@ wb_add_data <- function(
     withFilter      = FALSE,
     name            = NULL,
     sep             = ", ",
-    removeCellStyle = FALSE
+    removeCellStyle = FALSE,
+    na.strings
 ) {
   assert_workbook(wb)
+
+  if (missing(na.strings)) na.strings <- substitute()
+
   wb$clone()$add_data(
     sheet           = sheet,
     x               = x,
@@ -127,7 +132,8 @@ wb_add_data <- function(
     withFilter      = withFilter,
     name            = name,
     sep             = sep,
-    removeCellStyle = removeCellStyle
+    removeCellStyle = removeCellStyle,
+    na.strings      = na.strings
   )
 }
 
@@ -161,6 +167,7 @@ wb_add_data <- function(
 #' @param lastColumn logical. If TRUE, the last column is bold
 #' @param bandedRows logical. If TRUE, rows are colour banded
 #' @param bandedCols logical. If TRUE, the columns are colour banded
+#' @param na.strings optional
 #'
 #' @details columns of x with class Date/POSIXt, currency, accounting,
 #' hyperlink, percentage are automatically styled as dates, currency,
@@ -185,9 +192,12 @@ wb_add_data_table <- function(
     firstColumn = FALSE,
     lastColumn  = FALSE,
     bandedRows  = TRUE,
-    bandedCols  = FALSE
+    bandedCols  = FALSE,
+    na.strings
 ) {
   assert_workbook(wb)
+  if (missing(na.strings)) na.strings <- substitute()
+
   wb$clone()$add_data_table(
     sheet       = sheet,
     x           = x,
@@ -203,7 +213,8 @@ wb_add_data_table <- function(
     firstColumn = firstColumn,
     lastColumn  = lastColumn,
     bandedRows  = bandedRows,
-    bandedCols  = bandedCols
+    bandedCols  = bandedCols,
+    na.strings  = na.strings
   )
 }
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -801,6 +801,7 @@ wbWorkbook <- R6::R6Class(
     #' @param name name
     #' @param sep sep
     #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
+    #' @param na.strings na.strings
     #' @param return The `wbWorkbook` object
     add_data = function(
         sheet           = current_sheet(),
@@ -814,8 +815,12 @@ wbWorkbook <- R6::R6Class(
         withFilter      = FALSE,
         name            = NULL,
         sep             = ", ",
-        removeCellStyle = FALSE
+        removeCellStyle = FALSE,
+        na.strings
       ) {
+
+      if (missing(na.strings)) na.strings <- substitute()
+
       write_data(
         wb              = self,
         sheet           = sheet,
@@ -829,7 +834,8 @@ wbWorkbook <- R6::R6Class(
         withFilter      = withFilter,
         name            = name,
         sep             = sep,
-        removeCellStyle = removeCellStyle
+        removeCellStyle = removeCellStyle,
+        na.strings      = na.strings
       )
       self
     },
@@ -850,6 +856,7 @@ wbWorkbook <- R6::R6Class(
     #' @param lastColumn lastColumn
     #' @param bandedRows bandedRows
     #' @param bandedCols bandedCols
+    #' @param na.strings na.strings
     #' @returns The `wbWorkbook` object
     add_data_table = function(
         sheet       = current_sheet(),
@@ -866,8 +873,12 @@ wbWorkbook <- R6::R6Class(
         firstColumn = FALSE,
         lastColumn  = FALSE,
         bandedRows  = TRUE,
-        bandedCols  = FALSE
+        bandedCols  = FALSE,
+        na.strings
     ) {
+
+      if (missing(na.strings)) na.strings <- substitute()
+
       write_datatable(
         wb          = self,
         sheet       = sheet,
@@ -884,7 +895,8 @@ wbWorkbook <- R6::R6Class(
         firstColumn = firstColumn,
         lastColumn  = lastColumn,
         bandedRows  = bandedRows,
-        bandedCols  = bandedCols
+        bandedCols  = bandedCols,
+        na.strings  = na.strings
       )
       self
     },

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -133,7 +133,7 @@ write_xlsx <- function(x, file, asTable = FALSE, ...) {
   ## colNames = TRUE,
   ## rowNames = FALSE,
   ## keepNA = FALSE
-  ## na.string = NULL
+  ## na.strings = NULL
 
   #----write_datatable---#
   ## startCol = 1

--- a/man/update_cell.Rd
+++ b/man/update_cell.Rd
@@ -11,7 +11,8 @@ update_cell(
   cell,
   data_class,
   colNames = FALSE,
-  removeCellStyle = FALSE
+  removeCellStyle = FALSE,
+  na.strings
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ update_cell(
 \item{colNames}{if TRUE colNames are passed down}
 
 \item{removeCellStyle}{keep the cell style?}
+
+\item{na.strings}{optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)}
 }
 \description{
 Minimal invasive update of cell(s) inside of imported workbooks.

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -523,7 +523,8 @@ add data
   withFilter = FALSE,
   name = NULL,
   sep = ", ",
-  removeCellStyle = FALSE
+  removeCellStyle = FALSE,
+  na.strings
 )}\if{html}{\out{</div>}}
 }
 
@@ -554,6 +555,8 @@ add data
 
 \item{\code{removeCellStyle}}{if writing into existing cells, should the cell style be removed?}
 
+\item{\code{na.strings}}{na.strings}
+
 \item{\code{return}}{The \code{wbWorkbook} object}
 }
 \if{html}{\out{</div>}}
@@ -580,7 +583,8 @@ add a data table
   firstColumn = FALSE,
   lastColumn = FALSE,
   bandedRows = TRUE,
-  bandedCols = FALSE
+  bandedCols = FALSE,
+  na.strings
 )}\if{html}{\out{</div>}}
 }
 
@@ -616,6 +620,8 @@ add a data table
 \item{\code{bandedRows}}{bandedRows}
 
 \item{\code{bandedCols}}{bandedCols}
+
+\item{\code{na.strings}}{na.strings}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wb_add_data_table.Rd
+++ b/man/wb_add_data_table.Rd
@@ -20,7 +20,8 @@ wb_add_data_table(
   firstColumn = FALSE,
   lastColumn = FALSE,
   bandedRows = TRUE,
-  bandedCols = FALSE
+  bandedCols = FALSE,
+  na.strings
 )
 }
 \arguments{
@@ -64,6 +65,8 @@ sep).
 \item{bandedRows}{logical. If TRUE, rows are colour banded}
 
 \item{bandedCols}{logical. If TRUE, the columns are colour banded}
+
+\item{na.strings}{optional}
 }
 \description{
 Add data to a worksheet and format as an Excel table

--- a/man/write_data.Rd
+++ b/man/write_data.Rd
@@ -18,7 +18,8 @@ wb_add_data(
   withFilter = FALSE,
   name = NULL,
   sep = ", ",
-  removeCellStyle = FALSE
+  removeCellStyle = FALSE,
+  na.strings
 )
 
 write_data(
@@ -34,7 +35,8 @@ write_data(
   withFilter = FALSE,
   sep = ", ",
   name = NULL,
-  removeCellStyle = FALSE
+  removeCellStyle = FALSE,
+  na.strings
 )
 }
 \arguments{
@@ -65,6 +67,8 @@ write_data(
 \item{sep}{Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).}
 
 \item{removeCellStyle}{if writing into existing cells, should the cell style be removed?}
+
+\item{na.strings}{optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)}
 }
 \value{
 A clone of `wb``

--- a/man/write_data2.Rd
+++ b/man/write_data2.Rd
@@ -13,7 +13,8 @@ write_data2(
   rowNames = FALSE,
   startRow = 1,
   startCol = 1,
-  removeCellStyle = FALSE
+  removeCellStyle = FALSE,
+  na.strings
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ write_data2(
 \item{startCol}{col to place it}
 
 \item{removeCellStyle}{keep the cell style?}
+
+\item{na.strings}{optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)}
 }
 \description{
 dummy function to write data

--- a/man/write_datatable.Rd
+++ b/man/write_datatable.Rd
@@ -20,7 +20,8 @@ write_datatable(
   firstColumn = FALSE,
   lastColumn = FALSE,
   bandedRows = TRUE,
-  bandedCols = FALSE
+  bandedCols = FALSE,
+  na.strings
 )
 }
 \arguments{
@@ -61,6 +62,8 @@ A vector of the form c(startCol, startRow)}
 \item{bandedRows}{logical. If TRUE, rows are colour banded}
 
 \item{bandedCols}{logical. If TRUE, the columns are colour banded}
+
+\item{na.strings}{optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)}
 }
 \description{
 Write to a worksheet and format as an Excel table

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -205,3 +205,35 @@ test_that("writing NA, NaN and Inf", {
   expect_equal(exp, got)
 
 })
+
+
+test_that("writing NA, NaN and Inf", {
+
+  tmp <- temp_xlsx()
+  wb <- wb_workbook()
+
+  x <- data.frame(x = c(NA, Inf, -Inf, NaN))
+  wb$add_worksheet("Test1")$add_data(x = x, na.strings = NULL)$save(tmp)
+  wb$add_worksheet("Test2")$add_data_table(x = x, na.strings = "N/A")$save(tmp)
+  wb$add_worksheet("Test3")$add_data(x = x, na.strings = "N/A")$save(tmp)
+
+  exp <- c(NA, "s", "s", "s")
+  got <- unname(unlist(attr(wb_to_df(tmp, "Test1"), "tt")))
+  expect_equal(exp, got)
+
+  exp <- c("N/A", "#NUM!", "#NUM!", "#VALUE!")
+  got <- unname(unlist(wb_to_df(tmp, "Test2")))
+  expect_equal(exp, got)
+
+  wb$clone_worksheet("Test1", "Clone1")$add_data(x = x, na.strings = NULL)$save(tmp)
+  wb$clone_worksheet("Test3", "Clone3")$add_data(x = x, na.strings = "N/A")$save(tmp)
+
+  exp <- c(NA, "s", "s", "s")
+  got <- unname(unlist(attr(wb_to_df(tmp, "Test1"), "tt")))
+  expect_equal(exp, got)
+
+  exp <- c("N/A", "#NUM!", "#NUM!", "#VALUE!")
+  got <- unname(unlist(wb_to_df(tmp, "Test2")))
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Add option to write custom `na.strings`. It is `na.strings` even though it allows just a single value, to match the identical argument when reading. This allows three options if `na.strings`

* is missing: write `#N/A` exception to output
* is NULL: write nothing
* is character or numeric: write `inlineStr` of `as.character(na.strings)`

This applies to `NA` only and is intended to be used when replacing `NA` in numeric data with character strings or empty cells.