### PR TITLE
[wb_load] read x namespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openxlsx2 (in development)
 
+## New features
+
+* Allow reading files with x namespace created by third party software. [405](https://github.com/JanMarvin/openxlsx2/pull/405)
+
 ## Fixes
 
 * Fixed a case where embedded files were assigned incorrectly in worksheet relationships. This caused corrupted output. [403](https://github.com/JanMarvin/openxlsx2/pull/403)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* Allow reading files with x namespace created by third party software. [405](https://github.com/JanMarvin/openxlsx2/pull/405)
+* Allow reading files with xml namespace created by third party software. [405](https://github.com/JanMarvin/openxlsx2/pull/405)
 
 ## Fixes
 

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -65,7 +65,7 @@ read_xml <- function(xml, pointer = TRUE, escapes = FALSE, declaration = FALSE, 
       stringi::stri_read_lines(xml, encoding = "UTF-8"),
       collapse = "")
 
-    if (grepl('xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"', xml_file)) {
+    if (grepl('xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"', xml_file, fixed = TRUE)) {
       xml_file <- stringi::stri_replace_all_fixed(xml_file, "<x:", "<")
       xml_file <- stringi::stri_replace_all_fixed(xml_file, "</x:", "</")
 

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -56,18 +56,18 @@ read_xml <- function(xml, pointer = TRUE, escapes = FALSE, declaration = FALSE, 
   if (identical(xml, ""))
     xml <- "<NA_character_ />"
 
-  # Clean xml files from x namespace. Otherwise all nodes might look like
+  # Clean xml files from xml namespace. Otherwise all nodes might look like
   # <x:node/> and not <node/>. https://github.com/JanMarvin/openxlsx2/pull/213
-  has_x_ns <- getOption("openxlsx2.namespace_x", default = FALSE)
-  if (has_x_ns && isfile && !isvml) {
+  xml_ns <- getOption("openxlsx2.namespace_xml")
+  if (!is.null(xml_ns) && isfile && !isvml) {
 
     xml_file <- stringi::stri_join(
       stringi::stri_read_lines(xml, encoding = "UTF-8"),
       collapse = "")
 
-    if (grepl('xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"', xml_file, fixed = TRUE)) {
-      xml_file <- stringi::stri_replace_all_fixed(xml_file, "<x:", "<")
-      xml_file <- stringi::stri_replace_all_fixed(xml_file, "</x:", "</")
+    if (grepl(sprintf('xmlns:%s="http://schemas.openxmlformats.org/spreadsheetml/2006/main"', xml_ns), xml_file, fixed = TRUE)) {
+      xml_file <- stringi::stri_replace_all_fixed(xml_file, sprintf("<%s:", xml_ns), "<")
+      xml_file <- stringi::stri_replace_all_fixed(xml_file, sprintf("</%s:", xml_ns), "</")
 
       # replace xml with already and cleaned output
       xml <- xml_file

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -58,7 +58,7 @@ read_xml <- function(xml, pointer = TRUE, escapes = FALSE, declaration = FALSE, 
 
   # Clean xml files from x namespace. Otherwise all nodes might look like
   # <x:node/> and not <node/>. https://github.com/JanMarvin/openxlsx2/pull/213
-  has_x_ns <- isTRUE(options()[["openxlsx2.has_x_namespace"]])
+  has_x_ns <- getOption("openxlsx2.namespace_x", default = FALSE)
   if (has_x_ns && isfile && !isvml) {
 
     xml_file <- stringi::stri_join(

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -58,7 +58,7 @@ read_xml <- function(xml, pointer = TRUE, escapes = FALSE, declaration = FALSE, 
 
   # Clean xml files from x namespace. Otherwise all nodes might look like
   # <x:node/> and not <node/>. https://github.com/JanMarvin/openxlsx2/pull/213
-  has_x_ns = isTRUE(options()[["openxlsx2.has_x_namespace"]])
+  has_x_ns <- isTRUE(options()[["openxlsx2.has_x_namespace"]])
   if (has_x_ns && isfile && !isvml) {
 
     xml_file <- stringi::stri_join(

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -200,10 +200,10 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
       op <- options("openxlsx2.namespace_x" = TRUE)
       on.exit(options(op), add = TRUE)
       out <- paste0(
-        "File has x namespace. We correct this for you, but be careful.\n",
+        "This file was slightly modified to import it. It should be fine, but be careful.\n",
         "This is somewhat experimental.."
       )
-      message(out)
+      warning(out)
       workbook_xml <- read_xml(workbookXML, escapes = TRUE)
     }
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -196,6 +196,17 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     # escape
     workbook_xml <- read_xml(workbookXML, escapes = TRUE)
 
+    if (length(xml_node_name(workbook_xml, stringi::stri_join("x:workbook")))) {
+      op <- options("openxlsx2.has_x_namespace" = TRUE)
+      on.exit(options(op), add = TRUE)
+      out <- paste0(
+        "File has x namespace. We correct this for you, but be careful.\n",
+        "This is somewhat experimental.."
+      )
+      message(out)
+      workbook_xml <- read_xml(workbookXML, escapes = TRUE)
+    }
+
     wb$workbook$fileVersion <- xml_node(workbook_xml, "workbook", "fileVersion")
     wb$workbook$alternateContent <- xml_node(workbook_xml, "workbook", "mc:AlternateContent")
     wb$workbook$bookViews <- xml_node(workbook_xml, "workbook", "bookViews")

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -8,6 +8,12 @@
 #'  strips the wbWorkbook to a bare minimum.
 #' @description  wb_load returns a workbook object conserving styles and
 #' formatting of the original .xlsx file.
+#' @details A warning is displayed if an xml namespace for main is found in the
+#' xlsx file. Certain xlsx files created by third-party applications contain a
+#' namespace (usually `x`). This namespace is not required for the file to work
+#' in spreadsheet software and is not expected by `openxlsx2`. Therefore it is
+#' removed when the file is loaded into a workbook. Removal is generally
+#' expected to be safe, but the feature is still experimental.
 #' @return Workbook object.
 #' @export
 #' @seealso [wb_remove_worksheet()]
@@ -196,14 +202,19 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     # escape
     workbook_xml <- read_xml(workbookXML, escapes = TRUE)
 
-    if (length(xml_node_name(workbook_xml, stringi::stri_join("x:workbook")))) {
-      op <- options("openxlsx2.namespace_x" = TRUE)
+    xml_name <- xml_node_name(workbook_xml)[1]
+
+    if (xml_name != "workbook") {
+      xml_ns <- stringi::stri_split_fixed(xml_name, ":")[[1]][[1]]
+      op <- options("openxlsx2.namespace_xml" = xml_ns)
       on.exit(options(op), add = TRUE)
-      out <- paste0(
-        "This file was slightly modified to import it. It should be fine, but be careful.\n",
-        "This is somewhat experimental.."
+      msg <- paste0(
+        "The `{%s}` namespace(s) has been removed from the xml files, for example:\n",
+        "\t<%s:field> changed to:\n",
+        "\t<field>\n",
+        "See 'Details' in ?openxlsx2::wb_load() for more information."
       )
-      warning(out)
+      warning(sprintf(msg, xml_ns, xml_ns))
       workbook_xml <- read_xml(workbookXML, escapes = TRUE)
     }
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -197,7 +197,7 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     workbook_xml <- read_xml(workbookXML, escapes = TRUE)
 
     if (length(xml_node_name(workbook_xml, stringi::stri_join("x:workbook")))) {
-      op <- options("openxlsx2.has_x_namespace" = TRUE)
+      op <- options("openxlsx2.namespace_x" = TRUE)
       on.exit(options(op), add = TRUE)
       out <- paste0(
         "File has x namespace. We correct this for you, but be careful.\n",

--- a/man/wb_load.Rd
+++ b/man/wb_load.Rd
@@ -24,6 +24,14 @@ Workbook object.
 wb_load returns a workbook object conserving styles and
 formatting of the original .xlsx file.
 }
+\details{
+A warning is displayed if an xml namespace for main is found in the
+xlsx file. Certain xlsx files created by third-party applications contain a
+namespace (usually \code{x}). This namespace is not required for the file to work
+in spreadsheet software and is not expected by \code{openxlsx2}. Therefore it is
+removed when the file is loaded into a workbook. Removal is generally
+expected to be safe, but the feature is still experimental.
+}
 \examples{
 ## load existing workbook from package folder
 wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -340,6 +340,6 @@ test_that("load file with x namespace", {
     wb <- wb_load(fl),
     "File has x namespace. We correct this for you, but be careful."
   )
-  expect_false(isTRUE(options()[["openxlsx2.has_x_namespace"]]))
+  expect_false(getOption("openxlsx2.namespace_x", default = FALSE))
 
 })

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -331,15 +331,3 @@ test_that("vml target is updated on load", {
   expect_equal(exp, got)
 
 })
-
-test_that("load file with x namespace", {
-
-  fl <- "https://github.com/ycphs/openxlsx/files/8480120/2022-04-12-11-42-36-DP_Melanges1.xlsx"
-
-  expect_warning(
-    wb <- wb_load(fl),
-    "This file was slightly modified to import it. It should be fine, but be careful."
-  )
-  expect_false(getOption("openxlsx2.namespace_x", default = FALSE))
-
-})

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -336,9 +336,9 @@ test_that("load file with x namespace", {
 
   fl <- "https://github.com/ycphs/openxlsx/files/8480120/2022-04-12-11-42-36-DP_Melanges1.xlsx"
 
-  expect_message(
+  expect_warning(
     wb <- wb_load(fl),
-    "File has x namespace. We correct this for you, but be careful."
+    "This file was slightly modified to import it. It should be fine, but be careful."
   )
   expect_false(getOption("openxlsx2.namespace_x", default = FALSE))
 

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -331,3 +331,15 @@ test_that("vml target is updated on load", {
   expect_equal(exp, got)
 
 })
+
+test_that("load file with x namespace", {
+
+  fl <- "https://github.com/ycphs/openxlsx/files/8480120/2022-04-12-11-42-36-DP_Melanges1.xlsx"
+
+  expect_message(
+    wb <- wb_load(fl),
+    "File has x namespace. We correct this for you, but be careful."
+  )
+  expect_false(isTRUE(options()[["openxlsx2.has_x_namespace"]]))
+
+})

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -354,3 +354,23 @@ test_that("xml_node_create", {
   expect_identical(xml_exp, xml_got)
 
 })
+
+test_that("works with x namespace", {
+
+  # create artificial xml file that will trigger x namespace removal
+  tmp <- tempfile(fileext = ".xml")
+  xml <- '<?xml xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ?><x:a><x:b/></x:a>'
+  writeLines(xml, tmp)
+
+  exp <- "<x:a><x:b/></x:a>"
+  got <- read_xml(tmp, pointer = FALSE)
+  expect_equal(exp, got)
+
+  op <- options("openxlsx2.has_x_namespace" = TRUE)
+  on.exit(options(op), add = TRUE)
+
+  exp <- "<a><b/></a>"
+  got <- read_xml(tmp, pointer = FALSE)
+  expect_equal(exp, got)
+
+})

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -366,7 +366,7 @@ test_that("works with x namespace", {
   got <- read_xml(tmp, pointer = FALSE)
   expect_equal(exp, got)
 
-  op <- options("openxlsx2.has_x_namespace" = TRUE)
+  op <- options("openxlsx2.namespace_x" = TRUE)
   on.exit(options(op), add = TRUE)
 
   exp <- "<a><b/></a>"

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -366,7 +366,7 @@ test_that("works with x namespace", {
   got <- read_xml(tmp, pointer = FALSE)
   expect_equal(exp, got)
 
-  op <- options("openxlsx2.namespace_x" = TRUE)
+  op <- options("openxlsx2.namespace_xml" = "x")
   on.exit(options(op), add = TRUE)
 
   exp <- "<a><b/></a>"

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -191,3 +191,15 @@ test_that("reading charts", {
   expect_equal("", wb$drawings_rels[[21]])
 
 })
+
+test_that("load file with xml namespace", {
+
+  fl <- "https://github.com/ycphs/openxlsx/files/8480120/2022-04-12-11-42-36-DP_Melanges1.xlsx"
+
+  expect_warning(
+    wb <- wb_load(fl),
+    "has been removed from the xml files, for example"
+  )
+  expect_null(getOption("openxlsx2.namespace_xml"))
+
+})


### PR DESCRIPTION
allow reading files with x namespace

## what was the motivation for this PR?

This fixes import for files created by third party software as seen in https://github.com/ycphs/openxlsx/issues/344.

Maybe one of you can test this @Matpli, @elinw? You can build this branch using:

```R
remotes::install_github("JanMarvin/openxlsx2", ref = "gh_issue_213")
```

## what does this PR do?

I have taken the initial #213 and created a few more safeguards to make sure that we do not have to check every xml file we import. 

1. Instead now we only check if we find `x:workbook` in `/xl/workbook.xml` 
1. If TRUE set `options("openxlsx2.has_x_namespace" = TRUE)`
1. If this option is true we read the file into R
1. If this string is found `xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"`, we will remove the `x` namespace from the input
1. We let the user know that this is somewhat experimental and largely untested

It works with the example file provided by @Matpli and if I save this file I can open it in MS365. But this file is quite large so if anyone can provide a smaller example file, that would be great.
