### PR TITLE
[wb_load] update vml file name. fixes #402

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # openxlsx2 (in development)
 
+## Fixes
+
+* Fixed a case where embedded files were assigned incorrectly in worksheet relationships. This caused corrupted output. [403](https://github.com/JanMarvin/openxlsx2/pull/403)
 
 ***************************************************************************
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -954,6 +954,16 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
               if (any(relsInd)) {
                 wb$vml_rels[i] <- read_xml(vmlDrawingRelsXML[relsInd], pointer = FALSE)
               }
+              if (any(relsInd)) {
+                wb_rel <- rbindlist(xml_attr(wb$worksheets_rels[[i]], "Relationship"))
+                wb_rel$typ <- basename(wb_rels$Type)
+                is_vmlDrawing <- which(wb_rel$typ == "vmlDrawing")
+
+                if (length(is_vmlDrawing)) {
+                  wb_rels$Target[is_vmlDrawing] <- sprintf("../drawings/vmlDrawing%s.vml", i)
+                  wb$worksheets_rels[[i]][is_vmlDrawing] <- df_to_xml("Relationship", wb_rels[is_vmlDrawing, c("Id", "Target", "Type")])
+                }
+              }
             }
           }
         }

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -955,9 +955,9 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
                 wb$vml_rels[i] <- read_xml(vmlDrawingRelsXML[relsInd], pointer = FALSE)
               }
               if (any(relsInd)) {
-                wb_rel <- rbindlist(xml_attr(wb$worksheets_rels[[i]], "Relationship"))
-                wb_rel$typ <- basename(wb_rels$Type)
-                is_vmlDrawing <- which(wb_rel$typ == "vmlDrawing")
+                wb_rels <- rbindlist(xml_attr(wb$worksheets_rels[[i]], "Relationship"))
+                wb_rels$typ <- basename(wb_rels$Type)
+                is_vmlDrawing <- which(wb_rels$typ == "vmlDrawing")
 
                 if (length(is_vmlDrawing)) {
                   wb_rels$Target[is_vmlDrawing] <- sprintf("../drawings/vmlDrawing%s.vml", i)

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -320,3 +320,14 @@ test_that("loading slicers works", {
   expect_equal(exp, got)
 
 })
+
+test_that("vml target is updated on load", {
+
+  fl <- system.file("extdata", "mtcars_chart.xlsx", package = "openxlsx2")
+  wb <- wb_load(fl)
+
+  exp <- "<Relationship Id=\"rId2\" Target=\"../drawings/vmlDrawing4.vml\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing\"/>"
+  got <- wb$worksheets_rels[[4]][2]
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
We update vmlDrawing name, but ignored it in worksheets_rels.