### PR TITLE
[R/dataValidation] Fixes #277.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 ## Internal changes
 
+* Moving the data validation code from the workbook to the worksheet. Also, `data_validation_list()` is no longer stored in `dataValidationLst`. It has been moved to `extLst`, fixing a bug when saving and adding another data validation list. The code for retrieving the date origin from a workbook has been improved and `get_date_origin(wb, origin = TRUE)` now returns the origin as an integer from a `wbWorkbook`. [299](https://github.com/JanMarvin/openxlsx2/pull/299)
+
 * Removed level4 from XML functions. There was only a single use case for a level4 function that has been solved differently. If level4 is needed, this can be solved using a level3 and additional level2 functions. In addition xml_nodes now return nodes for all reachable nestings, therefore `xml_node("<a/><a/>", "a")` will now return a character vector of length two. For `xml_node("<a/><b/>", "a")` only a single character vector is returned. [280](https://github.com/JanMarvin/openxlsx2/issues/280)
 
 * Changes to various internal pugixml functions, to improve handling of XML strings. [279](https://github.com/JanMarvin/openxlsx2/issues/279)

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -1552,7 +1552,7 @@ wb_add_data_validation <- function(
     prompt = NULL
 ) {
   assert_workbook(wb)
-  wb$clone()$add_data_validation(
+  wb$clone(deep = TRUE)$add_data_validation(
     sheet        = sheet,
     cols         = cols,
     rows         = rows,
@@ -1635,7 +1635,7 @@ wb_set_sheet_visibility <- function(wb, sheet = current_sheet(), value) {
 #' ## In Excel: View tab -> Page Break Preview
 wb_add_page_break <- function(wb, sheet = current_sheet(), row = NULL, col = NULL) {
   assert_workbook(wb)
-  wb$clone()$add_page_break(sheet = sheet, row = row, col = col)
+  wb$clone(deep = TRUE)$add_page_break(sheet = sheet, row = row, col = col)
 }
 
 
@@ -1976,7 +1976,7 @@ wb_clean_sheet <- function(
     merged_cells = TRUE
 ) {
   assert_workbook(wb)
-  wb$clone()$clean_sheet(
+  wb$clone(deep = TRUE)$clean_sheet(
     sheet        = sheet,
     numbers      = numbers,
     characters   = characters,
@@ -2498,5 +2498,5 @@ wb_clone_sheet_style <- function(wb, from = current_sheet(), to) {
 #' @export
 wb_add_sparklines <- function(wb, sheet = current_sheet(), sparklines) {
   assert_workbook(wb)
-  wb$clone()$add_sparklines(sheet, sparklines)
+  wb$clone(deep = TRUE)$add_sparklines(sheet, sparklines)
 }

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5386,7 +5386,7 @@ wbWorkbook <- R6::R6Class(
       invisible(self)
     },
 
-    # TODO can this be merged with above?
+    # data validations list goes to extLst not to worksheet
     data_validation_list = function(
       sheet = current_sheet(),
       startRow,
@@ -5403,6 +5403,7 @@ wbWorkbook <- R6::R6Class(
       promptTitle,
       prompt
     ) {
+
       # TODO consider some defaults to logicals
       # TODO rename: setDataValidationList?
       sheet <- private$get_sheet_index(sheet)
@@ -5433,7 +5434,8 @@ wbWorkbook <- R6::R6Class(
       formula <- sprintf("<x14:formula1><xm:f>%s</xm:f></x14:formula1>", value)
       sqref <- sprintf("<xm:sqref>%s</xm:sqref>", sqref)
       xmlData <- xml_add_child(data_val, c(formula, sqref))
-      private$append_sheet_field(sheet, "dataValidationsLst", xmlData)
+      self$worksheets[[sheet]]$.__enclos_env__$private$add_data_validation_lst(xmlData)
+
       invisible(self)
     },
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -2467,6 +2467,9 @@ wbWorkbook <- R6::R6Class(
       promptTitle = NULL,
       prompt = NULL
     ) {
+
+      sheet <- private$get_sheet_index(sheet)
+
       ## rows and cols
       if (!is.numeric(cols)) {
         cols <- col2int(cols)
@@ -2539,13 +2542,20 @@ wbWorkbook <- R6::R6Class(
       showInputMsg <- as.character(as.integer(showInputMsg[1]))
       showErrorMsg <- as.character(as.integer(showErrorMsg[1]))
 
+      # prepare for worksheet
+      origin <- get_date_origin(self, origin = TRUE)
+
+      sqref <- stri_join(
+        get_cell_refs(data.frame(
+          "x" = c(min(rows), max(rows)),
+          "y" = c(min(cols), max(cols))
+        )),
+        sep = " ",
+        collapse = ":"
+      )
+
       if (type == "list") {
-        private$data_validation_list(
-          sheet        = sheet,
-          startRow     = min(rows),
-          endRow       = max(rows),
-          startCol     = min(cols),
-          endCol       = max(cols),
+        self$worksheets[[sheet]]$.__enclos_env__$private$data_validation_list(
           value        = value,
           allowBlank   = allowBlank,
           showInputMsg = showInputMsg,
@@ -2554,15 +2564,11 @@ wbWorkbook <- R6::R6Class(
           errorTitle   = errorTitle,
           error        = error,
           promptTitle  = promptTitle,
-          prompt       = prompt
+          prompt       = prompt,
+          sqref        = sqref
         )
       } else {
-        private$data_validation(
-          sheet        = sheet,
-          startRow     = min(rows),
-          endRow       = max(rows),
-          startCol     = min(cols),
-          endCol       = max(cols),
+        self$worksheets[[sheet]]$.__enclos_env__$private$data_validation(
           type         = type,
           operator     = operator,
           value        = value,
@@ -2573,7 +2579,9 @@ wbWorkbook <- R6::R6Class(
           errorTitle   = errorTitle,
           error        = error,
           promptTitle  = promptTitle,
-          prompt       = prompt
+          prompt       = prompt,
+          origin       = origin,
+          sqref        = sqref
         )
       }
 
@@ -3922,7 +3930,7 @@ wbWorkbook <- R6::R6Class(
       }
 
       if (length(sheets) != length(self$worksheets)) {
-        stop(sprintf("Worksheet order must be same length as number of worksheets [%s]", length(wb$worksheets)))
+        stop(sprintf("Worksheet order must be same length as number of worksheets [%s]", length(self$worksheets)))
       }
 
       if (any(sheets > length(self$worksheets))) {
@@ -5282,159 +5290,6 @@ wbWorkbook <- R6::R6Class(
           }
         } ## end of isChartSheet[i]
       } ## end of loop through nSheets
-
-      invisible(self)
-    },
-
-    data_validation = function(
-      sheet = current_sheet(),
-      startRow,
-      endRow,
-      startCol,
-      endCol,
-      type,
-      operator,
-      value,
-      allowBlank,
-      showInputMsg,
-      showErrorMsg,
-      errorStyle,
-      errorTitle,
-      error,
-      promptTitle,
-      prompt
-    ) {
-      # TODO rename: setDataValidation?
-      # TODO can this be moved to the worksheet class?
-      sheet <- private$get_sheet_index(sheet)
-      sqref <-
-        stri_join(get_cell_refs(data.frame(
-          "x" = c(startRow, endRow),
-          "y" = c(startCol, endCol)
-        )),
-          sep = " ",
-          collapse = ":"
-        )
-
-      header <- xml_node_create(
-        "dataValidation",
-        xml_attributes = c(
-          type = type,
-          operator = operator,
-          allowBlank = allowBlank,
-          showInputMessage = showInputMsg,
-          showErrorMessage = showErrorMsg,
-          sqref = sqref,
-          errorStyle = errorStyle,
-          errorTitle = errorTitle,
-          error = error,
-          promptTitle = promptTitle,
-          prompt = prompt
-        )
-      )
-
-      # TODO consider switch(type, date = ..., time = ..., )
-      if (type == "date") {
-        # TODO consider origin <- if () ... else ...
-        origin <- 25569L
-        # TODO would it be faster to just search each self$workbook instead of
-        # trying to unlist and join everything?
-        if (grepl(
-          'date1904="1"|date1904="true"',
-          stri_join(unlist(self$workbook), sep = " ", collapse = ""),
-          ignore.case = TRUE
-        )) {
-          origin <- 24107L
-        }
-
-        value <- as.integer(value) + origin
-      }
-
-      if (type == "time") {
-        # TODO simplify with above?  This is the same thing?
-        origin <- 25569L
-        if (grepl(
-          'date1904="1"|date1904="true"',
-          stri_join(unlist(self$workbook), sep = " ", collapse = ""),
-          ignore.case = TRUE
-        )) {
-          origin <- 24107L
-        }
-
-        t <- format(value[1], "%z")
-        offSet <-
-          suppressWarnings(
-            ifelse(substr(t, 1, 1) == "+", 1L, -1L) * (
-              as.integer(substr(t, 2, 3)) + as.integer(substr(t, 4, 5)) / 60
-            ) / 24
-          )
-        if (is.na(offSet)) {
-          offSet[i] <- 0
-        }
-
-        value <- as.numeric(as.POSIXct(value)) / 86400 + origin + offSet
-      }
-
-      form <- sapply(
-        seq_along(value),
-        function(i) {
-          sprintf("<formula%s>%s</formula%s>", i, value[i], i)
-        }
-      )
-
-      private$append_sheet_field(sheet, "dataValidations", xml_add_child(header, form))
-      invisible(self)
-    },
-
-    # data validations list goes to extLst not to worksheet
-    data_validation_list = function(
-      sheet = current_sheet(),
-      startRow,
-      endRow,
-      startCol,
-      endCol,
-      value,
-      allowBlank,
-      showInputMsg,
-      showErrorMsg,
-      errorStyle,
-      errorTitle,
-      error,
-      promptTitle,
-      prompt
-    ) {
-
-      # TODO consider some defaults to logicals
-      # TODO rename: setDataValidationList?
-      sheet <- private$get_sheet_index(sheet)
-      sqref <-
-        stri_join(get_cell_refs(data.frame(
-          "x" = c(startRow, endRow),
-          "y" = c(startCol, endCol)
-        )),
-          sep = " ",
-          collapse = ":"
-        )
-
-      data_val <- xml_node_create(
-        "x14:dataValidation",
-        xml_attributes = c(
-          type = "list",
-          allowBlank = allowBlank,
-          showInputMessage = showInputMsg,
-          showErrorMessage = showErrorMsg,
-          errorStyle = errorStyle,
-          errorTitle = errorTitle,
-          error = error,
-          promptTitle = promptTitle,
-          prompt = prompt
-        )
-      )
-
-      formula <- sprintf("<x14:formula1><xm:f>%s</xm:f></x14:formula1>", value)
-      sqref <- sprintf("<xm:sqref>%s</xm:sqref>", sqref)
-      xmlData <- xml_add_child(data_val, c(formula, sqref))
-      self$worksheets[[sheet]]$.__enclos_env__$private$do_append_x14(xmlData, "x14:dataValidation", "x14:dataValidations")
 
       invisible(self)
     },

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5434,7 +5434,7 @@ wbWorkbook <- R6::R6Class(
       formula <- sprintf("<x14:formula1><xm:f>%s</xm:f></x14:formula1>", value)
       sqref <- sprintf("<xm:sqref>%s</xm:sqref>", sqref)
       xmlData <- xml_add_child(data_val, c(formula, sqref))
-      self$worksheets[[sheet]]$.__enclos_env__$private$add_data_validation_lst(xmlData)
+      self$worksheets[[sheet]]$.__enclos_env__$private$do_append_x14(xmlData, "x14:dataValidation", "x14:dataValidations")
 
       invisible(self)
     },

--- a/man/get_date_origin.Rd
+++ b/man/get_date_origin.Rd
@@ -4,10 +4,12 @@
 \alias{get_date_origin}
 \title{Get the date origin an xlsx file is using}
 \usage{
-get_date_origin(xlsxFile)
+get_date_origin(xlsxFile, origin = FALSE)
 }
 \arguments{
-\item{xlsxFile}{An xlsx or xlsm file.}
+\item{xlsxFile}{An xlsx or xlsm file or a wbWorkbook object.}
+
+\item{origin}{return the origin instead of the character string.}
 }
 \value{
 One of "1900-01-01" or "1904-01-01".
@@ -30,6 +32,8 @@ m <- read_xlsx("get_date_originExample.xlsx")
 do <- get_date_origin(system.file("extdata", "readTest.xlsx", package = "openxlsx2"))
 convert_date(m[[1]], do)
 }
+get_date_origin(wb_workbook())
+get_date_origin(wb_workbook(), origin = TRUE)
 }
 \seealso{
 \code{\link[=convert_date]{convert_date()}}

--- a/man/wbWorksheet.Rd
+++ b/man/wbWorksheet.Rd
@@ -37,8 +37,6 @@ A Worksheet
 
 \item{\code{dataValidations}}{dataValidations}
 
-\item{\code{dataValidationsLst}}{dataValidationsLst}
-
 \item{\code{freezePane}}{freezePane}
 
 \item{\code{hyperlinks}}{hyperlinks}

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -148,7 +148,7 @@ test_that("data validation", {
   exp <- c(
     "<x14:dataValidation type=\"list\" allowBlank=\"1\" showInputMessage=\"1\" showErrorMessage=\"1\"><x14:formula1><xm:f>'Sheet 4'!$A$1:$A$10</xm:f></x14:formula1><xm:sqref>A2:A31</xm:sqref></x14:dataValidation>"
   )
-  got <- wb$worksheets[[3]]$dataValidationsLst
+  got <- xml_node(wb$worksheets[[3]]$extLst, "ext", "x14:dataValidations", "x14:dataValidation")
   expect_equal(exp, got)
 
   wb$save(temp)
@@ -169,22 +169,20 @@ test_that("data validation", {
     wb2$worksheets[[2]]$dataValidations
   )
 
-  # FIXME gh #277
-  # when saving, dataValidationsLst is moved to ext. Upon loading it is not
-  # moved to dataValidationsLst but remains in extLst. Hence we need to check
-  # if creating another entry in dataValidationsLst and saving again properly
-  # merges or creates broken xlsx output. Preferably the list is not silently
-  # moved from one entry to another, but remains at a single spot. E.g. load it,
-  # move the node around and remove the node in the extLst.
-  #
-  # # this will be broken. Has one extLst, but two "<ext xmlns:x14 ...>" entries.
-  # wb2$add_data_validation("Sheet 3", col = 2, rows = 2:31, type = "list",
-  #                         value = "'Sheet 4'!$A$1:$A$10")
-  # wb2$save(temp)
   expect_equal(
-    wb$worksheets[[3]]$dataValidationsLst,
+    xml_node(wb$worksheets[[3]]$extLst, "ext", "x14:dataValidations", "x14:dataValidation"),
     xml_node(wb2$worksheets[[3]]$extLst, "ext", "x14:dataValidations", "x14:dataValidation")
   )
+
+  wb2$add_data_validation("Sheet 3", col = 2, rows = 2:31, type = "list",
+                          value = "'Sheet 4'!$A$1:$A$10")
+
+  exp <- c(
+    "<x14:dataValidation type=\"list\" allowBlank=\"1\" showInputMessage=\"1\" showErrorMessage=\"1\"><x14:formula1><xm:f>'Sheet 4'!$A$1:$A$10</xm:f></x14:formula1><xm:sqref>A2:A31</xm:sqref></x14:dataValidation>",
+    "<x14:dataValidation type=\"list\" allowBlank=\"1\" showInputMessage=\"1\" showErrorMessage=\"1\"><x14:formula1><xm:f>'Sheet 4'!$A$1:$A$10</xm:f></x14:formula1><xm:sqref>B2:B31</xm:sqref></x14:dataValidation>"
+  )
+  got <- xml_node(wb2$worksheets[[3]]$extLst, "ext", "x14:dataValidations", "x14:dataValidation")
+  expect_equal(exp, got)
 
   ### tests if conditions
 

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -195,7 +195,7 @@ test_that("add_sparklines", {
 
   expect_error(
     wb$add_sparklines(sparklines = xml_node_create("sparklines", sparklines)),
-    "sparklines nodes must all be 'x14:sparklineGroup'"
+    "all nodes must match x14:sparklineGroup. Got sparklines"
   )
 
 })


### PR DESCRIPTION
Certain data validation is an x14 extension. Previously, it was added to dataValdiationLst and moved to extLst when saving. When loading, it remained in extLst. This caused problems when a second dataValidationsLst entry was added. Now, dataValidationsLst is skipped completely. Instead, we write directly to extLst using the approach used with sparklines.