### PR TITLE
change default col size to 10

### DIFF
--- a/R/baseXML.R
+++ b/R/baseXML.R
@@ -236,7 +236,7 @@ genBaseStyleSheet <- function(dxfs = NULL, tableStyles = NULL, extLst = NULL) {
   list(
     numFmts = NULL,
 
-    fonts = c('<font><sz val="11"/><color rgb="FF000000"/><name val="Calibri"/><family val="2"/><scheme val="minor"/></font>'),
+    fonts = c('<font><sz val="12"/><color theme="1"/><name val="Calibri"/><family val="2"/><scheme val="minor"/></font>'),
 
     fills = c(
       '<fill><patternFill patternType="none"/></fill>',

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -593,7 +593,7 @@ wb_set_row_heights <- function(wb, sheet = current_sheet(), rows, heights) {
 #' @param sheet A name or index of a worksheet
 #' @param cols Indices of cols to set width
 #' @param widths width to set cols to specified in Excel column width units or "auto" for automatic sizing. The widths argument is
-#' recycled to the length of cols. The default width is 8.43. Though there is no specific default width for Excel, it depends on
+#' recycled to the length of cols. The default width is 10. Though there is no specific default width for Excel, it depends on
 #' Excel version, operating system and DPI settings used. Setting it to specific value also is no guarantee that the output will be
 #' of the selected width.
 #' @param hidden Logical vector. If TRUE the column is hidden.
@@ -632,7 +632,7 @@ wb_set_row_heights <- function(wb, sheet = current_sheet(), rows, heights) {
 #' wb_save(wb, "wb_set_col_widthsExample.xlsx", overwrite = TRUE)
 #' }
 #'
-wb_set_col_widths <- function(wb, sheet = current_sheet(), cols, widths = 8.43, hidden = FALSE) {
+wb_set_col_widths <- function(wb, sheet = current_sheet(), cols, widths = 10, hidden = FALSE) {
   assert_workbook(wb)
   wb$clone()$set_col_widths(
     sheet  = sheet,
@@ -825,7 +825,7 @@ wb_remove_worksheet <- function(wb, sheet = current_sheet()) {
 #' \dontrun{
 #' wb_save(wb, "wb_set_base_font_example.xlsx", overwrite = TRUE)
 #' }
-wb_set_base_font <- function(wb, fontSize = 11, fontColour = "black", fontName = "Calibri") {
+wb_set_base_font <- function(wb, fontSize = 12, fontColour = wb_colour(theme = "1"), fontName = "Calibri") {
   assert_workbook(wb)
   wb$clone()$set_base_font(
     fontSize   = fontSize,

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1878,16 +1878,10 @@ wbWorkbook <- R6::R6Class(
     #' @param fontColour fontColour
     #' @param fontName fontName
     #' @return The `wbWorkbook` object
-    set_base_font = function(fontSize = 11, fontColour = "black", fontName = "Calibri") {
+    set_base_font = function(fontSize = 12, fontColour = wb_colour(theme = "1"), fontName = "Calibri") {
       if (fontSize < 0) stop("Invalid fontSize")
-      fontColour <- validateColour(fontColour)
-
-      self$styles_mgr$styles$fonts[[1]] <- sprintf(
-        '<font><sz val="%s"/><color rgb="%s"/><name val="%s"/></font>',
-        fontSize,
-        fontColour,
-        fontName
-      )
+      if (is.character(fontColour) && is.null(names(fontColour))) fontColour <- wb_colour(fontColour)
+      self$styles_mgr$styles$fonts[[1]] <- create_font(sz = as.character(fontSize), color = fontColour, name = fontName)
     },
 
     ### sheet names ----
@@ -2200,7 +2194,7 @@ wbWorkbook <- R6::R6Class(
     #' @param hidden A logical vector to determine which cols are hidden; values
     #'   are repeated across length of `cols`
     #' @return The `wbWorkbook` object, invisibly
-    set_col_widths = function(sheet = current_sheet(), cols, widths = 8.43, hidden = FALSE) {
+    set_col_widths = function(sheet = current_sheet(), cols, widths = 10, hidden = FALSE) {
       sheet <- private$get_sheet_index(sheet)
 
       # should do nothing if the cols' length is zero
@@ -2238,6 +2232,7 @@ wbWorkbook <- R6::R6Class(
       cols <- cols[ok]
 
       col_df <- self$worksheets[[sheet]]$unfold_cols()
+      base_font <- wb_get_base_font(self)
 
       if (any(widths == "auto")) {
 
@@ -2250,25 +2245,9 @@ wbWorkbook <- R6::R6Class(
 
         # https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.column
 
-        # TODO save this instead as internal package data for quicker loading
-        fw <- system.file("extdata", "fontwidth/FontWidth.csv", package = "openxlsx2")
-        font_width_tab <- read.csv(fw)
-
-        # TODO base font might not be the font used in this column
-        base_font <- wb_get_base_font(self)
-        font <- base_font$name$val
-        size <- as.integer(base_font$size$val)
-
-        sel <- font_width_tab$FontFamilyName == font & font_width_tab$FontSize == size
-        # maximum digit width of selected font
-        mdw <- font_width_tab$Width[sel]
-
-        # formula from openxml.spreadsheet.column documentation. The formula returns exactly the expected
-        # value, but the output in excel is still off. Therefore round to create even numbers. In my tests
-        # the results were close to the initial col_width sizes. Character width is still bad, numbers are
-        # way larger, therefore characters cells are to wide. Not sure if we need improve this.
-        widths <- trunc((col_width * mdw + 5) / mdw * 256) / 256
-        widths <- round(widths)
+        widths <- calc_col_width(base_font = base_font, col_width = col_width)
+      } else {
+        widths <- calc_col_width(base_font = base_font, col_width = widths)
       }
 
       # create empty cols

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -199,7 +199,7 @@ wbWorksheet <- R6::R6Class(
       self$sheetPr               <- tabColour
       self$dimension             <- '<dimension ref="A1"/>'
       self$sheetViews            <- sprintf('<sheetViews><sheetView workbookViewId="0" zoomScale="%s" showGridLines="%s" showRowColHeaders="%s" tabSelected="%s"/></sheetViews>', as.integer(zoom), as.integer(gridLines), as.integer(rowColHeaders), as.integer(tabSelected))
-      self$sheetFormatPr         <- '<sheetFormatPr defaultRowHeight="15.0"/>'
+      self$sheetFormatPr         <- '<sheetFormatPr baseColWidth="10" defaultRowHeight="16" x14ac:dyDescent="0.2"/>'
       self$cols_attr             <- character()
       self$autoFilter            <- character()
       self$mergeCells            <- character()
@@ -751,7 +751,7 @@ empty_cols_attr <- function(n = 0, beg, end) {
   if (n > 0) {
     z$min <- n_seq
     z$max <- n_seq
-    z$width <- "8.43" # default width in ms365
+    z$width <- "11.375" # default width in MS365 Desktop for Mac
   }
 
   z

--- a/R/converters.R
+++ b/R/converters.R
@@ -61,3 +61,40 @@ get_cell_refs <- function(cellCoords) {
   l <- int2col(unlist(cellCoords[, 2]))
   paste0(l, cellCoords[, 1])
 }
+
+
+
+#' calculate the required column width
+#'
+#' @param base_font the base font name and fontsize
+#' @param col_width column width
+#' @keywords internal
+#' @examples
+#' base_font <- wb_get_base_font(wb)
+#' calc_col_width(base_font, col_width = 10)
+#' @noRd
+calc_col_width <- function(base_font, col_width) {
+
+  # TODO save this instead as internal package data for quicker loading
+  fw <- system.file("extdata", "fontwidth/FontWidth.csv", package = "openxlsx2")
+  font_width_tab <- read.csv(fw)
+
+  # TODO base font might not be the font used in this column
+  font <- base_font$name$val
+  size <- as.integer(base_font$size$val)
+
+  sel <- font_width_tab$FontFamilyName == font & font_width_tab$FontSize == size
+  # maximum digit width of selected font
+  mdw <- font_width_tab$Width[sel]
+
+  # formula from openxml.spreadsheet.column documentation. The formula returns exactly the expected
+  # value, but the output in excel is still off. Therefore round to create even numbers. In my tests
+  # the results were close to the initial col_width sizes. Character width is still bad, numbers are
+  # way larger, therefore characters cells are to wide. Not sure if we need improve this.
+
+  # Note: cannot reproduce the exact values with MS365 on Mac. Nevertheless, these values are closer
+  # to the expected widths
+  widths <- trunc((as.numeric(col_width) * mdw + 5 + 2) / mdw * 256) / 256
+  widths <- round(widths, 3)
+  widths
+}

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -287,7 +287,7 @@ write_xlsx <- function(x, file, asTable = FALSE, ...) {
   colWidths <- NULL
   if ("colWidths" %in% names(params)) {
     colWidths <- params$colWidths
-    if (any(is.na(colWidths))) colWidths[is.na(colWidths)] <- 8.43
+    if (any(is.na(colWidths))) colWidths[is.na(colWidths)] <- 11.375
   }
 
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -821,8 +821,8 @@ A list of of the font
 Get the base font
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$set_base_font(
-  fontSize = 11,
-  fontColour = "black",
+  fontSize = 12,
+  fontColour = wb_colour(theme = "1"),
   fontName = "Calibri"
 )}\if{html}{\out{</div>}}
 }
@@ -1047,7 +1047,7 @@ Group cols
 \if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$set_col_widths(
   sheet = current_sheet(),
   cols,
-  widths = 8.43,
+  widths = 10,
   hidden = FALSE
 )}\if{html}{\out{</div>}}
 }

--- a/man/wb_modify_basefont.Rd
+++ b/man/wb_modify_basefont.Rd
@@ -5,7 +5,12 @@
 \alias{wb_set_base_font}
 \title{Modify the default font}
 \usage{
-wb_set_base_font(wb, fontSize = 11, fontColour = "black", fontName = "Calibri")
+wb_set_base_font(
+  wb,
+  fontSize = 12,
+  fontColour = wb_colour(theme = "1"),
+  fontName = "Calibri"
+)
 }
 \arguments{
 \item{wb}{A workbook object}

--- a/man/wb_set_col_widths.Rd
+++ b/man/wb_set_col_widths.Rd
@@ -8,7 +8,7 @@ wb_set_col_widths(
   wb,
   sheet = current_sheet(),
   cols,
-  widths = 8.43,
+  widths = 10,
   hidden = FALSE
 )
 }
@@ -20,7 +20,7 @@ wb_set_col_widths(
 \item{cols}{Indices of cols to set width}
 
 \item{widths}{width to set cols to specified in Excel column width units or "auto" for automatic sizing. The widths argument is
-recycled to the length of cols. The default width is 8.43. Though there is no specific default width for Excel, it depends on
+recycled to the length of cols. The default width is 10. Though there is no specific default width for Excel, it depends on
 Excel version, operating system and DPI settings used. Setting it to specific value also is no guarantee that the output will be
 of the selected width.}
 

--- a/tests/testthat/test-base_font.R
+++ b/tests/testthat/test-base_font.R
@@ -3,14 +3,14 @@ test_that("get_base_font works", {
   expect_equal(
     wb$get_base_font(),
     list(
-      size = list(val = "11"),
+      size = list(val = "12"),
       # should this be "#000000"?
-      colour = list(rgb = "FF000000"),
+      colour = list(theme = "1"),
       name = list(val = "Calibri")
     )
   )
 
-  wb$set_base_font( fontSize = 9, fontName = "Arial", fontColour = "red")
+  wb$set_base_font(fontSize = 9, fontName = "Arial", fontColour = wb_colour("red"))
   expect_equal(
     wb$get_base_font(),
     list(

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -13,7 +13,7 @@ test_that("wb_set_col_widths", {
   # set column width to 12
   expect_silent(wb$set_col_widths("test", widths = 12L, cols = seq_along(mtcars)))
   expect_equal(
-    "<col min=\"1\" max=\"11\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"12\"/>",
+    "<col min=\"1\" max=\"11\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"12.875\"/>",
     wb$worksheets[[1]]$cols_attr
   )
 
@@ -23,22 +23,46 @@ test_that("wb_set_col_widths", {
   # reset the column with, we do not provide an option ot remove the column entry
   expect_silent(wb$set_col_widths("test", cols = seq_along(mtcars)))
   expect_equal(
-    "<col min=\"1\" max=\"11\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"8.43\"/>",
+    "<col min=\"1\" max=\"11\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"10.875\"/>",
     wb$worksheets[[1]]$cols_attr
   )
 
   # create column width for column 25
   expect_silent(wb$set_col_widths("test", cols = "Y", widths = 22))
   expect_equal(
-    c("<col min=\"1\" max=\"11\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"8.43\"/>",
-      "<col min=\"12\" max=\"24\" width=\"8.43\"/>",
-      "<col min=\"25\" max=\"25\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"22\"/>"),
+    c("<col min=\"1\" max=\"11\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"10.875\"/>",
+      "<col min=\"12\" max=\"24\" width=\"11.375\"/>",
+      "<col min=\"25\" max=\"25\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"22.875\"/>"),
     wb$worksheets[[1]]$cols_attr
   )
 
   # a few more errors
   expect_error(wb$set_col_widths("test", cols = "Y", width = 1:2))
   expect_error(wb$set_col_widths("test", cols = "Y", hidden = 1:2))
+
+
+
+
+  wb <- wb_workbook()$
+    add_worksheet()$
+    set_col_widths(cols = 1:10, width = (8:17) + .5)$
+    add_data(x = rbind(8:17), colNames = FALSE)
+
+  exp <- c(
+    "<col min=\"1\" max=\"1\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"9.375\"/>",
+    "<col min=\"2\" max=\"2\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"10.375\"/>",
+    "<col min=\"3\" max=\"3\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"11.375\"/>",
+    "<col min=\"4\" max=\"4\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"12.375\"/>",
+    "<col min=\"5\" max=\"5\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"13.375\"/>",
+    "<col min=\"6\" max=\"6\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"14.375\"/>",
+    "<col min=\"7\" max=\"7\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"15.375\"/>",
+    "<col min=\"8\" max=\"8\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"16.375\"/>",
+    "<col min=\"9\" max=\"9\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"17.375\"/>",
+    "<col min=\"10\" max=\"10\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"18.375\"/>"
+  )
+  got <- wb$worksheets[[1]]$cols_attr
+  expect_equal(exp, got)
+
 })
 
 

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -159,8 +159,9 @@ test_that("test add_font()", {
   expect_silent(wb$add_font("S1", dims = "A1:K1", color = wb_colour(hex = "FFFFFF00")))
 
   # check xf
-  exp <- c("<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>",
-           "<xf applyFont=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"1\" numFmtId=\"0\" xfId=\"0\"/>"
+  exp <- c(
+    "<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>",
+    "<xf applyFont=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"1\" numFmtId=\"0\" xfId=\"0\"/>"
   )
   got <- wb$styles_mgr$styles$cellXfs
 
@@ -168,8 +169,9 @@ test_that("test add_font()", {
 
 
   # check font
-  exp <- c("<font><sz val=\"11\"/><color rgb=\"FF000000\"/><name val=\"Calibri\"/><family val=\"2\"/><scheme val=\"minor\"/></font>",
-           "<font><color rgb=\"FFFFFF00\"/><name val=\"Calibri\"/><sz val=\"11\"/></font>"
+  exp <- c(
+    "<font><sz val=\"12\"/><color theme=\"1\"/><name val=\"Calibri\"/><family val=\"2\"/><scheme val=\"minor\"/></font>",
+    "<font><color rgb=\"FFFFFF00\"/><name val=\"Calibri\"/><sz val=\"11\"/></font>"
   )
   got <- wb$styles_mgr$styles$fonts
 


### PR DESCRIPTION
This adjusts a few functions to use default column width of 10 and default font size 12. This is what MS365 uses on Mac. It is changed, because otherwise column widths were slightly off. 9. something instead of 10. Adjusted to this new values, all calculations are correct for Calibri. Yet, I would not bet that our calculations are valid for all versions. Previously we were using 8.43 and font size 11 as default. Which might be correct for the MS365 webbrowser edition or certain Windows low dpi versions.

Maybe you can check the following on Windows @jmbarbone ? On Mac the column width is exactly 8.5 ... 17.5.
```R
  wb <- wb_workbook()$
    add_worksheet()$
    set_col_widths(cols = 1:10, width = (8:17) + .5)$
    add_data(x = rbind(8:17), colNames = FALSE)$
    open()
```