### PR TITLE
[R/update_cell_loop] further speedups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # openxlsx2 (in development)
 
-* Fixes a bug in `update_cell()` that slowed down writing on worksheets with data. In addition, this function has been cleaned up and further improved. It is no longer exported, as users only need to use `wb_add_data()` or `write_data()`, each of which calls `update_cell()` under the hood. [275](https://github.com/JanMarvin/openxlsx2/pull/275)
+* Fixes a bug in `update_cell()` that slowed down writing on worksheets with data. In addition, this function has been cleaned up and further improved. It is no longer exported, as users only need to use `wb_add_data()` or `write_data()`, each of which calls `update_cell()` under the hood. [275](https://github.com/JanMarvin/openxlsx2/pull/275) [276](https://github.com/JanMarvin/openxlsx2/pull/276)
 
 * Add new options to data validation. allow type custom, add arguments `errorStyle`, `errorTitle`, `error`, `promptTitle`, `prompt`. [271](https://github.com/JanMarvin/openxlsx2/issues/271)
 

--- a/R/write.R
+++ b/R/write.R
@@ -37,22 +37,13 @@ update_cell <- function(x, wb, sheet, cell, data_class,
                         colNames = FALSE, removeCellStyle = FALSE,
                         na.strings) {
 
+  sheet_id <- wb$validate_sheet(sheet)
+
   dims <- dims_to_dataframe(cell, fill = TRUE)
   cols <- colnames(dims)
   rows <- rownames(dims)
 
   cells_needed <- unname(unlist(dims))
-
-  if (is.character(sheet)) {
-    sheet_id <- which(sheet == wb$sheet_names)
-  } else {
-    sheet_id <- sheet
-  }
-
-  if (missing(data_class)) {
-    # TODO consider using inherit() for class checking
-    data_class <- openxlsx2_type(x)
-  }
 
 
   # 1) pull sheet to modify from workbook; 2) modify it; 3) push it back
@@ -64,10 +55,6 @@ update_cell <- function(x, wb, sheet, cell, data_class,
   # contain fields A1 and C1.
   cells_in_wb <- cc$r
   rows_in_wb <- row_attr$r
-
-  if (!inherits(x, "data.frame")) {
-    x <- as.data.frame(x)
-  }
 
   # check if there are rows not available
   if (!all(rows %in% rows_in_wb)) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -108,15 +108,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // update_cell_loop
-void update_cell_loop(Rcpp::DataFrame cc, Rcpp::DataFrame x, Rcpp::CharacterVector data_class, std::vector<std::string> rows, std::vector<std::string> cols, bool colNames, bool removeCellStyle, std::string cell, bool no_na_strings, Rcpp::Nullable<Rcpp::String> na_strings_, Rcpp::Nullable<Rcpp::String> hyperlinkstyle_);
+void update_cell_loop(Rcpp::DataFrame cc, Rcpp::DataFrame x, Rcpp::IntegerVector data_class, vec_string rows, vec_string cols, bool colNames, bool removeCellStyle, std::string cell, bool no_na_strings, Rcpp::Nullable<Rcpp::String> na_strings_, Rcpp::Nullable<Rcpp::String> hyperlinkstyle_);
 RcppExport SEXP _openxlsx2_update_cell_loop(SEXP ccSEXP, SEXP xSEXP, SEXP data_classSEXP, SEXP rowsSEXP, SEXP colsSEXP, SEXP colNamesSEXP, SEXP removeCellStyleSEXP, SEXP cellSEXP, SEXP no_na_stringsSEXP, SEXP na_strings_SEXP, SEXP hyperlinkstyle_SEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::DataFrame >::type cc(ccSEXP);
     Rcpp::traits::input_parameter< Rcpp::DataFrame >::type x(xSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type data_class(data_classSEXP);
-    Rcpp::traits::input_parameter< std::vector<std::string> >::type rows(rowsSEXP);
-    Rcpp::traits::input_parameter< std::vector<std::string> >::type cols(colsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type data_class(data_classSEXP);
+    Rcpp::traits::input_parameter< vec_string >::type rows(rowsSEXP);
+    Rcpp::traits::input_parameter< vec_string >::type cols(colsSEXP);
     Rcpp::traits::input_parameter< bool >::type colNames(colNamesSEXP);
     Rcpp::traits::input_parameter< bool >::type removeCellStyle(removeCellStyleSEXP);
     Rcpp::traits::input_parameter< std::string >::type cell(cellSEXP);


### PR DESCRIPTION
Well, sometimes it's the little things, like writing correct c++-code.

```R
> library(microbenchmark)
> library(openxlsx2)
> 
> # a larger data frame with strings, missings and numbers
> xlsxFile <- system.file("extdata", "readTest.xlsx", package = "openxlsx2")
> wb1 <- wb_load(xlsxFile)
> data <- wb_to_df(wb1, sheet = 3, skipEmptyRows = TRUE)
> 
> res <- microbenchmark::microbenchmark(
+   wb <- wb_workbook()$add_worksheet()$add_data(x = data),
+   wb <- wb$add_data(x = data),
+   times = 25
+ ); res
Unit: milliseconds
                                                   expr       min        lq     mean    median        uq       max neval
 wb <- wb_workbook()$add_worksheet()$add_data(x = data)  31.77736  32.08635  34.6002  32.37475  32.69734  44.95653    25
                            wb <- wb$add_data(x = data) 143.69455 145.38906 149.5828 146.44222 155.83526 161.53349    25
```

25s -> 145ms.  I'm calling it a day. Only 4.3 times slower :)

[Edit:] previously the initial creation was part of my speed measurement :see_no_evil: 