### PR TITLE
remove `$hyperlink` code

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5139,7 +5139,6 @@ wbWorkbook <- R6::R6Class(
         } else {
           ## Write worksheets
           ws <- self$worksheets[[i]]
-          hasHL <- length(ws$hyperlinks) > 0
 
           prior <- ws$get_prior_sheet_data()
           post <- ws$get_post_sheet_data()
@@ -5189,15 +5188,6 @@ wbWorkbook <- R6::R6Class(
           ## write worksheet rels
           if (length(self$worksheets_rels[[i]])) {
             ws_rels <- self$worksheets_rels[[i]]
-            if (hasHL) {
-              h_inds <- stri_join(seq_along(self$worksheets[[i]]$hyperlinks), "h")
-              ws_rels <-
-                c(ws_rels, unlist(
-                  lapply(seq_along(h_inds), function(j) {
-                    self$worksheets[[i]]$hyperlinks[[j]]$to_target_xml(h_inds[j])
-                  })
-                ))
-            }
 
             ## Check if any tables were deleted - remove these from rels
             # TODO a relship manager should take care of this

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -304,25 +304,6 @@ wbWorksheet <- R6::R6Class(
           )
         },
 
-        # hyperlinks
-        if (n <- length(self$hyperlinks)) {
-          h_inds <- paste0(seq_len(n), "h")
-          paste(
-            "<hyperlinks>",
-            paste(
-              vapply(
-                seq_along(h_inds),
-                function(i)  {
-                  self$hyperlinks[[i]]$to_xml(h_inds[i])
-                },
-                NA_character_
-              ),
-              collapse = ""
-            ),
-            "</hyperlinks>"
-          )
-        },
-
         self$pageMargins,
         self$pageSetup,
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -795,34 +795,6 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
 
     } ## if (length(tablesXML))
 
-    ## might we have some external hyperlinks
-    # TODO use lengths()
-    if (any(vapply(wb$worksheets[sheets$typ == "worksheet"], function(x) length(x$hyperlinks), NA_integer_) > 0)) {
-
-      ## Do we have external hyperlinks
-      hlinks <- lapply(xml, function(x) x[grepl("hyperlink", x) & grepl("External", x)])
-      # TODO use lengths()
-      hlinksInds <- which(lengths(hlinks) > 0)
-
-      ## If it's an external hyperlink it will have a target in the sheet_rels
-      if (length(hlinksInds)) {
-        for (i in hlinksInds) {
-          ids <- apply_reg_match(hlinks[[i]], '(?<=Id=").*?"')
-          ids <- gsub('"$', "", ids)
-
-          targets <- apply_reg_match(hlinks[[i]], '(?<=Target=").*?"')
-          targets <- gsub('"$', "", targets)
-
-          ids2 <- lapply(wb$worksheets[[i]]$hyperlinks, reg_match, pat = '(?<=r:id=").*?"')
-          ids2[lengths(ids2) == 0] <- NA
-          ids2 <- gsub('"$', "", unlist(ids2))
-
-          targets <- targets[match(ids2, ids)]
-          names(wb$worksheets[[i]]$hyperlinks) <- targets
-        }
-      }
-    }
-
 
     ## Drawings ------------------------------------------------------------------------------------
 
@@ -1057,12 +1029,6 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     # Otherwise spreadsheet software will stumble over missing rels to drwaing.
     wb$worksheets_rels <- lapply(seq_along(wb$sheet_names), FUN = function(x) character())
   } ## end of worksheetRels
-
-  ## convert hyperliks to hyperlink objects
-  if (!data_only)
-    for (i in seq_len(nSheets)) {
-      wb$worksheets[[i]]$hyperlinks <- xml_to_hyperlink(wb$worksheets[[i]]$hyperlinks)
-    }
 
   ## queryTables
   if (!data_only && length(queryTablesXML) > 0) {


### PR DESCRIPTION
I do not see a use case for this and could not make it work, creating links from `openxlsx2`.
* Is it defunct at the moment?
* Was it never used or was it used in `openxlsx`?
* Do we need it?