### PR TITLE
[wb_load] xml cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## Fixes
 
+* Fix loading and writing files with slicers. Loading would add a few empty slicer xml files to `Content_Types` and `workbook.xml.rels`. [361](https://github.com/JanMarvin/openxlsx2/issues/361)
+
 * Align the logic for writing data to empty worksheets and updating/writing to worksheets with data. This removes `update_cell_loop()` and changes how `update_cell()` behaves. Not only does this remove duplicated code, it also brings great speed improvements (issue [356](https://github.com/JanMarvin/openxlsx2/issues/356)). [356](https://github.com/JanMarvin/openxlsx2/issues/356)
 
 * It is now possible to use special characters in formulas without coding. Previously `&` had to be encoded like `&amp;` [251](https://github.com/JanMarvin/openxlsx2/issues/251)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## Fixes
 
+* Fix cloning pivot charts. [361](https://github.com/JanMarvin/openxlsx2/issues/361)
+
 * Fix loading and writing files with slicers. Loading would add a few empty slicer xml files to `Content_Types` and `workbook.xml.rels`. [361](https://github.com/JanMarvin/openxlsx2/issues/361)
 
 * Align the logic for writing data to empty worksheets and updating/writing to worksheets with data. This removes `update_cell_loop()` and changes how `update_cell()` behaves. Not only does this remove duplicated code, it also brings great speed improvements (issue [356](https://github.com/JanMarvin/openxlsx2/issues/356)). [356](https://github.com/JanMarvin/openxlsx2/issues/356)

--- a/R/baseXML.R
+++ b/R/baseXML.R
@@ -1,4 +1,4 @@
-
+# functions to create basic xml lists
 
 genBaseContent_Type <- function() {
   c(
@@ -12,7 +12,6 @@ genBaseContent_Type <- function() {
     '<Override PartName="/xl/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>'
   )
 }
-
 
 genBaseShapeVML <- function(clientData, id) {
   if (grepl("visible", clientData, ignore.case = TRUE)) {
@@ -34,10 +33,6 @@ genBaseShapeVML <- function(clientData, id) {
   )
 }
 
-
-
-
-
 genClientData <- function(col, row, visible, height, width) {
   txt <- sprintf(
     '<x:ClientData ObjectType="Note"><x:MoveWithCells/><x:SizeWithCells/><x:Anchor>%s, 15, %s, 10, %s, 147, %s, 18</x:Anchor><x:AutoFill>False</x:AutoFill><x:Row>%s</x:Row><x:Column>%s</x:Column>',
@@ -52,21 +47,6 @@ genClientData <- function(col, row, visible, height, width) {
 
   return(txt)
 }
-
-
-# genBaseRels <- function() {
-#
-#   '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
-#    <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
-#    <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>'
-#
-# }
-#
-#
-# genBaseApp <- function() {
-#   list('<Application>Microsoft Excel</Application>')
-# }
-
 
 genBaseCore <- function(creator = "", title = NULL, subject = NULL, category = NULL) {
   core <- '<coreProperties xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
@@ -92,85 +72,6 @@ genBaseCore <- function(creator = "", title = NULL, subject = NULL, category = N
   return(core)
 }
 
-#
-# addAuthor <- function(wb,Author = NULL) {
-#
-#   if (!is.null(Author)) {
-#     current_creator <-
-#       stri_match(wb$core, regex = "<dc:creator>(.*?)</dc:creator>")[1, 2]
-#     wb$core <-
-#       stri_replace_all_fixed(
-#         wb$core,
-#         pattern = current_creator,
-#         replacement = stri_c(current_creator, Author, sep = ";")
-#       )
-#   }
-#
-#
-# }
-#
-#
-# setAuthor <- function(wb,Author = NULL) {
-#
-#   if (!is.null(Author)) {
-#     current_creator <-
-#       stri_match(wb$core, regex = "<dc:creator>(.*?)</dc:creator>")[1, 2]
-#     wb$core <-
-#       stri_replace_all_fixed(
-#         wb$core,
-#         pattern = current_creator,
-#         replacement =  Author
-#       )
-#   }
-#
-#
-# }
-#
-# wb_set_last_modified_by <- function(wb,ModifiedBy=NULL) {
-#
-#   if (!is.null(addmodifier)) {
-#     current_lastmodifier <-
-#       stri_match(wb$core, regex = "<cp:lastModifiedBy>(.*?)</cp:lastModifiedBy>")[1, 2]
-#     wb$core <-
-#       stri_replace_all_fixed(
-#         wb$core,
-#         pattern = current_lastmodifier,
-#         replacement = ModifiedBy
-#       )
-#   }
-#
-#
-# }
-#
-#
-
-#
-#
-# setBaseCore <- function(core,setcreator="",setmodifier="",
-#                         title = NULL, subject = NULL, category = NULL) {
-#
-#
-#   core <- c(core, sprintf('<dc:creator>%s</dc:creator>', setcreator))
-#   core <- c(core, sprintf('<dcterms:created xsi:type="dcterms:W3CDTF">%s</dcterms:created>', format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ")))
-#
-#   if (!is.null(title))
-#     core <- c(core, sprintf('<dc:title>%s</dc:title>', replace_legal_chars(title)))
-#
-#   if (!is.null(subject))
-#     core <- c(core, sprintf('<dc:subject>%s</dc:subject>', replace_legal_chars(subject)))
-#
-#   if (!is.null(category))
-#     core <- c(core, sprintf('<cp:category>%s</cp:category>', replace_legal_chars(category)))
-#
-#   core <- c(core, '</coreProperties>')
-#
-#   return(core)
-#
-# }
-
-
-
-
 genBaseWorkbook.xml.rels <- function() {
   c(
     '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>',
@@ -178,7 +79,6 @@ genBaseWorkbook.xml.rels <- function() {
     '<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>'
   )
 }
-
 
 genBaseWorkbook <- function() {
 
@@ -261,7 +161,6 @@ genBaseStyleSheet <- function(dxfs = NULL, tableStyles = NULL, extLst = NULL) {
   )
 }
 
-
 genBasePic <- function(imageNo) {
   sprintf('<xdr:pic>
       <xdr:nvPicPr>
@@ -284,15 +183,6 @@ genBasePic <- function(imageNo) {
       </xdr:spPr>
     </xdr:pic>', imageNo, imageNo, imageNo)
 }
-
-
-
-
-
-
-
-
-
 
 genBaseTheme <- function() {
   stringi::stri_unescape_unicode(
@@ -609,33 +499,6 @@ gen_databar_extlst <- function(guid, sqref, posColour, negColour, values, border
 
   return(xml)
 }
-
-
-
-contentTypePivotXML <- function(i) {
-  c(
-    sprintf('<Override PartName="/xl/pivotCache/pivotCacheDefinition%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/>', i),
-    sprintf('<Override PartName="/xl/pivotCache/pivotCacheRecords%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml"/>', i),
-    sprintf('<Override PartName="/xl/pivotTables/pivotTable%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"/>', i)
-  )
-}
-
-contentTypeSlicerCacheXML <- function(i) {
-  c(
-    sprintf('<Override PartName="/xl/slicerCaches/slicerCache%s.xml" ContentType="application/vnd.ms-excel.slicerCache+xml"/>', i),
-    sprintf('<Override PartName="/xl/slicers/slicer%s.xml" ContentType="application/vnd.ms-excel.slicer+xml"/>', i)
-  )
-}
-
-
-genBaseSlicerXML <- function() {
-  '<ext uri="{A8765BA9-456A-4dab-B4F3-ACF838C121DE}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
-    <x14:slicerList>
-    <x14:slicer r:id="rId0"/>
-      </x14:slicerList>
-      </ext>'
-}
-
 
 genSlicerCachesExtLst <- function(i) {
   paste0(

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -656,23 +656,23 @@ wbWorkbook <- R6::R6Class(
                 new_sheet_name <- guard_ws(new)
 
                 ## we need to replace "'oldname'" as well as "oldname"
-                if (grepl("'", old_sheet_name)) {
-                  chart <- gsub(
-                    stri_join("(?<=')", old_sheet_name, "(?='!)"),
-                    stri_join(new_sheet_name),
-                    chart,
-                    perl = TRUE
-                  )
-                } else {
-                  chart <- gsub(
-                    stri_join("(?<=[^A-Za-z0-9])", old_sheet_name, "(?=!)"),
-                    stri_join(new_sheet_name),
-                    chart,
-                    perl = TRUE
-                  )
-                }
+                chart <- gsub(
+                  old_sheet_name,
+                  new_sheet_name,
+                  chart,
+                  perl = TRUE
+                )
 
                 self$charts$chart[chartid] <- chart
+
+                # two charts can not point to the same rels
+                if (self$charts$rels[chartid] != "") {
+                  self$charts$rels[chartid] <- gsub(
+                    stri_join(old_chart, ".xml"),
+                    stri_join(chartid, ".xml"),
+                    self$charts$rels[chartid]
+                  )
+                }
 
                 rl <- gsub(stri_join("(?<=charts/)", cf), newname, rl, perl = TRUE)
               }

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -759,8 +759,8 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
       wb$slicerCaches <- vapply(slicerCachesXML, read_xml, pointer = FALSE,
                                 FUN.VALUE = NA_character_, USE.NAMES = FALSE)
 
-      wb$Content_Types <- c(wb$Content_Types, sprintf('<Override PartName="/xl/slicerCaches/slicerCache%s.xml" ContentType="application/vnd.ms-excel.slicerCache+xml"/>', inds))
-      wb$workbook.xml.rels <- c(wb$workbook.xml.rels, sprintf('<Relationship Id="rId%s" Type="http://schemas.microsoft.com/office/2007/relationships/slicerCache" Target="slicerCaches/slicerCache%s.xml"/>', 1E5 + inds, inds))
+      wb$Content_Types <- c(wb$Content_Types, sprintf('<Override PartName="/xl/slicerCaches/slicerCache%s.xml" ContentType="application/vnd.ms-excel.slicerCache+xml"/>', inds[inds > 0]))
+      wb$workbook.xml.rels <- c(wb$workbook.xml.rels, sprintf('<Relationship Id="rId%s" Type="http://schemas.microsoft.com/office/2007/relationships/slicerCache" Target="slicerCaches/slicerCache%s.xml"/>', 1E5 + inds[inds > 0], inds[inds > 0]))
 
       # get extLst object. select the slicerCaches and replace it
       ext_nams <- xml_node_name(wb$workbook$extLst, "extLst", "ext")

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -299,3 +299,24 @@ test_that("Sheet not found", {
   )
 
 })
+
+test_that("loading slicers works", {
+
+  wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
+
+  exp <- c(
+    "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\" Target=\"sharedStrings.xml\"/>",
+    "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>",
+    "<Relationship Id=\"rId4\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme\" Target=\"theme/theme1.xml\"/>",
+    "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>",
+    "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet2.xml\"/>",
+    "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet3.xml\"/>",
+    "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet4.xml\"/>",
+    "<Relationship Id=\"rId20001\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition\" Target=\"pivotCache/pivotCacheDefinition1.xml\"/>",
+    "<Relationship Id=\"rId20002\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition\" Target=\"pivotCache/pivotCacheDefinition2.xml\"/>",
+    "<Relationship Id=\"rId100001\" Type=\"http://schemas.microsoft.com/office/2007/relationships/slicerCache\" Target=\"slicerCaches/slicerCache1.xml\"/>"
+  )
+  got <- wb$workbook.xml.rels
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
* cleanup of baseXML
* fix opening workbooks with slicer
* fix cloning pivot charts

Unfortunately I didn't check loading sheets with and without slicers or I misinterpreted the errors I saw when cloning slicers. 

```R
# clone sheet with pivotTable (and drop slicer)
wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))$
  clone_worksheet(old = "irisSample", new = "clone 1")$
  open()
```