### PR TITLE
[wb_add_data] fix double escapes. fixes #436x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 ## Fixes
 
+* Fix double xml escaping when saving. [435](https://github.com/JanMarvin/openxlsx2/pull/435)
+
 * Minor tweak for POSIXct dates and try to avoid the notorious 29Feb1900. [424](https://github.com/JanMarvin/openxlsx2/pull/424)
 
 * Implement reading `customXml` folder for input files with connection. [419](https://github.com/JanMarvin/openxlsx2/pull/419)

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -306,7 +306,7 @@ void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame 
         break;
       case character:
         cell.c_t = "inlineStr";
-        cell.is  = txt_to_is(vals, 0, 1, 1);
+        cell.is  = txt_to_is(vals, 1, 1, 1);
         break;
       case hyperlink:
       case formula:

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -330,3 +330,24 @@ test_that("write & load file with chartsheet", {
   expect_silent(wb2 <- wb_load(temp))
 
 })
+
+test_that("escaping of inlinestrings works", {
+
+  temp <- temp_xlsx()
+  wb <- wb_workbook()$
+    add_worksheet("Test")$
+    add_data(dims = "A1", x = "A & B")$
+    save(temp)
+
+  exp <- "A & B"
+  got <- wb_to_df(wb, colNames = FALSE)$A
+  expect_equal(exp, got)
+
+  got <- wb_to_df(temp, colNames = FALSE)$A
+  expect_equal(exp, got)
+
+  wb2 <- wb_load(temp)
+  got <- wb_to_df(wb2, colNames = FALSE)$A
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Previously we escaped when writing to the workbook and when saving the workbook as file, we were escaping a second time.