### PR TITLE
Add data and add style

### DIFF
--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -87,6 +87,7 @@ wb_save <- function(wb, path = NULL, overwrite = TRUE) {
 #' @param withFilter If `TRUE`, add filters to the column name row. NOTE can only have one filter per worksheet.
 #' @param name If not NULL, a named region is defined.
 #' @param sep Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).
+#' @param applyCellStyle Should we write cell styles to the workbook
 #' @param removeCellStyle keep the cell style?
 #' @param na.strings na.strings
 #' @export
@@ -110,6 +111,7 @@ wb_add_data <- function(
     withFilter      = FALSE,
     name            = NULL,
     sep             = ", ",
+    applyCellStyle  = TRUE,
     removeCellStyle = FALSE,
     na.strings
 ) {
@@ -130,6 +132,7 @@ wb_add_data <- function(
     withFilter      = withFilter,
     name            = name,
     sep             = sep,
+    applyCellStyle  = applyCellStyle,
     removeCellStyle = removeCellStyle,
     na.strings      = na.strings
   )
@@ -166,6 +169,8 @@ wb_add_data <- function(
 #' @param lastColumn logical. If TRUE, the last column is bold
 #' @param bandedRows logical. If TRUE, rows are colour banded
 #' @param bandedCols logical. If TRUE, the columns are colour banded
+#' @param applyCellStyle Should we write cell styles to the workbook
+#' @param removeCellStyle keep the cell style?
 #' @param na.strings optional
 #'
 #' @details columns of x with class Date/POSIXt, currency, accounting,
@@ -193,6 +198,8 @@ wb_add_data_table <- function(
     lastColumn  = FALSE,
     bandedRows  = TRUE,
     bandedCols  = FALSE,
+    applyCellStyle  = TRUE,
+    removeCellStyle = FALSE,
     na.strings
 ) {
   assert_workbook(wb)
@@ -215,6 +222,8 @@ wb_add_data_table <- function(
     lastColumn  = lastColumn,
     bandedRows  = bandedRows,
     bandedCols  = bandedCols,
+    applyCellStyle  = applyCellStyle,
+    removeCellStyle = removeCellStyle,
     na.strings  = na.strings
   )
 }
@@ -243,6 +252,8 @@ wb_add_data_table <- function(
 #' @param xy An alternative to specifying `startCol` and
 #' `startRow` individually.  A vector of the form
 #' `c(startCol, startRow)`.
+#' @param applyCellStyle Should we write cell styles to the workbook
+#' @param removeCellStyle keep the cell style?
 #' @family workbook wrappers
 #' @export
 wb_add_formula <- function(
@@ -253,7 +264,9 @@ wb_add_formula <- function(
     startRow = 1,
     dims     = rowcol_to_dims(startRow, startCol),
     array    = FALSE,
-    xy       = NULL
+    xy       = NULL,
+    applyCellStyle  = TRUE,
+    removeCellStyle = FALSE
 ) {
   assert_workbook(wb)
   wb$clone()$add_formula(
@@ -263,7 +276,9 @@ wb_add_formula <- function(
     startRow = startRow,
     dims     = dims,
     array    = array,
-    xy       = xy
+    xy       = xy,
+    applyCellStyle  = applyCellStyle,
+    removeCellStyle = removeCellStyle
   )
 }
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5036,7 +5036,7 @@ wbWorkbook <- R6::R6Class(
     #' @return The `wbWorksheetObject`, invisibly
     set_cell_style = function(sheet = current_sheet(), dims, style) {
 
-      if (length(dims) == 1 && grepl(":", dims))
+      if (length(dims) == 1 && grepl(":|;", dims))
         dims <- dims_to_dataframe(dims, fill = TRUE)
       sheet <- private$get_sheet_index(sheet)
 
@@ -5996,7 +5996,7 @@ wbWorkbook <- R6::R6Class(
     do_cell_init = function(sheet = current_sheet(), dims) {
 
       sheet <- private$get_sheet_index(sheet)
-      if (length(dims) == 1 && grepl(":", dims))
+      if (length(dims) == 1 && grepl(":|;", dims))
         dims <- dims_to_dataframe(dims, fill = TRUE)
 
       exp_cells <- unname(unlist(dims))
@@ -6004,12 +6004,18 @@ wbWorkbook <- R6::R6Class(
 
       # initialize cell
       if (!all(exp_cells %in% got_cells)) {
+
         init_cells <- NA
-        for (exp_cell in exp_cells[!exp_cells %in% got_cells])
-        # TODO use dims once PR#236 is merged
-        self$add_data(x = init_cells, na.strings = NULL, colNames = FALSE,
-                      startCol = col2int(exp_cell),
-                      startRow = as.numeric(gsub("\\D", "", exp_cell)))
+        missing_cells <- exp_cells[!exp_cells %in% got_cells]
+
+        for (exp_cell in missing_cells) {
+          self$add_data(
+            x = init_cells,
+            na.strings = NULL,
+            colNames = FALSE,
+            dims = exp_cell
+          )
+        }
       }
 
       invisible(self)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -925,6 +925,7 @@ wbWorkbook <- R6::R6Class(
     #' @param withFilter withFilter
     #' @param name name
     #' @param sep sep
+    #' @param applyCellStyle applyCellStyle
     #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
     #' @param na.strings na.strings
     #' @param return The `wbWorkbook` object
@@ -941,6 +942,7 @@ wbWorkbook <- R6::R6Class(
         withFilter      = FALSE,
         name            = NULL,
         sep             = ", ",
+        applyCellStyle  = TRUE,
         removeCellStyle = FALSE,
         na.strings
       ) {
@@ -984,6 +986,8 @@ wbWorkbook <- R6::R6Class(
     #' @param lastColumn lastColumn
     #' @param bandedRows bandedRows
     #' @param bandedCols bandedCols
+    #' @param applyCellStyle applyCellStyle
+    #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
     #' @param na.strings na.strings
     #' @returns The `wbWorkbook` object
     add_data_table = function(
@@ -1003,6 +1007,8 @@ wbWorkbook <- R6::R6Class(
         lastColumn  = FALSE,
         bandedRows  = TRUE,
         bandedCols  = FALSE,
+        applyCellStyle = TRUE,
+        removeCellStyle = FALSE,
         na.strings
     ) {
 
@@ -1026,6 +1032,8 @@ wbWorkbook <- R6::R6Class(
         lastColumn  = lastColumn,
         bandedRows  = bandedRows,
         bandedCols  = bandedCols,
+        applyCellStyle = applyCellStyle,
+        removeCellStyle = removeCellStyle,
         na.strings  = na.strings
       )
       invisible(self)
@@ -1039,6 +1047,8 @@ wbWorkbook <- R6::R6Class(
     #' @param dims dims
     #' @param array array
     #' @param xy xy
+    #' @param applyCellStyle applyCellStyle
+    #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
     #' @returns The `wbWorkbook` object
     add_formula = function(
         sheet    = current_sheet(),
@@ -1047,7 +1057,9 @@ wbWorkbook <- R6::R6Class(
         startRow = 1,
         dims     = rowcol_to_dims(startRow, startCol),
         array    = FALSE,
-        xy       = NULL
+        xy       = NULL,
+        applyCellStyle = TRUE,
+        removeCellStyle = FALSE
     ) {
       write_formula(
         wb       = self,
@@ -1057,7 +1069,9 @@ wbWorkbook <- R6::R6Class(
         startRow = startRow,
         dims     = dims,
         array    = array,
-        xy       = xy
+        xy       = xy,
+        applyCellStyle = applyCellStyle,
+        removeCellStyle = removeCellStyle
       )
       invisible(self)
     },

--- a/R/utils.R
+++ b/R/utils.R
@@ -158,31 +158,43 @@ random_string <- function(n = 1, length = 16, pattern = "[A-Za-z0-9]", keep_seed
 #' @param as_integer optional if the output should be returned as interger
 #' @noRd
 dims_to_rowcol <- function(x, as_integer = FALSE) {
-  dimensions <- unlist(strsplit(x, ":"))
-  cols <- gsub("[[:digit:]]","", dimensions)
-  rows <- gsub("[[:upper:]]","", dimensions)
 
-  # if "A:B"
-  if (any(rows == "")) rows[rows == ""] <- "1"
+  dims <- x
+  if (length(x) == 1 && grepl(";", x))
+    dims <- unlist(strsplit(x, ";"))
 
-  # convert cols to integer
-  cols_int <- col2int(cols)
-  rows_int <- as.integer(rows)
+  cols_out <- NULL
+  rows_out <- NULL
+  for (dim in dims) {
+    dimensions <- unlist(strsplit(dim, ":"))
+    cols <- gsub("[[:digit:]]","", dimensions)
+    rows <- gsub("[[:upper:]]","", dimensions)
 
-  if (length(dimensions) == 2) {
-    # needs integer to create sequence
-    cols <- int2col(seq.int(min(cols_int), max(cols_int)))
-    rows_int <- seq.int(min(rows_int), max(rows_int))
+    # if "A:B"
+    if (any(rows == "")) rows[rows == ""] <- "1"
+
+    # convert cols to integer
+    cols_int <- col2int(cols)
+    rows_int <- as.integer(rows)
+
+    if (length(dimensions) == 2) {
+      # needs integer to create sequence
+      cols <- int2col(seq.int(min(cols_int), max(cols_int)))
+      rows_int <- seq.int(min(rows_int), max(rows_int))
+    }
+
+    if (as_integer) {
+      cols <- cols_int
+      rows <- rows_int
+    } else {
+      rows <- as.character(rows_int)
+    }
+
+    cols_out <- unique(c(cols_out, cols))
+    rows_out <- unique(c(rows_out, rows))
   }
 
-  if (as_integer) {
-    cols <- cols_int
-    rows <- rows_int
-  } else {
-    rows <- as.character(rows_int)
-  }
-
-  list(cols, rows)
+  list(cols_out, rows_out)
 }
 
 #' row and col to dims

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -8,28 +8,41 @@
 #' @export
 dims_to_dataframe <- function(dims, fill = FALSE) {
 
-  if (!grepl(":", dims)) {
-    dims <- paste0(dims, ":", dims)
+  if (grepl(";", dims)) {
+    dims <- unlist(strsplit(dims, ";"))
   }
 
-  if (identical(dims, "Inf:-Inf")) {
-    # This should probably be fixed elsewhere?
-    stop("dims are inf:-inf")
-  } else {
-    dimensions <- strsplit(dims, ":")[[1]]
+  rows_out <- NULL
+  cols_out <- NULL
+  for(dim in dims) {
 
-    rows <- as.numeric(gsub("[[:upper:]]","", dimensions))
-    rows <- seq.int(rows[1], rows[2])
+    if (!grepl(":", dim)) {
+      dim <- paste0(dim, ":", dim)
+    }
 
-    # TODO seq.wb_columns?  make a wb_cols vector?
-    cols <- gsub("[[:digit:]]","", dimensions)
-    cols <- int2col(seq.int(col2int(cols[1]), col2int(cols[2])))
+    if (identical(dim, "Inf:-Inf")) {
+      # This should probably be fixed elsewhere?
+      stop("dims are inf:-inf")
+    } else {
+      dimensions <- strsplit(dim, ":")[[1]]
+
+      rows <- as.numeric(gsub("[[:upper:]]","", dimensions))
+      rows <- seq.int(rows[1], rows[2])
+
+      rows_out <- unique(c(rows_out, rows))
+
+      # TODO seq.wb_columns?  make a wb_cols vector?
+      cols <- gsub("[[:digit:]]","", dimensions)
+      cols <- int2col(seq.int(col2int(cols[1]), col2int(cols[2])))
+
+      cols_out <- unique(c(cols_out, cols))
+    }
   }
 
   # create data frame from rows/
   dims_to_df(
-    rows = rows,
-    cols = cols,
+    rows = rows_out,
+    cols = cols_out,
     fill = fill
   )
 }

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -773,7 +773,9 @@ get_cell_styles <- function(wb, sheet, cell) {
     out
   },
   NA_integer_)
-  wb$styles_mgr$styles$cellXfs[id + 1]
+  out <- wb$styles_mgr$styles$cellXfs[id + 1]
+  if (is.na(out)) out <- ""
+  out
 }
 
 
@@ -852,13 +854,13 @@ set_cell_style <- function(wb, sheet, cell, value) {
 #' @examples
 #' # do not apply anthing
 #' style1 <- create_dxfs_style()
-#' 
+#'
 #' # change font color and background color
 #' style2 <- create_dxfs_style(
 #'   font_color = wb_colour(hex = "FF9C0006"),
 #'   bgFill = wb_colour(hex = "FFFFC7CE")
 #' )
-#' 
+#'
 #' # change font (type, size and color) and background
 #' # the old default in openxlsx and openxlsx2 <= 0.3
 #' style3 <- create_dxfs_style(
@@ -867,7 +869,7 @@ set_cell_style <- function(wb, sheet, cell, value) {
 #'   font_color = wb_colour(hex = "FF9C0006"),
 #'   bgFill = wb_colour(hex = "FFFFC7CE")
 #' )
-#' 
+#'
 #' ## See package vignettes for further examples
 #' @export
 create_dxfs_style <- function(

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -773,8 +773,10 @@ get_cell_styles <- function(wb, sheet, cell) {
     out
   },
   NA_integer_)
+
   out <- wb$styles_mgr$styles$cellXfs[id + 1]
-  if (is.na(out)) out <- ""
+  if (!all(identical(out, character())) && any(is.na(out))) 
+    out[is.na(out)] <- ""
   out
 }
 

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -769,11 +769,11 @@ get_cell_styles <- function(wb, sheet, cell) {
   z <- wb$get_cell_style(sheet, cell)
   id <- vapply(z, function(x) {
     out <- which(wb$styles_mgr$get_xf()$id %in% x)
-    if (identical(out,integer())) out <- 1L
+    if (identical(out,integer())) out <- 0L
     out
   },
   NA_integer_)
-  wb$styles_mgr$styles$cellXfs[id]
+  wb$styles_mgr$styles$cellXfs[id + 1]
 }
 
 

--- a/R/write.R
+++ b/R/write.R
@@ -93,7 +93,7 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
   }
 
   replacement <- c("r", cell_style, "c_t", "c_cm", "c_ph", "c_vm", "v",
-                   "f", "f_t", "f_ref", "f_ca", "f_si","is")
+                   "f", "f_t", "f_ref", "f_ca", "f_si", "is")
 
   sel <- match(x$r, cc$r)
   cc[sel, replacement] <- x[replacement]
@@ -324,144 +324,6 @@ write_data2 <- function(wb, sheet, data, name = NULL,
     cc[is_inf, "c_t"] <- "e"
   }
 
-  ### Begin styles
-  style_cc <- is.null(wb$worksheets[[sheetno]]$sheet_data$cc) || removeCellStyle
-
-  if (style_cc) {
-
-    ## create a cell style format for specific types at the end of the existing
-    # styles. gets the reference an passes it on.
-    short_date_fmt <- long_date_fmt <- accounting_fmt <- percentage_fmt <-
-      comma_fmt <- scientific_fmt <- NULL
-
-    hash_id          <- round(as.numeric(Sys.time()), digits = 3)
-    numeric_fmtid    <- paste0("numeric_fmt", hash_id)
-    short_date_fmtid <- paste0("short_date_fmt", hash_id)
-    long_date_fmtid  <- paste0("long_date_fmt", hash_id)
-    accounting_fmtid <- paste0("accounting_fmt", hash_id)
-    percentage_fmtid <- paste0("percentage_fmt", hash_id)
-    scientific_fmtid <- paste0("scientific_fmt", hash_id)
-    comma_fmtid      <- paste0("comma_fmt", hash_id)
-
-    # if hyperlinks are found, Excel sets something like the following font
-    # blue with underline
-    if (any(dc == openxlsx2_celltype[["hyperlink"]])) {
-      if (!length(wb$styles_mgr$get_font_id("hyperlinkfont"))) {
-        hyperlinkfont <- create_font(
-          color = wb_colour(hex = "FF0000FF"),
-          name = wb_get_base_font(wb)$name$val,
-          u = "single")
-
-        wb$styles_mgr$add(hyperlinkfont, "hyperlinkfont")
-
-        hyperlink_xf <- create_cell_style(fontId = wb$styles_mgr$get_font_id("hyperlinkfont"))
-        wb$styles_mgr$add(hyperlink_xf, "hyperlinkstyle")
-      }
-    }
-
-    # options("openxlsx2.numFmt" = NULL)
-    if (any(dc == openxlsx2_celltype[["numeric"]])) { # numeric or integer
-      if (!is.null(unlist(options("openxlsx2.numFmt")))) {
-        cust_numFmt <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.numFmt")))
-        wb$styles_mgr$add(cust_numFmt, numeric_fmtid)
-        numfmt_num <- wb$styles_mgr$get_numfmt_id(numeric_fmtid)
-        numeric_fmt <- write_xf(nmfmt_df(numfmt_num))
-        wb$styles_mgr$add(numeric_fmt, numeric_fmtid)
-      }
-    }
-    if (any(dc == openxlsx2_celltype[["short_date"]])) { # Date
-      if (is.null(unlist(options("openxlsx2.dateFormat")))) {
-        numfmt_dt <- 14
-      } else {
-        cust_dateFormat <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.dateFormat")))
-        wb$styles_mgr$add(cust_dateFormat, short_date_fmtid)
-        numfmt_dt <- wb$styles_mgr$get_numfmt_id(short_date_fmtid)
-      }
-      short_date_fmt <- write_xf(nmfmt_df(numfmt_dt))
-      wb$styles_mgr$add(short_date_fmt, short_date_fmtid)
-    }
-    if (any(dc == openxlsx2_celltype[["long_date"]])) {
-      if (is.null(unlist(options("openxlsx2.datetimeFormat")))) {
-        numfmt_posix <- 22
-      } else {
-        cust_datetimeFormat <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.datetimeFormat")))
-        wb$styles_mgr$add(cust_datetimeFormat, long_date_fmtid)
-        numfmt_posix <- wb$styles_mgr$get_numfmt_id(long_date_fmtid)
-      }
-      long_date_fmt  <- write_xf(nmfmt_df(numfmt_posix))
-      wb$styles_mgr$add(long_date_fmt, long_date_fmtid)
-    }
-    if (any(dc == openxlsx2_celltype[["accounting"]])) { # accounting
-      if (is.null(unlist(options("openxlsx2.accountingFormat")))) {
-        numfmt_accounting <- 4
-      } else {
-        cust_accountingFormat <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.accountingFormat")))
-        wb$styles_mgr$add(cust_accountingFormat, accounting_fmtid)
-        numfmt_accounting <- wb$styles_mgr$get_numfmt_id(accounting_fmtid)
-      }
-      accounting_fmt <- write_xf(nmfmt_df(numfmt_accounting))
-      wb$styles_mgr$add(accounting_fmt, accounting_fmtid)
-    }
-    if (any(dc == openxlsx2_celltype[["percentage"]])) { # percentage
-      if (is.null(unlist(options("openxlsx2.percentageFormat")))) {
-        numfmt_percentage <- 10
-      } else {
-        cust_percentageFormat <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.percentageFormat")))
-        wb$styles_mgr$add(cust_percentageFormat, percentage_fmtid)
-        numfmt_percentage <- wb$styles_mgr$get_numfmt_id(percentage_fmtid)
-      }
-      percentage_fmt <- write_xf(nmfmt_df(numfmt_percentage))
-      wb$styles_mgr$add(percentage_fmt, percentage_fmtid)
-    }
-    if (any(dc == openxlsx2_celltype[["scientific"]])) {
-      if (is.null(unlist(options("openxlsx2.scientificFormat")))) {
-        numfmt_scientific <- 48
-      } else {
-        cust_scientificFormat <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.scientificFormat")))
-        wb$styles_mgr$add(cust_scientificFormat, scientific_fmtid)
-        numfmt_scientific <- wb$styles_mgr$get_numfmt_id(scientific_fmtid)
-      }
-      scientific_fmt <- write_xf(nmfmt_df(numfmt_scientific))
-      wb$styles_mgr$add(scientific_fmt, scientific_fmtid)
-    }
-    if (any(dc == openxlsx2_celltype[["comma"]])) {
-      if (is.null(unlist(options("openxlsx2.comma")))) {
-        numfmt_comma <- 3
-      } else {
-        cust_scientificFormat <- create_numfmt(
-          numFmtId = wb$styles_mgr$next_numfmt_id(),
-          formatCode = unlist(options("openxlsx2.commaFormat")))
-        wb$styles_mgr$add(cust_scientificFormat, comma_fmtid)
-        numfmt_comma <- wb$styles_mgr$get_numfmt_id(comma_fmtid)
-      }
-      comma_fmt <- write_xf(nmfmt_df(numfmt_comma))
-      wb$styles_mgr$add(comma_fmt, comma_fmtid)
-    }
-
-    cc$c_s[cc$typ == "0"]  <- wb$styles_mgr$get_xf_id(short_date_fmtid)
-    cc$c_s[cc$typ == "1"]  <- wb$styles_mgr$get_xf_id(long_date_fmtid)
-    if (length(wb$styles_mgr$get_xf_id(numeric_fmtid)) == 1) {
-      cc$c_s[cc$typ == "2"]  <- wb$styles_mgr$get_xf_id(numeric_fmtid)
-    }
-    cc$c_s[cc$typ == "6"]  <- wb$styles_mgr$get_xf_id(accounting_fmtid)
-    cc$c_s[cc$typ == "7"]  <- wb$styles_mgr$get_xf_id(percentage_fmtid)
-    cc$c_s[cc$typ == "8"]  <- wb$styles_mgr$get_xf_id(scientific_fmtid)
-    cc$c_s[cc$typ == "9"]  <- wb$styles_mgr$get_xf_id(comma_fmtid)
-    cc$c_s[cc$typ == "10"] <- wb$styles_mgr$get_xf_id("hyperlinkstyle")
-  }
-
   if (is.null(wb$worksheets[[sheetno]]$sheet_data$cc)) {
 
     wb$worksheets[[sheetno]]$dimension <- paste0("<dimension ref=\"", dims, "\"/>")
@@ -473,6 +335,7 @@ write_data2 <- function(wb, sheet, data, name = NULL,
   } else {
     # update cell(s)
     # message("update_cell()")
+  
     wb <- update_cell(
       x = cc,
       wb =  wb,
@@ -483,6 +346,164 @@ write_data2 <- function(wb, sheet, data, name = NULL,
       na.strings = na.strings
     )
   }
+
+  ### Begin styles
+  # TODO: could be optional if styles should be applied or not
+  style_cc <- TRUE
+
+  if (style_cc) {
+
+    ## create a cell style format for specific types at the end of the existing
+    # styles. gets the reference an passes it on.
+    get_data_class_dims <- function(data_class) {
+      sel <- dc == openxlsx2_celltype[[data_class]]
+      sel_cols <- names(rtyp[sel == TRUE])
+      sel_rows <- rownames(rtyp)
+
+      # # ignore first row if colNames
+      # if (colNames) sel_rows <- sel_rows[-1]
+
+      paste(
+        unname(
+          unlist(
+            rtyp[rownames(rtyp) %in% sel_rows, sel_cols, drop = FALSE]
+          )
+        ),
+        collapse = ";"
+      )
+    }
+
+    # if hyperlinks are found, Excel sets something like the following font
+    # blue with underline
+    if (any(dc == openxlsx2_celltype[["hyperlink"]])) {
+
+      dim_sel <- get_data_class_dims("hyperlink")
+      # message("hyperlink: ", dim_sel)
+
+      wb$add_font(
+          sheet = sheetno,
+          dim = dim_sel,
+          color = wb_colour(hex = "FF0000FF"),
+          name = wb_get_base_font(wb)$name$val,
+          u = "single"
+      )
+    }
+
+    # options("openxlsx2.numFmt" = NULL)
+    if (any(dc == openxlsx2_celltype[["numeric"]])) { # numeric or integer
+      if (!is.null(unlist(options("openxlsx2.numFmt")))) {
+
+        numfmt_numeric <- unlist(options("openxlsx2.numFmt"))
+
+        dim_sel <- get_data_class_dims("numeric")
+        # message("numeric: ", dim_sel)
+
+        wb$add_numfmt(
+          sheet = sheetno,
+          dim = dim_sel,
+          numfmt = numfmt_numeric
+        )
+      }
+    }
+    if (any(dc == openxlsx2_celltype[["short_date"]])) { # Date
+      if (is.null(unlist(options("openxlsx2.dateFormat")))) {
+        numfmt_dt <- 14
+      } else {
+        numfmt_dt <- unlist(options("openxlsx2.dateFormat"))
+      }
+
+      dim_sel <- get_data_class_dims("short_date")
+      # message("short_date: ", dim_sel)
+
+      wb$add_numfmt(
+        sheet = sheetno,
+        dim = dim_sel,
+        numfmt = numfmt_dt
+      )
+    }
+    if (any(dc == openxlsx2_celltype[["long_date"]])) {
+      if (is.null(unlist(options("openxlsx2.datetimeFormat")))) {
+        numfmt_posix <- 22
+      } else {
+        numfmt_posix <- unlist(options("openxlsx2.datetimeFormat"))
+      }
+
+      dim_sel <- get_data_class_dims("long_date")
+      # message("long_date: ", dim_sel)
+
+      wb$add_numfmt(
+        sheet = sheetno,
+        dim = dim_sel,
+        numfmt = numfmt_posix
+      )
+    }
+    if (any(dc == openxlsx2_celltype[["accounting"]])) { # accounting
+      if (is.null(unlist(options("openxlsx2.accountingFormat")))) {
+        numfmt_accounting <- 4
+      } else {
+        numfmt_accounting <- unlist(options("openxlsx2.accountingFormat"))
+      }
+
+      dim_sel <- get_data_class_dims("accounting")
+      # message("accounting: ", dim_sel)
+
+      wb$add_numfmt(
+        sheet = sheetno,
+        
+      sheet = sheetno,dim = dim_sel,
+        numfmt = numfmt_accounting
+      )
+    }
+    if (any(dc == openxlsx2_celltype[["percentage"]])) { # percentage
+      if (is.null(unlist(options("openxlsx2.percentageFormat")))) {
+        numfmt_percentage <- 10
+      } else {
+        numfmt_percentage <- unlist(options("openxlsx2.percentageFormat"))
+      }
+
+      dim_sel <- get_data_class_dims("percentage")
+      # message("percentage: ", dim_sel)
+
+      wb$add_numfmt(
+        sheet = sheetno,
+        dim = dim_sel,
+        numfmt = numfmt_percentage
+      )
+    }
+    if (any(dc == openxlsx2_celltype[["scientific"]])) {
+      if (is.null(unlist(options("openxlsx2.scientificFormat")))) {
+        numfmt_scientific <- 48
+      } else {
+        numfmt_scientific <- unlist(options("openxlsx2.scientificFormat"))
+      }
+
+      dim_sel <- get_data_class_dims("scientific")
+      # message("scientific: ", dim_sel)
+
+      wb$add_numfmt(
+        sheet = sheetno,
+        dim = dim_sel,
+        numfmt = numfmt_scientific
+      )
+    }
+    if (any(dc == openxlsx2_celltype[["comma"]])) {
+      if (is.null(unlist(options("openxlsx2.comma")))) {
+        numfmt_comma <- 3
+      } else {
+        numfmt_comma <- unlist(options("openxlsx2.commaFormat"))
+      }
+
+      dim_sel <- get_data_class_dims("comma")
+      # message("comma: ", dim_sel)
+
+      wb$add_numfmt(
+        sheet = sheetno,
+        dim = dim_sel,
+        numfmt = numfmt_comma
+      )
+    }
+  }
+  ### End styles
 
   return(wb)
 }

--- a/R/write.R
+++ b/R/write.R
@@ -131,6 +131,7 @@ nmfmt_df <- function(x) {
 #' @param rowNames include rownames?
 #' @param startRow row to place it
 #' @param startCol col to place it
+#' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle keep the cell style?
 #' @param na.strings optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
 #' @details
@@ -154,11 +155,19 @@ nmfmt_df <- function(x) {
 #' write_data2(wb, "sheet4", as.data.frame(Titanic), startRow = 2, startCol = 2)
 #'
 #' @export
-write_data2 <- function(wb, sheet, data, name = NULL,
-                        colNames = TRUE, rowNames = FALSE,
-                        startRow = 1, startCol = 1,
-                        removeCellStyle = FALSE,
-                        na.strings) {
+write_data2 <- function(
+    wb,
+    sheet,
+    data,
+    name = NULL,
+    colNames = TRUE,
+    rowNames = FALSE,
+    startRow = 1,
+    startCol = 1,
+    applyCellStyle = TRUE,
+    removeCellStyle = FALSE,
+    na.strings
+  ) {
 
   if (missing(na.strings)) na.strings <- substitute()
 
@@ -335,7 +344,7 @@ write_data2 <- function(wb, sheet, data, name = NULL,
   } else {
     # update cell(s)
     # message("update_cell()")
-  
+
     wb <- update_cell(
       x = cc,
       wb =  wb,
@@ -348,10 +357,8 @@ write_data2 <- function(wb, sheet, data, name = NULL,
   }
 
   ### Begin styles
-  # TODO: could be optional if styles should be applied or not
-  style_cc <- TRUE
 
-  if (style_cc) {
+  if (applyCellStyle) {
 
     ## create a cell style format for specific types at the end of the existing
     # styles. gets the reference an passes it on.
@@ -532,6 +539,7 @@ write_data2 <- function(wb, sheet, data, name = NULL,
 #' @param bandedCols logical. If TRUE, the columns are colour banded
 #' @param bandedCols logical. If TRUE, a data table is created
 #' @param name If not NULL, a named region is defined.
+#' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
 #' @param na.strings optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
 #' @noRd
@@ -555,6 +563,7 @@ write_data_table <- function(
     bandedRows = TRUE,
     bandedCols = FALSE,
     name = NULL,
+    applyCellStyle = TRUE,
     removeCellStyle = FALSE,
     data_table = FALSE,
     na.strings
@@ -715,6 +724,7 @@ write_data_table <- function(
     rowNames = rowNames,
     startRow = startRow,
     startCol = startCol,
+    applyCellStyle = applyCellStyle,
     removeCellStyle = removeCellStyle,
     na.strings = na.strings
   )
@@ -801,6 +811,7 @@ write_data_table <- function(
 #' @param withFilter If `TRUE`, add filters to the column name row. NOTE can only have one filter per worksheet.
 #' @param sep Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).
 #' @param name If not NULL, a named region is defined.
+#' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
 #' @param na.strings optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
 #' @seealso [write_datatable()]
@@ -877,6 +888,7 @@ write_data <- function(
     withFilter = FALSE,
     sep = ", ",
     name = NULL,
+    applyCellStyle = TRUE,
     removeCellStyle = FALSE,
     na.strings
 ) {
@@ -903,6 +915,7 @@ write_data <- function(
     bandedRows = FALSE,
     bandedCols = FALSE,
     name = name,
+    applyCellStyle = applyCellStyle,
     removeCellStyle = removeCellStyle,
     data_table = FALSE,
     na.strings = na.strings
@@ -933,6 +946,8 @@ write_data <- function(
 #' @param xy An alternative to specifying `startCol` and
 #' `startRow` individually.  A vector of the form
 #' `c(startCol, startRow)`.
+#' @param applyCellStyle apply styles when writing on the sheet
+#' @param removeCellStyle if writing into existing cells, should the cell style be removed?
 #' @seealso [write_data()]
 #' @export write_formula
 #' @rdname write_formula
@@ -999,14 +1014,18 @@ write_data <- function(
 #'              x = "SUM(C2:C11*D2:D11)",
 #'              array = TRUE)
 #'
-write_formula <- function(wb,
-                          sheet,
-                          x,
-                          startCol = 1,
-                          startRow = 1,
-                          dims = rowcol_to_dims(startRow, startCol),
-                          array = FALSE,
-                          xy = NULL) {
+write_formula <- function(
+  wb,
+  sheet,
+  x,
+  startCol = 1,
+  startRow = 1,
+  dims = rowcol_to_dims(startRow, startCol),
+  array = FALSE,
+  xy = NULL,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE
+) {
   assert_class(x, "character")
   # remove xml encoding and reapply it afterwards. until v0.3 encoding was not enforced
   x <- replaceXMLEntities(x)
@@ -1028,7 +1047,9 @@ write_formula <- function(wb,
     array = array,
     xy = xy,
     colNames = FALSE,
-    rowNames = FALSE
+    rowNames = FALSE,
+    applyCellStyle = applyCellStyle,
+    removeCellStyle = removeCellStyle
   )
 }
 
@@ -1060,6 +1081,8 @@ write_formula <- function(wb,
 #' @param lastColumn logical. If TRUE, the last column is bold
 #' @param bandedRows logical. If TRUE, rows are colour banded
 #' @param bandedCols logical. If TRUE, the columns are colour banded
+#' @param applyCellStyle apply styles when writing on the sheet
+#' @param removeCellStyle if writing into existing cells, should the cell style be removed?
 #' @param na.strings optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
 #' @details columns of x with class Date/POSIXt, currency, accounting,
 #' hyperlink, percentage are automatically styled as dates, currency, accounting,
@@ -1171,6 +1194,8 @@ write_datatable <- function(
     lastColumn = FALSE,
     bandedRows = TRUE,
     bandedCols = FALSE,
+    applyCellStyle = TRUE,
+    removeCellStyle = FALSE,
     na.strings
 ) {
 
@@ -1196,8 +1221,9 @@ write_datatable <- function(
     bandedRows = bandedRows,
     bandedCols = bandedCols,
     name = NULL,
-    removeCellStyle = FALSE,
     data_table = TRUE,
+    applyCellStyle = applyCellStyle,
+    removeCellStyle = removeCellStyle,
     na.strings = na.strings
   )
 }

--- a/R/write.R
+++ b/R/write.R
@@ -360,8 +360,8 @@ write_data2 <- function(wb, sheet, data, name = NULL,
       sel_cols <- names(rtyp[sel == TRUE])
       sel_rows <- rownames(rtyp)
 
-      # # ignore first row if colNames
-      # if (colNames) sel_rows <- sel_rows[-1]
+      # ignore first row if colNames
+      if (colNames) sel_rows <- sel_rows[-1]
 
       paste(
         unname(
@@ -448,9 +448,7 @@ write_data2 <- function(wb, sheet, data, name = NULL,
       # message("accounting: ", dim_sel)
 
       wb$add_numfmt(
-        sheet = sheetno,
-        
-      sheet = sheetno,dim = dim_sel,
+        dim = dim_sel,
         numfmt = numfmt_accounting
       )
     }

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -538,6 +538,7 @@ add data
   withFilter = FALSE,
   name = NULL,
   sep = ", ",
+  applyCellStyle = TRUE,
   removeCellStyle = FALSE,
   na.strings
 )}\if{html}{\out{</div>}}
@@ -569,6 +570,8 @@ add data
 \item{\code{name}}{name}
 
 \item{\code{sep}}{sep}
+
+\item{\code{applyCellStyle}}{applyCellStyle}
 
 \item{\code{removeCellStyle}}{if writing into existing cells, should the cell style be removed?}
 
@@ -602,6 +605,8 @@ add a data table
   lastColumn = FALSE,
   bandedRows = TRUE,
   bandedCols = FALSE,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE,
   na.strings
 )}\if{html}{\out{</div>}}
 }
@@ -641,6 +646,10 @@ add a data table
 
 \item{\code{bandedCols}}{bandedCols}
 
+\item{\code{applyCellStyle}}{applyCellStyle}
+
+\item{\code{removeCellStyle}}{if writing into existing cells, should the cell style be removed?}
+
 \item{\code{na.strings}}{na.strings}
 }
 \if{html}{\out{</div>}}
@@ -659,7 +668,9 @@ add formula
   startRow = 1,
   dims = rowcol_to_dims(startRow, startCol),
   array = FALSE,
-  xy = NULL
+  xy = NULL,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -679,6 +690,10 @@ add formula
 \item{\code{array}}{array}
 
 \item{\code{xy}}{xy}
+
+\item{\code{applyCellStyle}}{applyCellStyle}
+
+\item{\code{removeCellStyle}}{if writing into existing cells, should the cell style be removed?}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wb_add_data_table.Rd
+++ b/man/wb_add_data_table.Rd
@@ -22,6 +22,8 @@ wb_add_data_table(
   lastColumn = FALSE,
   bandedRows = TRUE,
   bandedCols = FALSE,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE,
   na.strings
 )
 }
@@ -68,6 +70,10 @@ sep).
 \item{bandedRows}{logical. If TRUE, rows are colour banded}
 
 \item{bandedCols}{logical. If TRUE, the columns are colour banded}
+
+\item{applyCellStyle}{Should we write cell styles to the workbook}
+
+\item{removeCellStyle}{keep the cell style?}
 
 \item{na.strings}{optional}
 }

--- a/man/wb_add_formula.Rd
+++ b/man/wb_add_formula.Rd
@@ -12,7 +12,9 @@ wb_add_formula(
   startRow = 1,
   dims = rowcol_to_dims(startRow, startCol),
   array = FALSE,
-  xy = NULL
+  xy = NULL,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE
 )
 }
 \arguments{
@@ -33,6 +35,10 @@ wb_add_formula(
 \item{xy}{An alternative to specifying \code{startCol} and
 \code{startRow} individually.  A vector of the form
 \code{c(startCol, startRow)}.}
+
+\item{applyCellStyle}{Should we write cell styles to the workbook}
+
+\item{removeCellStyle}{keep the cell style?}
 }
 \description{
 Add a character vector containing Excel formula to a worksheet.

--- a/man/write_data.Rd
+++ b/man/write_data.Rd
@@ -19,6 +19,7 @@ wb_add_data(
   withFilter = FALSE,
   name = NULL,
   sep = ", ",
+  applyCellStyle = TRUE,
   removeCellStyle = FALSE,
   na.strings
 )
@@ -37,6 +38,7 @@ write_data(
   withFilter = FALSE,
   sep = ", ",
   name = NULL,
+  applyCellStyle = TRUE,
   removeCellStyle = FALSE,
   na.strings
 )
@@ -69,6 +71,8 @@ write_data(
 \item{name}{If not NULL, a named region is defined.}
 
 \item{sep}{Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).}
+
+\item{applyCellStyle}{apply styles when writing on the sheet}
 
 \item{removeCellStyle}{if writing into existing cells, should the cell style be removed?}
 

--- a/man/write_data2.Rd
+++ b/man/write_data2.Rd
@@ -13,6 +13,7 @@ write_data2(
   rowNames = FALSE,
   startRow = 1,
   startCol = 1,
+  applyCellStyle = TRUE,
   removeCellStyle = FALSE,
   na.strings
 )
@@ -33,6 +34,8 @@ write_data2(
 \item{startRow}{row to place it}
 
 \item{startCol}{col to place it}
+
+\item{applyCellStyle}{apply styles when writing on the sheet}
 
 \item{removeCellStyle}{keep the cell style?}
 

--- a/man/write_datatable.Rd
+++ b/man/write_datatable.Rd
@@ -22,6 +22,8 @@ write_datatable(
   lastColumn = FALSE,
   bandedRows = TRUE,
   bandedCols = FALSE,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE,
   na.strings
 )
 }
@@ -65,6 +67,10 @@ A vector of the form c(startCol, startRow)}
 \item{bandedRows}{logical. If TRUE, rows are colour banded}
 
 \item{bandedCols}{logical. If TRUE, the columns are colour banded}
+
+\item{applyCellStyle}{apply styles when writing on the sheet}
+
+\item{removeCellStyle}{if writing into existing cells, should the cell style be removed?}
 
 \item{na.strings}{optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)}
 }

--- a/man/write_formula.Rd
+++ b/man/write_formula.Rd
@@ -12,7 +12,9 @@ write_formula(
   startRow = 1,
   dims = rowcol_to_dims(startRow, startCol),
   array = FALSE,
-  xy = NULL
+  xy = NULL,
+  applyCellStyle = TRUE,
+  removeCellStyle = FALSE
 )
 }
 \arguments{
@@ -33,6 +35,10 @@ write_formula(
 \item{xy}{An alternative to specifying \code{startCol} and
 \code{startRow} individually.  A vector of the form
 \code{c(startCol, startRow)}.}
+
+\item{applyCellStyle}{apply styles when writing on the sheet}
+
+\item{removeCellStyle}{if writing into existing cells, should the cell style be removed?}
 }
 \description{
 Write a a character vector containing Excel formula to a worksheet.

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -178,4 +178,8 @@ test_that("dims_to_dataframe", {
   got <- dims_to_dataframe("A1;A2;C1;C2", fill = TRUE)
   expect_equal(exp, got)
 
+  exp <- list(c("A", "B"), "1")
+  got <- dims_to_rowcol("A1;B1")
+  expect_equal(exp, got)
+
 })

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -163,3 +163,19 @@ test_that("select_active_sheet", {
   expect_identical(1, wb_get_active_sheet(wb))
 
 })
+
+
+test_that("dims_to_dataframe", {
+
+  exp <- structure(
+    list(A = c("A1", "A2"), C = c("C1", "C2")),
+    row.names = 1:2,
+    class = "data.frame"
+  )
+  got <- dims_to_dataframe("A1:A2;C1:C2", fill = TRUE)
+  expect_equal(exp, got)
+
+  got <- dims_to_dataframe("A1;A2;C1;C2", fill = TRUE)
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Second attempt to clean up style application. This unifies our attempts to apply styles when writing data. If we write to  a workbook we can
* apply our styles `applyCellStyles = TRUE` on top of what other style we have found (e.g. if a cell uses a font, border or fill: we only add our number format to the existing style).
* use the original style or no style at all `applyCellStyles = FALSE`
* use only our styles and remove the previous style `removeCellStyle = TRUE`

```R
library(openxlsx2)

wb <- wb_workbook()$
  add_worksheet()$
  add_fill(dims = "B2:G8", color = wb_colour("yellow"))$
  add_data(dims = "C3", x = Sys.Date())$
  add_data(dims = "E5", x = Sys.Date(), removeCellStyle = TRUE)$
  add_data(dims = "A1", x = Sys.Date())

wb$open()
```