### PR TITLE
Improve drawings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 ## Internal changes
 
+* Implement loading of user defined chartShapes. Previously this was not implemented instead the previous logic assumed that every sheet has a matching drawing. With chartShapes this no longer is true. The number of drawings and the number of worksheets/chartsheets must not match. [323](https://github.com/JanMarvin/openxlsx2/pull/323)
+
 * When loading files with charts, they are now imported into the `wbWorkbook` object. Previously they were simply copied. This will allow easier interaction with charts in the future. [304](https://github.com/JanMarvin/openxlsx2/pull/304)
 
 * Moving the data validation code from the workbook to the worksheet. Also, `data_validation_list()` is no longer stored in `dataValidationLst`. It has been moved to `extLst`, fixing a bug when saving and adding another data validation list. The code for retrieving the date origin from a workbook has been improved and `get_date_origin(wb, origin = TRUE)` now returns the origin as an integer from a `wbWorkbook`. [299](https://github.com/JanMarvin/openxlsx2/pull/299)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5287,31 +5287,40 @@ wbWorkbook <- R6::R6Class(
 
       }
 
-      ## write worksheets
+      ## write drawings
 
-      # TODO just seq_along()
-      nSheets <- length(self$worksheets)
+      nDrawings <- length(self$drawings)
 
-      for (i in seq_len(nSheets)) {
+      for (i in seq_len(nDrawings)) {
+
         ## Write drawing i (will always exist) skip those that are empty
-        if (!identical(self$drawings[[i]], list())) {
+        if (!all(self$drawings[[i]] == "")) {
           write_file(
             head = '',
             body = pxml(self$drawings[[i]]),
             tail = '',
             fl = file.path(xldrawingsDir, stri_join("drawing", i, ".xml"))
           )
-          if (!identical(self$drawings_rels[[i]], list())) {
+          if (!all(self$drawings_rels[[i]] == "")) {
             write_file(
-              head = '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
+              head = '',
               body = pxml(self$drawings_rels[[i]]),
-              tail = "</Relationships>",
+              tail = '',
               fl = file.path(xldrawingsRelsDir, stri_join("drawing", i, ".xml.rels"))
             )
           }
         } else {
           self$worksheets[[i]]$drawing <- character()
         }
+        
+      }
+
+      ## write worksheets
+
+      # TODO just seq_along()
+      nSheets <- length(self$worksheets)
+
+      for (i in seq_len(nSheets)) {
 
         ## vml drawing
         if (length(self$vml_rels[[i]])) {

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1420,14 +1420,6 @@ wbWorkbook <- R6::R6Class(
         ct <- ct[!grepl("sharedStrings", ct)]
       }
 
-      for (draw in seq_along(self$drawings)) {
-          if (length(self$drawings[[draw]])) {
-              ct <- c(ct,
-                sprintf('<Override PartName="/xl/drawings/drawing%s.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>', draw)
-              )
-          }
-      }
-
       if (nComments > 0) {
         ct <- c(
           ct,
@@ -5309,6 +5301,16 @@ wbWorkbook <- R6::R6Class(
               fl = file.path(xldrawingsRelsDir, stri_join("drawing", i, ".xml.rels"))
             )
           }
+
+          drawing_type <- xml_node_name(self$drawings[[i]])
+          if (drawing_type == "xdr:wsDr") {
+            ct_drawing <- sprintf('<Override PartName="/xl/drawings/drawing%s.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>', i)
+          } else if (drawing_type == "c:userShapes") {
+            ct_drawing <- sprintf('<Override PartName="/xl/drawings/drawing%s.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chartshapes+xml"/>', i)
+          }
+          
+          ct <- c(ct, ct_drawing)
+
         } else {
           self$worksheets[[i]]$drawing <- character()
         }

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5303,9 +5303,9 @@ wbWorkbook <- R6::R6Class(
           )
           if (!all(self$drawings_rels[[i]] == "")) {
             write_file(
-              head = '',
+              head = '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
               body = pxml(self$drawings_rels[[i]]),
-              tail = '',
+              tail = '</Relationships>',
               fl = file.path(xldrawingsRelsDir, stri_join("drawing", i, ".xml.rels"))
             )
           }

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -211,7 +211,7 @@ wbWorksheet <- R6::R6Class(
       self$headerFooter          <- hf
       self$rowBreaks             <- character()
       self$colBreaks             <- character()
-      self$drawing               <- '<drawing r:id=\"rId1\"/>' ## will always be 1
+      self$drawing               <- character()
       self$legacyDrawing         <- character()
       self$legacyDrawingHF       <- character()
       self$oleObjects            <- character()

--- a/R/utils.R
+++ b/R/utils.R
@@ -227,3 +227,22 @@ get_relship_id <- function(obj, x) {
   relship <- relship[relship$typ == x,]
   unname(unlist(relship[c("Id")]))
 }
+
+#' filename_id returns an integer vector with the file name as name
+#' @param x vector of filenames
+#' @noRd
+filename_id <- function(x) {
+  vapply(X = x,
+         FUN = function(file) as.integer(gsub("\\D+", "", basename(file))),
+         FUN.VALUE = NA_integer_)
+}
+
+#' filename_id returns an integer vector with the file name as name
+#' @param x vector of file names
+#' @noRd
+read_xml_files <- function(x) {
+  vapply(X = x,
+         FUN = read_xml,
+         pointer = FALSE,
+         FUN.VALUE = NA_character_)
+}

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -876,9 +876,10 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
 
       drawing$drawing[drw_dr]  <- read_xml_files(drawing$drawing[drw_dr])
       drawing$rels[drw_rl]     <- read_xml_files(drawing$rels[drw_rl])
-      
+
       # get Relationship and return a list
       drawing$rels[drw_rl] <- lapply(drawing$rels[drw_rl], function(x) xml_node(x, "Relationships", "Relationship"))
+      if (length(drawing$rels) == 0) drawing$rels <- list()
 
       wb$drawings      <- as.list(drawing$drawing)
       wb$drawings_rels <- drawing$rels

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -876,9 +876,12 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
 
       drawing$drawing[drw_dr]  <- read_xml_files(drawing$drawing[drw_dr])
       drawing$rels[drw_rl]     <- read_xml_files(drawing$rels[drw_rl])
+      
+      # get Relationship and return a list
+      drawing$rels[drw_rl] <- lapply(drawing$rels[drw_rl], function(x) xml_node(x, "Relationships", "Relationship"))
 
       wb$drawings      <- as.list(drawing$drawing)
-      wb$drawings_rels <- as.list(drawing$rels)
+      wb$drawings_rels <- drawing$rels
 
     }
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -177,4 +177,8 @@ test_that("reading charts", {
   got <- wb$drawings_rels[[20]]
   expect_equal(exp, got)
 
+
+  wb$add_worksheet()
+  wb$save(temp)
+
 })


### PR DESCRIPTION
Implement user defined chartShapes. Previously this was not implemented instead the previous logic assumed that every sheet has a matching drawing, whereas we can have these user defined chartShapes drawing files that are numerated just like every other sheet.

```R
fl <- "https://github.com/JanMarvin/openxlsx-data/raw/main/unemployment-nrw202208.xlsx"
wb_load(fl)$open()
```

This should be added with #311, otherwise we might end up with broken references, if we add workbooks after a chartShape that is unaware of the drawings issue.

Cloning is possible and adding images is possible too

```R
wb <- wb_load(fl)
img <- system.file("extdata", "einstein.jpg", package = "openxlsx2")
wb$add_image("Uebersicht_Quoten", img, startRow = 5, startCol = 3, width = 6, height = 5)
wb$clone_worksheet("Uebersicht_Quoten", "Clone1")
```

Currently it is not possible to clone sheets with chartShapes. It looks like they are not reusable, so we would have to get the chart id, get the drawings id from the chart rels file and clone the drawing and add the cloned drawing to our new chart ids relationship.
I dont think that I'll fix this, at least not in this pull request.
