### PR TITLE
update create_dxfs_style

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openxlsx2
 Title: Read, Write and Edit 'xlsx' Files
-Version: 0.3
+Version: 0.3.0.90000
 Language: en-US
 Authors@R: c(
   person("Jordan Mark", "Barbone", email = "jmbarbone@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-9788-3628")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# openxlsx2 (in development)
+
+## Breaking changes
+
+* Conditional style defaults for `create_dxfs_style()` have changed to be more permissive. Previously we shipped a default font, default font size and font color. This has been changed to better reflect a behavior the user expects. [343](https://github.com/JanMarvin/openxlsx2/issues/343)
+
+
+***************************************************************************
+
+
 # openxlsx2 0.3
 
 ## New features

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -829,7 +829,8 @@ set_cell_style <- function(wb, sheet, cell, value) {
 
 #' @name create_dxfs_style
 #' @title Create a custom formatting style
-#' @description Create a new style to apply to worksheet cells
+#' @description Create a new style to apply to worksheet cells. Created styles have to be
+#' assigned to a workbook to use them
 #' @param font_name A name of a font. Note the font name is not validated. If fontName is NULL,
 #' the workbook base font is used. (Defaults to Calibri)
 #' @param font_color Colour of text in cell.  A valid hex colour beginning with "#"
@@ -847,18 +848,37 @@ set_cell_style <- function(wb, sheet, cell, value) {
 #' @param text_italic italic
 #' @param text_underline underline 1, true, single or double
 #' @return A dxfs style node
-#' @export
+#' @seealso [wb_add_styles()]
 #' @examples
+#' # do not apply anthing
+#' style1 <- create_dxfs_style()
+#' 
+#' # change font color and background color
+#' style2 <- create_dxfs_style(
+#'   font_color = wb_colour(hex = "FF9C0006"),
+#'   bgFill = wb_colour(hex = "FFFFC7CE")
+#' )
+#' 
+#' # change font (type, size and color) and background
+#' # the old default in openxlsx and openxlsx2 <= 0.3
+#' style3 <- create_dxfs_style(
+#'   font_name = "Calibri",
+#'   font_size = 11,
+#'   font_color = wb_colour(hex = "FF9C0006"),
+#'   bgFill = wb_colour(hex = "FFFFC7CE")
+#' )
+#' 
 #' ## See package vignettes for further examples
+#' @export
 create_dxfs_style <- function(
-    font_name      = "Calibri",
-    font_size      = "11",
-    font_color     = wb_colour(hex = "FF9C0006"),
+    font_name      = NULL,
+    font_size      = NULL,
+    font_color     = NULL,
     numFmt         = NULL,
     border         = NULL,
     border_color   = wb_colour(getOption("openxlsx2.borderColour", "black")),
     border_style   = getOption("openxlsx2.borderStyle", "thin"),
-    bgFill         = wb_colour(hex = "FFFFC7CE"),
+    bgFill         = NULL,
     text_bold      = NULL,
     text_strike    = NULL,
     text_italic    = NULL,
@@ -866,6 +886,7 @@ create_dxfs_style <- function(
 ) {
 
   if (is.null(font_color)) font_color = ""
+  if (is.null(font_size)) font_size = ""
   if (is.null(text_bold)) text_bold = ""
   if (is.null(text_strike)) text_strike = ""
   if (is.null(text_italic)) text_italic = ""
@@ -874,7 +895,8 @@ create_dxfs_style <- function(
   # found numFmtId=3 in MS365 xml not sure if this should be increased
   if (!is.null(numFmt)) numFmt <- create_numfmt(3, numFmt)
 
-  font <- create_font(color = font_color, name = font_name, sz = font_size,
+  font <- create_font(color = font_color, name = font_name,
+                      sz = as.character(font_size),
                       b = text_bold, i = text_italic, strike = text_strike,
                       u = text_underline,
                       family = "", scheme = "")

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -848,7 +848,7 @@ set_cell_style <- function(wb, sheet, cell, value) {
 #' @param text_italic italic
 #' @param text_underline underline 1, true, single or double
 #' @return A dxfs style node
-#' @seealso [wb_add_styles()]
+#' @seealso [wb_add_style()]
 #' @examples
 #' # do not apply anthing
 #' style1 <- create_dxfs_style()

--- a/man/create_dxfs_style.Rd
+++ b/man/create_dxfs_style.Rd
@@ -77,5 +77,5 @@ style3 <- create_dxfs_style(
 ## See package vignettes for further examples
 }
 \seealso{
-\code{\link[=wb_add_styles]{wb_add_styles()}}
+\code{\link[=wb_add_style]{wb_add_style()}}
 }

--- a/man/create_dxfs_style.Rd
+++ b/man/create_dxfs_style.Rd
@@ -5,14 +5,14 @@
 \title{Create a custom formatting style}
 \usage{
 create_dxfs_style(
-  font_name = "Calibri",
-  font_size = "11",
-  font_color = wb_colour(hex = "FF9C0006"),
+  font_name = NULL,
+  font_size = NULL,
+  font_color = NULL,
   numFmt = NULL,
   border = NULL,
   border_color = wb_colour(getOption("openxlsx2.borderColour", "black")),
   border_style = getOption("openxlsx2.borderStyle", "thin"),
-  bgFill = wb_colour(hex = "FFFFC7CE"),
+  bgFill = NULL,
   text_bold = NULL,
   text_strike = NULL,
   text_italic = NULL,
@@ -52,8 +52,30 @@ or one of colours(). If fontColour is NULL, the workbook base font colours is us
 A dxfs style node
 }
 \description{
-Create a new style to apply to worksheet cells
+Create a new style to apply to worksheet cells. Created styles have to be
+assigned to a workbook to use them
 }
 \examples{
+# do not apply anthing
+style1 <- create_dxfs_style()
+
+# change font color and background color
+style2 <- create_dxfs_style(
+  font_color = wb_colour(hex = "FF9C0006"),
+  bgFill = wb_colour(hex = "FFFFC7CE")
+)
+
+# change font (type, size and color) and background
+# the old default in openxlsx and openxlsx2 <= 0.3
+style3 <- create_dxfs_style(
+  font_name = "Calibri",
+  font_size = 11,
+  font_color = wb_colour(hex = "FF9C0006"),
+  bgFill = wb_colour(hex = "FFFFC7CE")
+)
+
 ## See package vignettes for further examples
+}
+\seealso{
+\code{\link[=wb_add_styles]{wb_add_styles()}}
 }

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -595,24 +595,29 @@ test_that("wb_conditional_formatting", {
   expect_equal(exp, got)
 })
 
-test_that("create dxfs style without font and bg color", {
-
-  exp <- "<dxf><font><name val=\"Calibri\"/><sz val=\"11\"/></font></dxf>"
-  got <- create_dxfs_style(font_color = "", bgFill = "")
-  expect_equal(exp, got)
-
-  got <- create_dxfs_style(font_color = NULL, bgFill = NULL)
-  expect_equal(exp, got)
-
-})
-
 test_that("create dxfs style without font family and size", {
 
-  exp <- "<dxf><font><color rgb=\"FF9C0006\"/></font><fill><patternFill patternType=\"solid\"><bgColor rgb=\"FFFFC7CE\"/></patternFill></fill></dxf>"
-  got <- create_dxfs_style(font_name = "", font_size = "")
+  # a workbook with this style loads, but has no highlighting
+  exp <- "<dxf><font/></dxf>"
+  got <- create_dxfs_style()
   expect_equal(exp, got)
 
-  got <- create_dxfs_style(font_name = NULL, font_size = NULL)
+  # most likely what the user expects. change font color and background color
+  exp <- "<dxf><font><color rgb=\"FF9C0006\"/></font><fill><patternFill patternType=\"solid\"><bgColor rgb=\"FFFFC7CE\"/></patternFill></fill></dxf>"
+  got <- create_dxfs_style(
+    font_color = wb_colour(hex = "FF9C0006"),
+    bgFill = wb_colour(hex = "FFFFC7CE")
+  )
+  expect_equal(exp, got)
+
+  # the fully fletched old default dxfs style
+  exp <- "<dxf><font><color rgb=\"FF9C0006\"/><name val=\"Calibri\"/><sz val=\"11\"/></font><fill><patternFill patternType=\"solid\"><bgColor rgb=\"FFFFC7CE\"/></patternFill></fill></dxf>"
+  got <- create_dxfs_style(
+    font_name = "Calibri",
+    font_size = 11,
+    font_color = wb_colour(hex = "FF9C0006"),
+    bgFill = wb_colour(hex = "FFFFC7CE")
+  )
   expect_equal(exp, got)
 
 })

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -31,8 +31,8 @@ test_that("type = 'expression' work", {
   wb$add_worksheet("cellIs")
 
   exp <- c(
-    '<dxf><font><color rgb="FF9C0006"/><name val="Calibri"/><sz val="11"/></font><fill><patternFill patternType="solid"><bgColor rgb="FFFFC7CE"/></patternFill></fill></dxf>',
-    '<dxf><font><color rgb="FF006100"/><name val="Calibri"/><sz val="11"/></font><fill><patternFill patternType="solid"><bgColor rgb="FFC6EFCE"/></patternFill></fill></dxf>'
+    '<dxf><font><color rgb="FF9C0006"/></font><fill><patternFill patternType="solid"><bgColor rgb="FFFFC7CE"/></patternFill></fill></dxf>',
+    '<dxf><font><color rgb="FF006100"/></font><fill><patternFill patternType="solid"><bgColor rgb="FFC6EFCE"/></patternFill></fill></dxf>'
   )
 
   expect_identical(exp, wb$styles_mgr$styles$dxfs)


### PR DESCRIPTION
This PR changes the default behavior for `create_dxfs_style()`. We only create a dxfs style with style information the user requested. Previously we would ship a default font type, font size, font color and background color.

Now this
```R
create_dxfs_style(
  font_color = wb_colour(hex = "FF9C0006"),
  bgFill = wb_colour(hex = "FFFFC7CE")
)
```

creates this

```XML
<dxf>
  <font>
    <color rgb=\"FF9C0006\"/>
  </font>
  <fill>
    <patternFill patternType=\"solid\">
      <bgColor rgb=\"FFFFC7CE\"/>
    </patternFill>
  </fill>
</dxf>
```