### PR TITLE
[add_data_table] improve rowNames. closes #354

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 ## Fixes
 
+* Improve `rowNames` when writing data to worksheet. Previously the name for the rownames column defaulted to `1`. This has been changed. Now with data it defaults to an empty cell and with a data table it defaults to `_rowNames_`. [375](https://github.com/JanMarvin/openxlsx2/pull/375)
+
 * Fix the workbook xml relationship file to not include a reference to shared strings per default. This solves [360](https://github.com/JanMarvin/openxlsx2/issues/360) for plain data files written from `openxlsx2`. [363](https://github.com/JanMarvin/openxlsx2/pull/363)
 
 * Adding cell styles has been streamlined to increase consistency. This includes all style functions like `wb_add_font()` and covers all cases of hyperlinks. [365](https://github.com/JanMarvin/openxlsx2/pull/365)

--- a/R/write.R
+++ b/R/write.R
@@ -745,7 +745,7 @@ write_data_table <- function(
 
     ## replace invalid XML characters
     col_names <- replace_legal_chars(colnames(x))
-    if (rowNames) col_names <- c("1", col_names)
+    if (rowNames) col_names <- c("_rowNames_", col_names)
 
     ## Table name validation
     if (is.null(tableName)) {

--- a/R/write.R
+++ b/R/write.R
@@ -336,7 +336,7 @@ write_data2 <- function(
   }
 
   # if rownames = TRUE and data_table = FALSE, remove "_rownames_"
-  if (!data_table && rowNames) {
+  if (!data_table && rowNames && colNames) {
     cc <- cc[cc$r != rtyp[1,1], ]
   }
 

--- a/R/write.R
+++ b/R/write.R
@@ -134,6 +134,7 @@ nmfmt_df <- function(x) {
 #' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle keep the cell style?
 #' @param na.strings optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
+#' @param data_table logical. if `TRUE` and `rowNames = TRUE`, do not write the cell containing  `"_rowNames_"`
 #' @details
 #' The string `"_openxlsx_NA"` is reserved for `openxlsx2`. If the data frame
 #' contains this string, the output will be broken.
@@ -166,7 +167,8 @@ write_data2 <- function(
     startCol = 1,
     applyCellStyle = TRUE,
     removeCellStyle = FALSE,
-    na.strings
+    na.strings,
+    data_table = FALSE
   ) {
 
   if (missing(na.strings)) na.strings <- substitute()
@@ -198,15 +200,15 @@ write_data2 <- function(
     sel <- !dc %in% c(4, 5, 10)
     data[sel] <- lapply(data[sel], as.character)
 
+    # add rownames
+    if (rowNames) {
+      data <- cbind("_rowNames_" = rownames(data), data)
+      dc <- c(c("_rowNames_" = openxlsx2_celltype[["character"]]), dc)
+    }
+
     # add colnames
     if (colNames)
       data <- rbind(colnames(data), data)
-
-    # add rownames
-    if (rowNames) {
-      data <- cbind(rownames(data), data)
-      dc <- c(c("_rowNames_" = openxlsx2_celltype[["character"]]), dc)
-    }
   }
 
 
@@ -331,6 +333,11 @@ write_data2 <- function(
   if (length(is_inf)) {
     cc[is_inf, "v"]   <- "#NUM!"
     cc[is_inf, "c_t"] <- "e"
+  }
+
+  # if rownames = TRUE and data_table = FALSE, remove "_rownames_"
+  if (!data_table && rowNames) {
+    cc <- cc[cc$r != rtyp[1,1], ]
   }
 
   if (is.null(wb$worksheets[[sheetno]]$sheet_data$cc)) {
@@ -726,9 +733,9 @@ write_data_table <- function(
     startCol = startCol,
     applyCellStyle = applyCellStyle,
     removeCellStyle = removeCellStyle,
-    na.strings = na.strings
+    na.strings = na.strings,
+    data_table = data_table
   )
-
 
   ### Beg: Only in datatable ---------------------------------------------------
 

--- a/man/write_data2.Rd
+++ b/man/write_data2.Rd
@@ -15,7 +15,8 @@ write_data2(
   startCol = 1,
   applyCellStyle = TRUE,
   removeCellStyle = FALSE,
-  na.strings
+  na.strings,
+  data_table = FALSE
 )
 }
 \arguments{
@@ -40,6 +41,8 @@ write_data2(
 \item{removeCellStyle}{keep the cell style?}
 
 \item{na.strings}{optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)}
+
+\item{data_table}{logical. if \code{TRUE} and \code{rowNames = TRUE}, do not write the cell containing  \code{"_rowNames_"}}
 }
 \description{
 dummy function to write data

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -243,3 +243,37 @@ test_that("update cell(s)", {
   expect_equal(exp, got)
 
 })
+
+test_that("write_rownames", {
+  wb <- wb_workbook()$
+    add_worksheet()$add_data(x = mtcars, rowNames = TRUE)$
+    add_worksheet()$add_data_table(x = mtcars, rowNames = TRUE)
+  
+  exp <- structure(
+    list(A = c(NA, "Mazda RX4"), B = c("mpg", "21")),
+    row.names = 1:2,
+    class = "data.frame",
+    tt = structure(
+      list(A = c(NA, "s"), B = c("s", "n")),
+      row.names = 1:2,
+      class = "data.frame"),
+    types = c(A = 0, B = 0)
+  )
+  got <- wb_to_df(wb, 1, dims = "A1:B2", colNames = FALSE)
+  expect_equal(exp, got)
+  
+  
+  exp <- structure(
+    list(A = c("_rowNames_", "Mazda RX4"), B = c("mpg", "21")),
+    row.names = 1:2,
+    class = "data.frame",
+    tt = structure(
+      list(A = c("s", "s"), B = c("s", "n")),
+      row.names = 1:2,
+      class = "data.frame"),
+    types = c(A = 0, B = 0)
+  )
+  got <- wb_to_df(wb, 2, dims = "A1:B2", colNames = FALSE)
+  expect_equal(exp, got)
+  
+})


### PR DESCRIPTION
Previously, when using `rownames = TRUE` when writing data, we would add a cell with `1` in top left box (the name for the rownames). This has been changed:
* when writing data: we do not fill this cell at all.
* when writing a data table: we fill this cell with `_rowNames_`.

_IIRC_ data tables require unique column names and can not be empty. 

* [x] test with Excel
* [x] add unittests
* [x] update NEWS

```R
wb <- wb_workbook()

wb$add_worksheet()$add_data(x = mtcars, rowNames = TRUE)
wb$add_worksheet()$add_data_table(x = mtcars, rowNames = TRUE)

wb$open()
```