### PR TITLE
[styles] avoid sample names. fixes #383

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4740,19 +4740,6 @@ wbWorkbook <- R6::R6Class(
       sheet <- private$get_sheet_index(sheet)
       private$do_cell_init(sheet, dims)
 
-      new_fill <- create_fill(
-        gradientFill = gradient_fill,
-        patternType = pattern,
-        fgColor = color
-      )
-
-      # sample() will change the random seed
-      smp <- random_string()
-      snew_fill <- paste0(smp, "new_fill")
-      # sxf_new_fill <- paste0(smp, "xf_new_fill") # not used?
-
-      self$styles_mgr$add(new_fill, snew_fill)
-
       # dim in dataframe can contain various styles. go cell by cell.
       did <- dims_to_dataframe(dims, fill = TRUE)
       # select a few cols and rows to fill
@@ -4762,8 +4749,16 @@ wbWorkbook <- R6::R6Class(
       dims <- unname(unlist(did[rows, cols, drop = FALSE]))
 
       for (dim in dims) {
+
+        new_fill <- create_fill(
+          gradientFill = gradient_fill,
+          patternType = pattern,
+          fgColor = color
+        )
+        self$styles_mgr$add(new_fill, new_fill)
+
         xf_prev <- get_cell_styles(self, sheet, dim)
-        xf_new_fill <- set_fill(xf_prev, self$styles_mgr$get_fill_id(snew_fill))
+        xf_new_fill <- set_fill(xf_prev, self$styles_mgr$get_fill_id(new_fill))
         self$styles_mgr$add(xf_new_fill, xf_new_fill)
         s_id <- self$styles_mgr$get_xf_id(xf_new_fill)
         self$set_cell_style(sheet, dim, s_id)
@@ -4817,38 +4812,35 @@ wbWorkbook <- R6::R6Class(
       sheet <- private$get_sheet_index(sheet)
       private$do_cell_init(sheet, dims)
 
-      new_font <- create_font(
-        b = bold,
-        charset = charset,
-        color = color,
-        condense = condense,
-        extend = extend,
-        family = family,
-        i = italic,
-        name = name,
-        outline = outline,
-        scheme = scheme,
-        shadow = shadow,
-        strike = strike,
-        sz = size,
-        u = underline,
-        vertAlign = vertAlign
-      )
-
-      smp <- random_string()
-      snew_font <- paste0(smp, "new_font")
-      sxf_new_font <- paste0(smp, "xf_new_font")
-
-      self$styles_mgr$add(new_font, snew_font)
-
       did <- dims_to_dataframe(dims, fill = TRUE)
       dims <- unname(unlist(did))
 
       for (dim in dims) {
+
+        new_font <- create_font(
+          b = bold,
+          charset = charset,
+          color = color,
+          condense = condense,
+          extend = extend,
+          family = family,
+          i = italic,
+          name = name,
+          outline = outline,
+          scheme = scheme,
+          shadow = shadow,
+          strike = strike,
+          sz = size,
+          u = underline,
+          vertAlign = vertAlign
+        )
+        self$styles_mgr$add(new_font, new_font)
+
         xf_prev <- get_cell_styles(self, sheet, dim)
-        xf_new_font <- set_font(xf_prev, self$styles_mgr$get_font_id(snew_font))
-        self$styles_mgr$add(xf_new_font, sxf_new_font)
-        s_id <- self$styles_mgr$get_xf_id(sxf_new_font)
+        xf_new_font <- set_font(xf_prev, self$styles_mgr$get_font_id(new_font))
+
+        self$styles_mgr$add(xf_new_font, xf_new_font)
+        s_id <- self$styles_mgr$get_xf_id(xf_new_font)
         self$set_cell_style(sheet, dim, s_id)
       }
 
@@ -4880,16 +4872,11 @@ wbWorkbook <- R6::R6Class(
           numFmtId = self$styles_mgr$next_numfmt_id(),
           formatCode = numfmt
         )
-
-        smp <- random_string()
-        snew_numfmt <- paste0(smp, "new_numfmt")
-        # sxf_new_numfmt <- paste0(smp, "xf_new_numfmt")
-
-        self$styles_mgr$add(new_numfmt, snew_numfmt)
+        self$styles_mgr$add(new_numfmt, new_numfmt)
 
         for (dim in dims) {
           xf_prev <- get_cell_styles(self, sheet, dim)
-          xf_new_numfmt <- set_numfmt(xf_prev, self$styles_mgr$get_numfmt_id(snew_numfmt))
+          xf_new_numfmt <- set_numfmt(xf_prev, self$styles_mgr$get_numfmt_id(new_numfmt))
           self$styles_mgr$add(xf_new_numfmt, xf_new_numfmt)
           s_id <- self$styles_mgr$get_xf_id(xf_new_numfmt)
           self$set_cell_style(sheet, dim, s_id)

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -414,3 +414,58 @@ test_that("applyCellStyle works", {
   expect_equal(exp, got)
 
 })
+
+test_that("style names are xml", {
+  sheet <- mtcars[1:6, 1:6]
+
+  wb <- wb_workbook() %>%
+    wb_add_worksheet("test") %>%
+    wb_add_data(x = "Title", startCol = 1, startRow = 1) %>%
+    wb_add_font(dims = "A1", bold = "1", size = "14") %>%
+    wb_add_data(x = sheet, colNames = TRUE, startCol = 1, startRow = 2, removeCellStyle = TRUE) %>%
+    wb_add_cell_style(dims = "B2:F2", horizontal = "right") %>%
+    wb_add_font(dims = "A2:F2", bold = "1", size = "11") %>%
+    wb_add_numfmt(dims = "B3:D8", numfmt = 2) %>%
+    wb_add_font(dims = "B3:D8", italic = "1", size = "11") %>%
+    wb_add_fill(dims = "B3:D8", color = wb_colour("orange")) %>%
+    wb_add_fill(dims = "C5", color = wb_colour("black")) %>%
+    wb_add_font(dims = "C5", color = wb_colour("white"))
+
+  exp <- list(
+    numFmts = NULL,
+    fonts = c(
+      "<font><sz val=\"11\"/><color rgb=\"FF000000\"/><name val=\"Calibri\"/><family val=\"2\"/><scheme val=\"minor\"/></font>",
+      "<font><b val=\"1\"/><color rgb=\"FF000000\"/><name val=\"Calibri\"/><sz val=\"14\"/></font>",
+      "<font><b val=\"1\"/><color rgb=\"FF000000\"/><name val=\"Calibri\"/><sz val=\"11\"/></font>",
+      "<font><color rgb=\"FF000000\"/><i val=\"1\"/><name val=\"Calibri\"/><sz val=\"11\"/></font>",
+      "<font><color rgb=\"FFFFFFFF\"/><name val=\"Calibri\"/><sz val=\"11\"/></font>"
+    ),
+    fills = c(
+      "<fill><patternFill patternType=\"none\"/></fill>",
+      "<fill><patternFill patternType=\"gray125\"/></fill>", "<fill><patternFill patternType=\"solid\"><fgColor rgb=\"FFFFA500\"/></patternFill></fill>",
+      "<fill><patternFill patternType=\"solid\"><fgColor rgb=\"FF000000\"/></patternFill></fill>"
+    ),
+    borders = "<border><left/><right/><top/><bottom/><diagonal/></border>",
+    cellStyleXfs = "<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/>",
+    cellXfs = c(
+      "<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>",
+      "<xf applyFont=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"1\" numFmtId=\"0\" xfId=\"0\"/>",
+      "<xf borderId=\"0\" fillId=\"0\" fontId=\"0\" numFmtId=\"0\" xfId=\"0\"><alignment horizontal=\"right\"/></xf>",
+      "<xf applyFont=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"2\" numFmtId=\"0\" xfId=\"0\"/>",
+      "<xf applyFont=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"2\" numFmtId=\"0\" xfId=\"0\"><alignment horizontal=\"right\"/></xf>",
+      "<xf applyNumberFormat=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"0\" numFmtId=\"2\" xfId=\"0\"/>",
+      "<xf applyFont=\"1\" applyNumberFormat=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"3\" numFmtId=\"2\" xfId=\"0\"/>",
+      "<xf applyFill=\"1\" applyFont=\"1\" applyNumberFormat=\"1\" borderId=\"0\" fillId=\"2\" fontId=\"3\" numFmtId=\"2\" xfId=\"0\"/>",
+      "<xf applyFill=\"1\" applyFont=\"1\" applyNumberFormat=\"1\" borderId=\"0\" fillId=\"3\" fontId=\"3\" numFmtId=\"2\" xfId=\"0\"/>",
+      "<xf applyFill=\"1\" applyFont=\"1\" applyNumberFormat=\"1\" borderId=\"0\" fillId=\"3\" fontId=\"4\" numFmtId=\"2\" xfId=\"0\"/>"
+    ),
+    cellStyles = "<cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/>",
+    dxfs = NULL,
+    tableStyles = NULL,
+    indexedColors = NULL,
+    extLst = NULL
+  )
+  got <- wb$styles_mgr$styles
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
This creates names as xml strings

```R
library(openxlsx2)

sheet <- mtcars[1:6, 1:6]

wb <- wb_workbook() %>%
  wb_add_worksheet("test") %>%
  wb_add_data(x = "Title", startCol = 1, startRow = 1) %>%
  wb_add_font(dims = "A1", bold = "1", size = "14") %>%
  wb_add_data(x = sheet, colNames = TRUE, startCol = 1, startRow = 2, removeCellStyle = TRUE) %>%
  wb_add_cell_style(dims = "B2:F2", horizontal = "right") %>%
  wb_add_font(dims = "A2:F2", bold = "1", size = "11") %>% 
  wb_add_numfmt(dims = "B3:D8", numfmt = 2) %>% 
  wb_add_font(dims = "B3:D8", italic = "1", size = "11") %>% 
  wb_add_fill(dims = "B3:D8", color = wb_colour("orange")) %>% 
  wb_add_fill(dims = "C5", color = wb_colour("black")) %>% 
  wb_add_font(dims = "C5", color = wb_colour("white"))

wb %>% wb_open()
```