### PR TITLE
Allow creation of dxfs style w/o font and bg color. closes #291

### DIFF
--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -885,6 +885,7 @@ create_dxfs_style <- function(
     text_underline = NULL # "true" or "double"
 ) {
 
+  if (is.null(font_color)) font_color = ""
   if (is.null(text_bold)) text_bold = ""
   if (is.null(text_strike)) text_strike = ""
   if (is.null(text_italic)) text_italic = ""

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -898,7 +898,10 @@ create_dxfs_style <- function(
                       u = text_underline,
                       family = "", scheme = "")
 
-  fill <- create_fill(patternType = "solid", bgColor = bgFill)
+  if (!is.null(bgFill) && bgFill != "") 
+    fill <- create_fill(patternType = "solid", bgColor = bgFill)
+  else
+    fill <- NULL
 
   # untested
   if (!is.null(border))

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -594,3 +594,11 @@ test_that("wb_conditional_formatting", {
   got <- wb$worksheets[[1]]$conditionalFormatting
   expect_equal(exp, got)
 })
+
+test_that("create dxfs style without font and bg color", {
+
+  exp <- "<dxf><font><name val=\"Calibri\"/><sz val=\"11\"/></font></dxf>"
+  got <- create_dxfs_style(font_color = "", bgFill = "")
+  expect_equal(exp, got)
+
+})

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -601,4 +601,7 @@ test_that("create dxfs style without font and bg color", {
   got <- create_dxfs_style(font_color = "", bgFill = "")
   expect_equal(exp, got)
 
+  got <- create_dxfs_style(font_color = NULL, bgFill = NULL)
+  expect_equal(exp, got)
+
 })


### PR DESCRIPTION
Disable colors in dxfs style:

```R
> create_dxfs_style(font_color = NULL, bgFill = NULL)
[1] "<dxf><font><name val=\"Calibri\"/><sz val=\"11\"/></font></dxf>"
```