### PR TITLE
handle customXml folder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 ## Fixes
 
+* Implement reading `customXml` folder for input files with connection. [419](https://github.com/JanMarvin/openxlsx2/pull/419)
+
 * Fixed saving files with `<sheetPr/>` tag. Previously this was wrapped in a second `sheetPr` node. This issue occurs with xlsm files only. [417](https://github.com/JanMarvin/openxlsx2/pull/417)
 
 * Fixed a case where embedded files were assigned incorrectly in worksheet relationships. This caused corrupted output. [403](https://github.com/JanMarvin/openxlsx2/pull/403)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6059,31 +6059,6 @@ wbWorkbook <- R6::R6Class(
         }
       }
 
-
-      if (length(self$workbook$definedNames)) {
-        # TODO consider self$get_sheet_names() which orders the sheet names?
-        sheets <- self$sheet_names[self$sheetOrder]
-
-        belongTo <- get_named_regions(self)
-        belongTo <- belongTo$sheets[belongTo$value != "table"]
-
-        ## sheets is in re-ordered order (order it will be displayed)
-        newId <- match(belongTo, sheets) - 1L
-        oldId <- as.integer(reg_match0(self$workbook$definedNames, '(?<= localSheetId=")[0-9]+'))
-
-        for (i in seq_along(self$workbook$definedNames)) {
-          if (!is.na(newId[i])) {
-            self$workbook$definedNames[[i]] <-
-              gsub(
-                sprintf('localSheetId=\"%s\"', oldId[i]),
-                sprintf('localSheetId=\"%s\"', newId[i]),
-                self$workbook$definedNames[[i]],
-                fixed = TRUE
-              )
-          }
-        }
-      }
-
       ## update workbook r:id to match reordered workbook.xml.rels externalLink element
       if (length(extRefInds)) {
         newInds <- seq_along(extRefInds) + length(sheetInds)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -30,6 +30,9 @@ wbWorkbook <- R6::R6Class(
     #' @field isChartSheet isChartSheet
     isChartSheet = logical(),
 
+    #' @field customXml customXml
+    customXml = NULL,
+
     #' @field connections connections
     connections = NULL,
 
@@ -1443,6 +1446,17 @@ wbWorkbook <- R6::R6Class(
       ## connections
       if (length(self$connections)) {
         write_file(body = self$connections, fl = file.path(xlDir, "connections.xml"))
+      }
+
+      if (length(self$customXml)) {
+        customXmlDir     <- dir_create(tmpDir, "customXml")
+        customXmlRelsDir <- dir_create(tmpDir, "customXml", "_rels")
+        for (fl in self$customXml[!grepl(".xml.rels$", self$customXml)]) {
+          file.copy(fl, customXmlDir, overwrite = TRUE)
+        }
+        for (fl in self$customXml[grepl(".xml.rels$", self$customXml)]) {
+          file.copy(fl, customXmlRelsDir, overwrite = TRUE)
+        }
       }
 
       ## externalLinks
@@ -5938,6 +5952,7 @@ wbWorkbook <- R6::R6Class(
       stylesInd        <- grep("styles\\.xml",                               self$workbook.xml.rels)
       themeInd         <- grep("theme/theme[0-9]+.xml",                      self$workbook.xml.rels)
       connectionsInd   <- grep("connections.xml",                            self$workbook.xml.rels)
+      customXMLInd     <- grep("customXml/item[0-9].xml",                    self$workbook.xml.rels)
       extRefInds       <- grep("externalLinks/externalLink[0-9]+.xml",       self$workbook.xml.rels)
       sharedStringsInd <- grep("sharedStrings.xml",                          self$workbook.xml.rels)
       tableInds        <- grep("table[0-9]+.xml",                            self$workbook.xml.rels)
@@ -5956,6 +5971,7 @@ wbWorkbook <- R6::R6Class(
           extRefInds,
           themeInd,
           connectionsInd,
+          customXMLInd,
           stylesInd,
           sharedStringsInd,
           tableInds,

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -144,6 +144,8 @@ create_border
 
 \item{\code{isChartSheet}}{isChartSheet}
 
+\item{\code{customXml}}{customXml}
+
 \item{\code{connections}}{connections}
 
 \item{\code{Content_Types}}{Content_Types}

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -194,6 +194,8 @@ test_that("reading charts", {
 
 test_that("load file with xml namespace", {
 
+  skip_if_offline()
+
   fl <- "https://github.com/ycphs/openxlsx/files/8480120/2022-04-12-11-42-36-DP_Melanges1.xlsx"
 
   expect_warning(
@@ -203,7 +205,6 @@ test_that("load file with xml namespace", {
   expect_null(getOption("openxlsx2.namespace_xml"))
 
 })
-
 
 test_that("reading file with macro and custom xml", {
 
@@ -222,5 +223,26 @@ test_that("reading file with macro and custom xml", {
   exp <- "<Properties xmlns=\"http://schemas.openxmlformats.org/officeDocument/2006/custom-properties\" xmlns:vt=\"http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes\"><property fmtid=\"{D5CDD505-2E9C-101B-9397-08002B2CF9AE}\" pid=\"2\" name=\"Source\"><vt:lpwstr>openxlsx2</vt:lpwstr></property></Properties>"
   got <- wb$custom
   expect_equal(exp, got)
+})
+
+test_that("load file with connection", {
+
+  skip_if_offline()
+
+  temp <- temp_xlsx()
+
+  wb <- wb_load("https://github.com/JanMarvin/openxlsx-data/raw/main/connection.xlsx")
+
+  expect_true(!is.null(wb$customXml))
+  expect_equal(3, length(wb$customXml))
+
+  wb$save(temp)
+
+  wb <- wb_load(temp)
+  expect_equal(3, length(wb$customXml))
+
+  expect_true(grepl("customXml/_rels/item1.xml.rels", wb$customXml[1]))
+  expect_true(grepl("customXml/item1.xml", wb$customXml[2]))
+  expect_true(grepl("customXml/itemProps1.xml", wb$customXml[3]))
 
 })


### PR DESCRIPTION
Connections created with powerquery use a top level folder `customXml`. This was previously ignored.

* [x] update NEWS

@nicojx this might solve your issue with disappearing connections