### PR TITLE
Enforce `fullCalcOnLoad`. closes #427

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@
 
 * Fixed a case where embedded files were assigned incorrectly in worksheet relationships. This caused corrupted output. [403](https://github.com/JanMarvin/openxlsx2/pull/403)
 
+## Breaking changes
+
+* Previously if a loaded workbook contained formulas pointing to cells modified by `openxlsx2`, these formulas were not updated, once the workbook was opened in spreadsheet software. This is now enforced, unless the option `openxlsx2.disableFullCalcOnLoad` is set. In this case we would respect the original calculation properties of the  workbook.
+
 
 ***************************************************************************
 

--- a/R/baseXML.R
+++ b/R/baseXML.R
@@ -108,6 +108,7 @@ genBaseWorkbook <- function() {
     fileSharing = NULL,
     workbookPr = '<workbookPr date1904="false"/>',
     alternateContent = NULL,
+    revisionPtr = NULL,
     absPath = NULL, # "x15ac:absPath"
     workbookProtection = NULL,
     bookViews = NULL,

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5978,6 +5978,7 @@ wbWorkbook <- R6::R6Class(
       sharedStringsInd <- grep("sharedStrings.xml",                          self$workbook.xml.rels)
       tableInds        <- grep("table[0-9]+.xml",                            self$workbook.xml.rels)
       personInds       <- grep("person.xml",                                 self$workbook.xml.rels)
+      calcChainInd     <- grep("calcChain.xml",                              self$workbook.xml.rels)
 
 
       ## Reordering of workbook.xml.rels
@@ -5996,7 +5997,8 @@ wbWorkbook <- R6::R6Class(
           stylesInd,
           sharedStringsInd,
           tableInds,
-          personInds
+          personInds,
+          calcChainInd
         )]
 
       ## Re assign rIds to children of workbook.xml.rels

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1696,10 +1696,10 @@ wbWorkbook <- R6::R6Class(
       # workbook order, therefore we have to make sure that the expected order is written.
       # Othterwise spreadsheet software will complain.
       workbook_openxml281 <- c(
-        "fileVersion", "fileSharing", "workbookPr", "alternateContent", "absPath", "workbookProtection",
-        "bookViews", "sheets", "functionGroups", "externalReferences", "definedNames", "calcPr",
-        "oleSize", "customWorkbookViews", "pivotCaches", "smartTagPr", "smartTagTypes", "webPublishing",
-        "fileRecoveryPr", "webPublishObjects", "extLst"
+        "fileVersion", "fileSharing", "workbookPr", "alternateContent", "revisionPtr", "absPath",
+        "workbookProtection", "bookViews", "sheets", "functionGroups", "externalReferences",
+        "definedNames", "calcPr", "oleSize", "customWorkbookViews", "pivotCaches", "smartTagPr",
+        "smartTagTypes", "webPublishing", "fileRecoveryPr", "webPublishObjects", "extLst"
       )
 
       write_file(

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -316,7 +316,7 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     calcPr <- xml_node(workbook_xml, "workbook", "calcPr")
     if (!data_only && length(calcPr)) {
       # we override the default unless explicitly requested
-      if (is.null(getOption("openxlsx2.disableFullCalcOnLoad"))) {
+      if (!(getOption("openxlsx2.disableFullCalcOnLoad", default = FALSE))) {
         calcPr <- xml_attr_mod(calcPr, c(fullCalcOnLoad = "1"))
       }
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -316,7 +316,7 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     calcPr <- xml_node(workbook_xml, "workbook", "calcPr")
     if (!data_only && length(calcPr)) {
       # we override the default unless explicitly requested
-      if (!getOption("openxlsx2.disableFullCalcOnLoad")) {
+      if (is.null(getOption("openxlsx2.disableFullCalcOnLoad"))) {
         calcPr <- xml_attr_mod(calcPr, c(fullCalcOnLoad = "1"))
       }
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -311,8 +311,15 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
       wb$workbook$revisionPtr <- revisionPtr
     }
 
+    # no clue what calcPr does. If a calcChain is available, this prevents
+    # formulas from getting reevaluated unless they are visited manually.
     calcPr <- xml_node(workbook_xml, "workbook", "calcPr")
     if (!data_only && length(calcPr)) {
+      # we override the default unless explicitly requested
+      if (!getOption("openxlsx2.disableFullCalcOnLoad")) {
+        calcPr <- xml_attr_mod(calcPr, c(fullCalcOnLoad = "1"))
+      }
+
       wb$workbook$calcPr <- calcPr
     }
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -306,6 +306,11 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
     }
 
     ## additional workbook attributes
+    revisionPtr <- xml_node(workbook_xml, "workbook", "xr:revisionPtr")
+    if (!data_only && length(revisionPtr)) {
+      wb$workbook$revisionPtr <- revisionPtr
+    }
+
     calcPr <- xml_node(workbook_xml, "workbook", "calcPr")
     if (!data_only && length(calcPr)) {
       wb$workbook$calcPr <- calcPr

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -387,9 +387,15 @@ wb_load <- function(file, xlsxFile = NULL, sheet, data_only = FALSE) {
       "Content_Types",
       '<Override PartName="/xl/calcChain.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.calcChain+xml"/>'
     )
+
+    ## workbook rels
+    wb$append(
+      "workbook.xml.rels",
+      sprintf('<Relationship Id="rId%s" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain" Target="calcChain.xml"/>',
+        length(wb$workbook.xml.rels) + 1
+      )
+    )
   }
-
-
 
   ## xl\sharedStrings
   if (length(sharedStringsXML)) {

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -312,11 +312,23 @@ test_that("loading slicers works", {
     "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet2.xml\"/>",
     "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet3.xml\"/>",
     "<Relationship Id=\"rId0\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet4.xml\"/>",
+    "<Relationship Id=\"rId8\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain\" Target=\"calcChain.xml\"/>",
     "<Relationship Id=\"rId20001\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition\" Target=\"pivotCache/pivotCacheDefinition1.xml\"/>",
     "<Relationship Id=\"rId20002\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition\" Target=\"pivotCache/pivotCacheDefinition2.xml\"/>",
     "<Relationship Id=\"rId100001\" Type=\"http://schemas.microsoft.com/office/2007/relationships/slicerCache\" Target=\"slicerCaches/slicerCache1.xml\"/>"
   )
   got <- wb$workbook.xml.rels
+  expect_equal(exp, got)
+
+  exp <- "<calcPr calcId=\"152511\" fullCalcOnLoad=\"1\"/>"
+  got <- wb$workbook$calcPr
+  expect_equal(exp, got)
+
+  options("openxlsx2.disableFullCalcOnLoad" = TRUE)
+  wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
+
+  exp <- "<calcPr calcId=\"152511\"/>"
+  got <- wb$workbook$calcPr
   expect_equal(exp, got)
 
 })


### PR DESCRIPTION
If a formula in a workbook originally created by Excel refers to a cell modified by `openxlsx2`, the formula was not recalculated when loaded in Excel. The formula was update only if the cell was visited and Enter was hit. This was hard to spot could easily result in errors. This was solved enforcing [`fullCalcOnLoad`](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.calculationproperties.fullcalculationonload?view=openxml-2.8.1).

This also brings `revisionPtr` simply to reduce visual differences when comparing two files.