### PR TITLE
add further named region arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* Improved `add_named_region()`. This function includes now various xml options. [386](https://github.com/JanMarvin/openxlsx2/pull/386)
+
 * Add ... as argument to `read_xlsx()` and `wb_read()`. [381](https://github.com/JanMarvin/openxlsx2/pull/381)
 
 * Allow reading files with xml namespace created by third party software. [405](https://github.com/JanMarvin/openxlsx2/pull/405)

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -1266,7 +1266,20 @@ wb_set_order <- function(wb, sheets) {
 #' @param cols Numeric vector specifying columns to include in region
 #' @param name Name for region. A character vector of length 1. Note region names musts be case-insensitive unique.
 #' @param overwrite Boolean. Overwrite if exists? Default to FALSE
-#' @param localSheetId localSheetId
+#' @param localSheet If `TRUE` the named region will be local for this sheet
+#' @param comment description text for named region
+#' @param customMenu customMenu (unknown xml feature)
+#' @param description description (unknown xml feature)
+#' @param is_function function (unknown xml feature)
+#' @param functionGroupId function group id (unknown xml feature)
+#' @param help help (unknown xml feature)
+#' @param hidden hidden if the named region should be hidden
+#' @param localName localName (unknown xml feature)
+#' @param publishToServer publish to server (unknown xml feature)
+#' @param statusBar status bar (unknown xml feature)
+#' @param vbProcedure wbProcedure (unknown xml feature)
+#' @param workbookParameter workbookParameter (unknown xml feature)
+#' @param xml xml (unknown xml feature)
 #' @details Region is given by: min(cols):max(cols) X min(rows):max(rows)
 #' @examples
 #' ## create named regions
@@ -1308,15 +1321,50 @@ NULL
 
 #' @rdname named_region
 #' @export
-wb_add_named_region <- function(wb, sheet = current_sheet(), cols, rows, name, localSheetId = NULL, overwrite = FALSE) {
+wb_add_named_region <- function(
+  wb,
+  sheet             = current_sheet(),
+  cols,
+  rows,
+  name,
+  localSheetId      = NULL,
+  overwrite         = FALSE,  
+  localSheet        = FALSE,
+  comment           = NULL,
+  customMenu        = NULL,
+  description       = NULL,
+  is_function       = NULL,
+  functionGroupId   = NULL,
+  help              = NULL,
+  hidden            = NULL,
+  localName         = NULL,
+  publishToServer   = NULL,
+  statusBar         = NULL,
+  vbProcedure       = NULL,
+  workbookParameter = NULL,
+  xml               = NULL
+) {
   assert_workbook(wb)
   wb$clone()$add_named_region(
-    sheet        = sheet,
-    cols         = cols,
-    rows         = rows,
-    name         = name,
-    localSheetId = localSheetId,
-    overwrite    = overwrite
+    sheet             = sheet,
+    cols              = cols,
+    rows              = rows,
+    name              = name,
+    localSheet        = localSheet,
+    overwrite         = overwrite,
+    comment           = comment,
+    customMenu        = customMenu,
+    description       = description,
+    is_function       = is_function,
+    functionGroupId   = functionGroupId,
+    help              = help,
+    hidden            = hidden,
+    localName         = localName,
+    publishToServer   = publishToServer,
+    statusBar         = statusBar,
+    vbProcedure       = wbProcedure,
+    workbookParameter = workbookParameter,
+    xml               = xml
   )
 }
 

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -1327,9 +1327,8 @@ wb_add_named_region <- function(
   cols,
   rows,
   name,
-  localSheetId      = NULL,
-  overwrite         = FALSE,  
   localSheet        = FALSE,
+  overwrite         = FALSE,
   comment           = NULL,
   customMenu        = NULL,
   description       = NULL,
@@ -1362,7 +1361,7 @@ wb_add_named_region <- function(
     localName         = localName,
     publishToServer   = publishToServer,
     statusBar         = statusBar,
-    vbProcedure       = wbProcedure,
+    vbProcedure       = vbProcedure,
     workbookParameter = workbookParameter,
     xml               = xml
   )

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4098,7 +4098,6 @@ wbWorkbook <- R6::R6Class(
       ## check name doesn't already exist
       ## named region
 
-      # TODO use reg_match0?
       definedNames <- rbindlist(xml_attr(self$workbook$definedNames, level1 = "definedName"))
       sel1 <- tolower(definedNames$name) == tolower(name)
       sel2 <- definedNames$localSheetId == localSheetId

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4100,7 +4100,14 @@ wbWorkbook <- R6::R6Class(
 
       # TODO use reg_match0?
       definedNames <- rbindlist(xml_attr(self$workbook$definedNames, level1 = "definedName"))
-      match_dn <- which(tolower(definedNames$name) == tolower(name) & definedNames$localSheetId == localSheetId)
+      sel1 <- tolower(definedNames$name) == tolower(name)
+      sel2 <- definedNames$localSheetId == localSheetId
+      if (!is.null(definedNames$localSheetId)) {
+        sel <- sel1 & sel2
+      } else {
+         sel <- sel1
+      }
+      match_dn <- which(sel)
 
       if (any(match_dn)) {
         if (overwrite)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4045,16 +4045,42 @@ wbWorkbook <- R6::R6Class(
     #' @param cols cols
     #' @param rows rows
     #' @param name name
-    #' @param localSheetId localSheetId
+    #' @param localSheet localSheet
     #' @param overwrite overwrite
+    #' @param comment comment
+    #' @param customMenu customMenu
+    #' @param description description
+    #' @param is_function function
+    #' @param functionGroupId function group id
+    #' @param help help
+    #' @param hidden hidden
+    #' @param localName localName
+    #' @param publishToServer publish to server
+    #' @param statusBar status bar
+    #' @param vbProcedure wbProcedure
+    #' @param workbookParameter workbookParameter
+    #' @param xml xml
     #' @returns The `wbWorkbook` object
     add_named_region = function(
       sheet = current_sheet(),
       cols,
       rows,
       name,
-      localSheetId = NULL,
-      overwrite = FALSE
+      localSheet        = FALSE,
+      overwrite         = FALSE,
+      comment           = NULL,
+      customMenu        = NULL,
+      description       = NULL,
+      is_function       = NULL,
+      functionGroupId   = NULL,
+      help              = NULL,
+      hidden            = NULL,
+      localName         = NULL,
+      publishToServer   = NULL,
+      statusBar         = NULL,
+      vbProcedure       = NULL,
+      workbookParameter = NULL,
+      xml               = NULL
     ) {
       sheet <- private$get_sheet_index(sheet)
 
@@ -4066,16 +4092,19 @@ wbWorkbook <- R6::R6Class(
         stop("cols argument must be a numeric/integer vector")
       }
 
+      localSheetId <- ""
+      if (localSheet) localSheetId <- as.character(sheet)
+
       ## check name doesn't already exist
       ## named region
 
       # TODO use reg_match0?
-      ex_names <- regmatches(self$workbook$definedNames, regexpr('(?<=name=")[^"]+', self$workbook$definedNames, perl = TRUE))
-      ex_names <- tolower(replaceXMLEntities(ex_names))
+      definedNames <- rbindlist(xml_attr(self$workbook$definedNames, level1 = "definedName"))
+      match_dn <- which(tolower(definedNames$name) == tolower(name) & definedNames$localSheetId == localSheetId)
 
-      if (tolower(name) %in% ex_names) {
+      if (any(match_dn)) {
         if (overwrite)
-          self$workbook$definedNames <- self$workbook$definedNames[!ex_names %in% tolower(name)]
+          self$workbook$definedNames <- self$workbook$definedNames[-match_dn]
         else
           stop(sprintf("Named region with name '%s' already exists! Use overwrite  = TRUE if you want to replace it", name))
       } else if (grepl("^[A-Z]{1,3}[0-9]+$", name)) {
@@ -4094,12 +4123,27 @@ wbWorkbook <- R6::R6Class(
       ref1 <- paste0("$", int2col(startCol), "$", startRow)
       ref2 <- paste0("$", int2col(endCol), "$", endRow)
 
+      if (localSheetId == "") localSheetId <- NULL
+
       private$create_named_region(
-        ref1         = ref1,
-        ref2         = ref2,
-        name         = name,
-        sheet        = self$sheet_names[sheet],
-        localSheetId = localSheetId
+        ref1               = ref1,
+        ref2               = ref2,
+        name               = name,
+        sheet              = self$sheet_names[sheet],
+        localSheetId       = localSheetId,
+        comment            = comment,
+        customMenu         = customMenu,
+        description        = description,
+        is_function        = is_function,
+        functionGroupId    = functionGroupId,
+        help               = help,
+        hidden             = hidden,
+        localName          = localName,
+        publishToServer    = publishToServer,
+        statusBar          = statusBar,
+        vbProcedure        = vbProcedure,
+        workbookParameter  = workbookParameter,
+        xml                = xml
       )
 
       invisible(self)
@@ -5637,28 +5681,69 @@ wbWorkbook <- R6::R6Class(
     },
 
     # old add_named_region()
-    create_named_region = function(ref1, ref2, name, sheet = current_sheet(), localSheetId = NULL) {
+    create_named_region = function(
+      ref1,
+      ref2,
+      name,
+      sheet = current_sheet(),
+      localSheetId      = NULL,
+      comment           = NULL,
+      customMenu        = NULL,
+      description       = NULL,
+      is_function       = NULL,
+      functionGroupId   = NULL,
+      help              = NULL,
+      hidden            = NULL,
+      localName         = NULL,
+      publishToServer   = NULL,
+      statusBar         = NULL,
+      vbProcedure       = NULL,
+      workbookParameter = NULL,
+      xml               = NULL
+    ) {
       name <- replace_legal_chars(name)
-      value <- if (is.null(localSheetId)) {
-        sprintf(
-          '<definedName name="%s">\'%s\'!%s:%s</definedName>',
-          name,
-          sheet,
-          ref1,
-          ref2
-        )
-      } else {
-        sprintf(
-          '<definedName name="%s" localSheetId="%s">\'%s\'!%s:%s</definedName>',
-          name,
-          localSheetId,
-          sheet,
-          ref1,
-          ref2
-        )
-      }
+      
+      # special names
 
-      private$append_workbook_field("definedNames", value)
+      ## print
+      # _xlnm .Print_Area
+      # _xlnm .Print_Titles
+
+      ## filters
+      # _xlnm .Criteria
+      # _xlnm ._FilterDatabase
+      # _xlnm .Extract
+
+      ## misc
+      # _xlnm .Consolidate_Area
+      # _xlnm .Database
+      # _xlnm .Sheet_Title
+
+      named_region <- c(
+        comment          = comment,
+        customMenu        = customMenu,
+        description       = description,
+        `function`        = is_function,
+        functionGroupId   = functionGroupId,
+        help              = help,
+        hidden            = hidden,
+        localName         = localName,
+        localSheetId      = localSheetId,
+        name              = name,
+        publishToServer   = publishToServer,
+        statusBar         = statusBar,
+        vbProcedure       = vbProcedure,
+        workbookParameter = workbookParameter,
+        xml               = xml
+      )
+
+      xml <- xml_node_create(
+        "definedName",
+        xml_children = sprintf("\'%s\'!%s:%s", sheet, ref1, ref2),
+        xml_attributes = named_region
+      )
+
+      private$append_workbook_field("definedNames", xml)
     },
 
     get_sheet_id = function(type = c("rId", "sheetId"), i = NULL) {

--- a/man/named_region.Rd
+++ b/man/named_region.Rd
@@ -13,7 +13,21 @@ wb_add_named_region(
   rows,
   name,
   localSheetId = NULL,
-  overwrite = FALSE
+  overwrite = FALSE,
+  localSheet = FALSE,
+  comment = NULL,
+  customMenu = NULL,
+  description = NULL,
+  is_function = NULL,
+  functionGroupId = NULL,
+  help = NULL,
+  hidden = NULL,
+  localName = NULL,
+  publishToServer = NULL,
+  statusBar = NULL,
+  vbProcedure = NULL,
+  workbookParameter = NULL,
+  xml = NULL
 )
 
 wb_remove_named_region(wb, sheet = current_sheet(), name = NULL)
@@ -29,9 +43,35 @@ wb_remove_named_region(wb, sheet = current_sheet(), name = NULL)
 
 \item{name}{Name for region. A character vector of length 1. Note region names musts be case-insensitive unique.}
 
-\item{localSheetId}{localSheetId}
-
 \item{overwrite}{Boolean. Overwrite if exists? Default to FALSE}
+
+\item{localSheet}{If \code{TRUE} the named region will be local for this sheet}
+
+\item{comment}{description text for named region}
+
+\item{customMenu}{customMenu (unknown xml feature)}
+
+\item{description}{description (unknown xml feature)}
+
+\item{is_function}{function (unknown xml feature)}
+
+\item{functionGroupId}{function group id (unknown xml feature)}
+
+\item{help}{help (unknown xml feature)}
+
+\item{hidden}{hidden if the named region should be hidden}
+
+\item{localName}{localName (unknown xml feature)}
+
+\item{publishToServer}{publish to server (unknown xml feature)}
+
+\item{statusBar}{status bar (unknown xml feature)}
+
+\item{vbProcedure}{wbProcedure (unknown xml feature)}
+
+\item{workbookParameter}{workbookParameter (unknown xml feature)}
+
+\item{xml}{xml (unknown xml feature)}
 }
 \description{
 Create / delete a named region

--- a/man/named_region.Rd
+++ b/man/named_region.Rd
@@ -12,9 +12,8 @@ wb_add_named_region(
   cols,
   rows,
   name,
-  localSheetId = NULL,
-  overwrite = FALSE,
   localSheet = FALSE,
+  overwrite = FALSE,
   comment = NULL,
   customMenu = NULL,
   description = NULL,
@@ -43,9 +42,9 @@ wb_remove_named_region(wb, sheet = current_sheet(), name = NULL)
 
 \item{name}{Name for region. A character vector of length 1. Note region names musts be case-insensitive unique.}
 
-\item{overwrite}{Boolean. Overwrite if exists? Default to FALSE}
-
 \item{localSheet}{If \code{TRUE} the named region will be local for this sheet}
+
+\item{overwrite}{Boolean. Overwrite if exists? Default to FALSE}
 
 \item{comment}{description text for named region}
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -1867,8 +1867,21 @@ add a named region
   cols,
   rows,
   name,
-  localSheetId = NULL,
-  overwrite = FALSE
+  localSheet = FALSE,
+  overwrite = FALSE,
+  comment = NULL,
+  customMenu = NULL,
+  description = NULL,
+  is_function = NULL,
+  functionGroupId = NULL,
+  help = NULL,
+  hidden = NULL,
+  localName = NULL,
+  publishToServer = NULL,
+  statusBar = NULL,
+  vbProcedure = NULL,
+  workbookParameter = NULL,
+  xml = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -1883,9 +1896,35 @@ add a named region
 
 \item{\code{name}}{name}
 
-\item{\code{localSheetId}}{localSheetId}
+\item{\code{localSheet}}{localSheet}
 
 \item{\code{overwrite}}{overwrite}
+
+\item{\code{comment}}{comment}
+
+\item{\code{customMenu}}{customMenu}
+
+\item{\code{description}}{description}
+
+\item{\code{is_function}}{function}
+
+\item{\code{functionGroupId}}{function group id}
+
+\item{\code{help}}{help}
+
+\item{\code{hidden}}{hidden}
+
+\item{\code{localName}}{localName}
+
+\item{\code{publishToServer}}{publish to server}
+
+\item{\code{statusBar}}{status bar}
+
+\item{\code{vbProcedure}}{wbProcedure}
+
+\item{\code{workbookParameter}}{workbookParameter}
+
+\item{\code{xml}}{xml}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -80,7 +80,7 @@ test_that("ws_page_setup example", {
   wb$page_setup(sheet = "print_title_cols", printTitleCols = 1, printTitleRows = 1)
 
   exp <- c(
-    "<definedName name=\"_xlnm.Print_Titles\" localSheetId=\"2\">'print_title_rows'!$1:$1</definedName>",
+    "<definedName localSheetId=\"2\" name=\"_xlnm.Print_Titles\">'print_title_rows'!$1:$1</definedName>",
     "<definedName name=\"_xlnm.Print_Titles\" localSheetId=\"3\">'print_title_cols'!$A:$A,'print_title_cols'!$1:$1</definedName>"
   )
   expect_equal(exp, wb$workbook$definedNames)


### PR DESCRIPTION
Not all of them are user relevant. Comment and hidden seem to be the only working.

* write global and local named regions
* write comments for named region
* write hidden named regions

```R
library(openxlsx2)

wb <- wb_workbook()$add_worksheet()$add_data(x = iris)

## specify region
wb$add_named_region(
  sheet = 1,
  name = "iris",
  rows = seq_len(nrow(iris) + 1),
  cols = seq_along(iris),
  comment = "test"
)

## specify region
wb$add_named_region(
  sheet = 1,
  name = "iris_head",
  rows = 1,
  cols = 1,
  hidden = "1"
)

wb$add_worksheet()$add_data(x = iris)

## specify region
wb$add_named_region(
  sheet = 2,
  name = "iris",
  rows = seq_len(nrow(iris) + 1),
  cols = seq_along(iris),
  localSheet = TRUE
)

wb$add_formula(x = "'Sheet 1'!iris_head", dims = "H1")

wb$open()
```

* [x] minor cleanups 
* [x] NEWS entry 
