### PR TITLE
add USE_SYSTEM_PUGIXML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .RData
 .DS_Store
 .vscode/*
+configure.log
+src/Makevars
 src/*.o
 src/*.so
 src/*.dll

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,6 +48,11 @@ options(repos = c(
 install.packages('openxlsx2')
 ```
 
+### Use system pugixml on Linux and Mac
+When installing from source you can use 
+`Sys.setenv(USE_SYSTEM_PUGIXML = 1)` to build `openxlsx2` against a local
+pugixml installation.
+
 ## Introduction
 
 `openxlsx2` aims to be the swiss knife for working with the openxml spreadsheet formats xlsx and xlsm (other formats of other spreadsheet software are not supported). We offer two different variants how to work with `openxlsx2`.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ options(repos = c(
 install.packages('openxlsx2')
 ```
 
+## Use system pugixml on Linux and Mac
+
+If the system variable `USE_SYSTEM_PUGIXML` is set, `openxlsx2`
+will build against a local pugixml installation.
+`Sys.setenv(USE_SYSTEM_PUGIXML = 1)`
+
 ## Introduction
 
 `openxlsx2` aims to be the swiss knife for working with the openxml
@@ -51,30 +57,29 @@ spreadsheet formats xlsx and xlsm (other formats of other spreadsheet
 software are not supported). We offer two different variants how to work
 with `openxlsx2`.
 
--   The first one is to simply work with R objects. It is possible to
-    read
-    ([`read_xlsx()`](https://janmarvin.github.io/openxlsx2/reference/read_xlsx.html))
-    and write
-    ([`write_xlsx()`](https://janmarvin.github.io/openxlsx2/reference/write_xlsx.html))
-    data from and to files. We offer a number of options in the commands
-    to support various features of the openxml format, including reading
-    and writing named ranges and tables. Furthermore, there are several
-    ways to read certain information of an openxml spreadsheet without
-    having opened it in a spreadsheet software before, e.g. to get the
-    contained sheet names or tables.
--   As a second variant `openxlsx2` offers the work with so called
-    [`wbWorkbook`](https://janmarvin.github.io/openxlsx2/reference/wbWorkbook.html)
-    objects. Here an openxml file is read into a corresponding
-    `wbWorkbook` object
-    ([`wb_load()`](https://janmarvin.github.io/openxlsx2/reference/wb_load.html))
-    or a new one is created
-    ([`wb_workbook()`](https://janmarvin.github.io/openxlsx2/reference/wb_workbook.html)).
-    Afterwards the object can be further modified using various
-    functions. For example, worksheets can be added or removed, the
-    layout of cells or entire worksheets can be changed, and cells can
-    be modified (overwritten or rewritten). Afterwards the `wbWorkbook`
-    objects can be written as openxml files and processed by suitable
-    spreadsheet software.
+- The first one is to simply work with R objects. It is possible to read
+  ([`read_xlsx()`](https://janmarvin.github.io/openxlsx2/reference/read_xlsx.html))
+  and write
+  ([`write_xlsx()`](https://janmarvin.github.io/openxlsx2/reference/write_xlsx.html))
+  data from and to files. We offer a number of options in the commands
+  to support various features of the openxml format, including reading
+  and writing named ranges and tables. Furthermore, there are several
+  ways to read certain information of an openxml spreadsheet without
+  having opened it in a spreadsheet software before, e.g. to get the
+  contained sheet names or tables.
+- As a second variant `openxlsx2` offers the work with so called
+  [`wbWorkbook`](https://janmarvin.github.io/openxlsx2/reference/wbWorkbook.html)
+  objects. Here an openxml file is read into a corresponding
+  `wbWorkbook` object
+  ([`wb_load()`](https://janmarvin.github.io/openxlsx2/reference/wb_load.html))
+  or a new one is created
+  ([`wb_workbook()`](https://janmarvin.github.io/openxlsx2/reference/wb_workbook.html)).
+  Afterwards the object can be further modified using various functions.
+  For example, worksheets can be added or removed, the layout of cells
+  or entire worksheets can be changed, and cells can be modified
+  (overwritten or rewritten). Afterwards the `wbWorkbook` objects can be
+  written as openxml files and processed by suitable spreadsheet
+  software.
 
 Many examples how to work with `openxlsx2` are in our [manual
 pages](https://janmarvin.github.io/openxlsx2/reference/index.html) and

--- a/configure
+++ b/configure
@@ -1,0 +1,76 @@
+# Anticonf (tm) script by Jeroen Ooms (2021)
+# Package requires pugixml. If system pugixml is found this is used,
+# unless the included pugixml is requested.
+# If your pugixml is installed in a custom location you need to set
+# INCLUDE_DIR and LIB_DIR manually via e.g:
+# R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+PKG_DEB_NAME="libpugixml-dev"
+PKG_RPM_NAME="pugixml-devel"
+PKG_BREW_NAME="pugixml"
+PKG_TEST_HEADER="\"pugixml.hpp\""
+PKG_LIBS="-lpugixml"
+PKG_CFLAGS="-I/usr/include"
+LIB_DIR="/usr/lib"
+
+UNAME=`uname`
+
+# Test common production platforms
+if [ "$UNAME" = "Darwin" ]; then
+  IS_MACOS=1
+fi
+
+# Find compiler
+CXX14=`${R_HOME}/bin/R CMD config CXX14` || unset CXX14
+CXX="$CXX14 `${R_HOME}/bin/R CMD config CXX14STD`"
+CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+LDFLAGS=`${R_HOME}/bin/R CMD config LDFLAGS`
+CXXCPP="$CXX -E"
+
+# Check for custom locations
+if [ "$USE_SYSTEM_PUGIXML" -eq "1" ]; then
+  echo "Found INCLUDE_DIR and/or LIB_DIR!"
+  PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
+  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
+  if [ "$IS_MACOS" ]; then
+    if [ `command -v brew` ]; then
+      BREWDIR=`brew --prefix`
+      PUGIXML_HOME="$BREWDIR/opt/$PKG_BREW_NAME"
+      PKG_CFLAGS="-I${PUGIXML_HOME}/include -I${PUGIXML_HOME}/libexec/include"
+      PKG_LIBS="-L${PUGIXML_HOME}/libexec $PKG_LIBS"
+    fi
+  fi
+  
+  # Test for libpugixml
+  echo "#include $PKG_TEST_HEADER" | ${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXXFLAGS} -xc++ - >/dev/null 2>configure.log
+  if [ $? -ne 0 ]; then
+    echo "-----------------------------[ ANTICONF ]-------------------------------"
+    echo "Configuration failed to find pugixml. Try installing:"
+    echo " * deb: $PKG_DEB_NAME (Debian / Ubuntu)"
+    echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
+    echo " * brew: $PKG_BREW_NAME (OSX)"
+    echo "Alternatively, you can set environment variable:"
+    echo "    USE_SYSTEM_PUGIXML=0"
+    echo "to use the included version of pugixml in openxlsx2. This should"
+    echo "already have been selected as fallback, but somehow did not work."
+    echo "To use a custom pugixml, set INCLUDE_DIR and LIB_DIR manually via:"
+    echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
+    echo "---------------------------[ ERROR MESSAGE ]----------------------------"
+    cat configure.log
+    echo "------------------------------------------------------------------------"
+    exit 1
+    
+  fi
+else
+  LIB_DIR=""
+  PKG_LIBS="-I."
+  PKG_CFLAGS="-I../inst/include/pugixml"
+fi
+
+# For debugging
+echo "Using PKG_CFLAGS=$PKG_CFLAGS"
+echo "Using PKG_LIBS=$PKG_LIBS"
+
+
+# Update Makevars
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars
+exit 0

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,0 @@
-PKG_CPPFLAGS = -I. -I../inst/include/pugixml

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,0 +1,7 @@
+PKG_CPPFLAGS=@cflags@
+PKG_LIBS=@libs@
+
+all: clean
+
+clean:
+	rm -f $(OBJECTS) $(SHLIB)


### PR DESCRIPTION
## What does it do?
On Linux and Mac (and possible other nix systems), this allows building against a system pugixml. The same would be possible on Windows (if we would know the path to a pugixml installation).

## What is the benefit?
Shared libs might be tweaked by distributions or it departments, updated faster (or slower, anyhow the update process is independent of the package), and using them reduces the filesize and build time of our package.

## What is the downside?

* The impact on our `openxlsx2.so` lib is negligible. It decreases ~38 KiB if build with system pugixml. I did not measure build time, but I didn't feel any change.
* We would have to maintain the configure script. I've tested this with Arch, tests with other Linux installations, Mac and possible other stranger OSes are a burden I'm not necessarily willing to take.
* Over time we would be forced to maintain various pugixml versions. Certain linux distributions such as Red Hat or Debian usually ship old or at least older versions of packages.

## Therefore

I call this a prove of concept. The impact on Windows might be bigger, but I do not really care that much.