### PR TITLE
Dxf nofont

### DIFF
--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -325,6 +325,8 @@ create_font <- function(
     i <- xml_node_create("i", xml_attributes = c("val" = i))
   }
 
+  if(is.null(name)) name <- ""
+  
   if (name != "") {
     name <- xml_node_create("name", xml_attributes = c("val" = name))
   }

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -347,6 +347,8 @@ create_font <- function(
     strike <- xml_node_create("strike", xml_attributes = c("val" = strike))
   }
 
+  if(is.null(sz)) sz <- ""
+
   if (sz != "") {
     sz <- xml_node_create("sz", xml_attributes = c("val" = sz))
   }

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -605,3 +605,14 @@ test_that("create dxfs style without font and bg color", {
   expect_equal(exp, got)
 
 })
+
+test_that("create dxfs style without font family and size", {
+
+  exp <- "<dxf><font><color rgb=\"FF9C0006\"/></font><fill><patternFill patternType=\"solid\"><bgColor rgb=\"FFFFC7CE\"/></patternFill></fill></dxf>"
+  got <- create_dxfs_style(font_name = "", font_size = "")
+  expect_equal(exp, got)
+
+  got <- create_dxfs_style(font_name = NULL, font_size = NULL)
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Allows this:

```R
yel_style <- create_dxfs_style(font_name = NULL, font_size = NULL)
```