### PR TITLE
fix get_cell_styles

### DIFF
--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -772,11 +772,11 @@ get_cell_styles <- function(wb, sheet, cell) {
   z <- get_cell_style(wb, sheet, cell)
   id <- vapply(z, function(x) {
     out <- which(wb$styles_mgr$get_xf()$id %in% x)
-    if (identical(out,integer())) out <- 0L
+    if (identical(out,integer())) out <- 1L
     out
   },
   NA_integer_)
-  wb$styles_mgr$styles$cellXfs[id+1]
+  wb$styles_mgr$styles$cellXfs[id]
 }
 
 

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -291,3 +291,12 @@ test_that("add_style", {
   expect_equal(exp, got)
 
 })
+
+test_that("assigning styles to loaded workbook works", {
+
+  wb <- wb_load(file = system.file("extdata", "oxlsx2_sheet.xlsx", package = "openxlsx2"))
+
+  # previously it would break on xml_import, because NA was returned  
+  expect_silent(wb$add_font()$add_font())
+
+})


### PR DESCRIPTION
When working with a loaded sheet, we tried to get the n+1 object from a vector of length n