### PR TITLE
improve print options. closes #393

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* Improve print options. Defaults to printing grid lines, if the worksheet contains grid lines. [440](https://github.com/JanMarvin/openxlsx2/pull/440)
+
 * Support reading files with form control. [426](https://github.com/JanMarvin/openxlsx2/pull/426)
 
 * Handle input files with chart extensions. [443](https://github.com/JanMarvin/openxlsx2/pull/443)

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -1196,15 +1196,16 @@ wb_protect <- function(
 #' @param wb A workbook object
 #' @param sheet A name or index of a worksheet
 #' @param show A logical. If `FALSE`, grid lines are hidden.
+#' @param print A logical. If `FALSE`, grid lines are not printed.
 #' @export
 #' @examples
 #' wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
 #' wb$get_sheet_names() ## list worksheets in workbook
 #' wb$grid_lines(1, show = FALSE)
 #' wb$grid_lines("testing", show = FALSE)
-wb_grid_lines <- function(wb, sheet = current_sheet(), show = FALSE) {
+wb_grid_lines <- function(wb, sheet = current_sheet(), show = FALSE, print = show) {
   assert_workbook(wb)
-  wb$clone()$grid_lines(sheet = sheet, show = show)
+  wb$clone()$grid_lines(sheet = sheet, show = show, print = print)
 }
 
 # TODO hide gridlines?

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4103,24 +4103,23 @@ wbWorkbook <- R6::R6Class(
     #' @description grid lines
     #' @param sheet sheet
     #' @param show show
+    #' @param print print
     #' @returns The `wbWorkbook` object
-    grid_lines = function(sheet = current_sheet(), show = FALSE) {
+    grid_lines = function(sheet = current_sheet(), show = FALSE, print = show) {
       sheet <- private$get_sheet_index(sheet)
 
-      if (!is.logical(show)) {
-        stop("show must be a logical")
-      }
+      assert_class(show, "logical")
+      assert_class(print, "logical")
 
+      ## show
       sv <- self$worksheets[[sheet]]$sheetViews
-      show <- as.integer(show)
-      ## If attribute exists gsub
-      if (grepl("showGridLines", sv)) {
-        sv <- gsub('showGridLines=".?[^"]', sprintf('showGridLines="%s', show), sv, perl = TRUE)
-      } else {
-        sv <- gsub("<sheetView ", sprintf('<sheetView showGridLines="%s" ', show), sv)
-      }
-
+      sv <- xml_attr_mod(sv, c(showGridLines = as_xml_attr(show)))
       self$worksheets[[sheet]]$sheetViews <- sv
+
+      ## print
+      if (print)
+        self$worksheets[[sheet]]$set_print_options(gridLines = print, gridLinesSet = print)
+
       invisible(self)
     },
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -510,7 +510,8 @@ wbWorkbook <- R6::R6Class(
           paperSize   = paperSize,
           orientation = orientation,
           hdpi        = hdpi,
-          vdpi        = vdpi
+          vdpi        = vdpi,
+          printGridLines = gridLines
         )
       )
 

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -505,6 +505,25 @@ wbWorksheet <- R6::R6Class(
       invisible(self)
     },
 
+    add_print_options = function(
+        gridLines          = NULL,
+        gridLinesSet       = NULL,
+        headings           = NULL,
+        horizontalCentered = NULL,
+        verticalCentered   = NULL
+    ) {
+      self$printOptions <- xml_node_create(
+        xml_name = "printOptions",
+        xml_attributes = c(
+          gridLines          = as_xml_attr(gridLines),
+          gridLinesSet       = as_xml_attr(gridLinesSet),
+          headings           = as_xml_attr(headings),
+          horizontalCentered = as_xml_attr(horizontalCentered),
+          verticalCentered   = as_xml_attr(verticalCentered)
+        )
+      )
+    },
+
     #' @description append a field.  Intended for internal use only.  Not
     #'   guaranteed to remain a public method.
     #' @param field a field name

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -148,6 +148,7 @@ wbWorksheet <- R6::R6Class(
     #' @param orientation orientation
     #' @param hdpi hdpi
     #' @param vdpi vdpi
+    #' @param printGridLines printGridLines
     #' @return a `wbWorksheet` object
     initialize = function(
       tabColour   = NULL,
@@ -160,7 +161,8 @@ wbWorksheet <- R6::R6Class(
       paperSize   = 9,
       orientation = "portrait",
       hdpi        = 300,
-      vdpi        = 300
+      vdpi        = 300,
+      printGridLines = gridLines
     ) {
       if (!is.null(tabColour)) {
         tabColour <- sprintf('<sheetPr><tabColor rgb="%s"/></sheetPr>', tabColour)
@@ -179,6 +181,11 @@ wbWorksheet <- R6::R6Class(
 
       if (all(lengths(hf) == 0)) {
         hf <- list()
+      }
+
+      # only add if printGridLines not TRUE. The openxml default is TRUE
+      if (printGridLines) {
+       self$set_print_options(gridLines = printGridLines, gridLinesSet = printGridLines)
       }
 
       ## list of all possible children
@@ -314,6 +321,7 @@ wbWorksheet <- R6::R6Class(
           )
         },
 
+        self$printOptions,
         self$pageMargins,
         self$pageSetup,
 
@@ -505,7 +513,14 @@ wbWorksheet <- R6::R6Class(
       invisible(self)
     },
 
-    add_print_options = function(
+    #' @description add print options
+    #' @param gridLines gridLines
+    #' @param gridLinesSet gridLinesSet
+    #' @param headings If TRUE prints row and column headings
+    #' @param horizontalCentered If TRUE the page is horizontally centered
+    #' @param verticalCentered If TRUE the page is vertically centered
+    #' @returns The `wbWorksheet` object
+    set_print_options = function(
         gridLines          = NULL,
         gridLinesSet       = NULL,
         headings           = NULL,

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -162,7 +162,7 @@ wbWorksheet <- R6::R6Class(
       orientation = "portrait",
       hdpi        = 300,
       vdpi        = 300,
-      printGridLines = gridLines
+      printGridLines = FALSE
     ) {
       if (!is.null(tabColour)) {
         tabColour <- sprintf('<sheetPr><tabColor rgb="%s"/></sheetPr>', tabColour)

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,7 +117,6 @@ as_binary <- function(x) {
   as.integer(x)
 }
 
-
 as_xml_attr <- function(x) {
   if (inherits(x, "logical")) {
     x <- as_binary(x)

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -1847,7 +1847,7 @@ remove filters
 \subsection{Method \code{grid_lines()}}{
 grid lines
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$grid_lines(sheet = current_sheet(), show = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$grid_lines(sheet = current_sheet(), show = FALSE, print = show)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1856,6 +1856,8 @@ grid lines
 \item{\code{sheet}}{sheet}
 
 \item{\code{show}}{show}
+
+\item{\code{print}}{print}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wbWorksheet.Rd
+++ b/man/wbWorksheet.Rd
@@ -5,6 +5,8 @@
 \title{R6 class for a Workbook Worksheet}
 \value{
 The \code{wbWorksheet} object
+
+The \code{wbWorksheet} object
 }
 \description{
 R6 class for a Workbook Worksheet
@@ -109,6 +111,7 @@ A Worksheet
 \item \href{#method-wbWorksheet-fold_cols}{\code{wbWorksheet$fold_cols()}}
 \item \href{#method-wbWorksheet-clean_sheet}{\code{wbWorksheet$clean_sheet()}}
 \item \href{#method-wbWorksheet-add_page_break}{\code{wbWorksheet$add_page_break()}}
+\item \href{#method-wbWorksheet-set_print_options}{\code{wbWorksheet$set_print_options()}}
 \item \href{#method-wbWorksheet-append}{\code{wbWorksheet$append()}}
 \item \href{#method-wbWorksheet-add_sparklines}{\code{wbWorksheet$add_sparklines()}}
 \item \href{#method-wbWorksheet-set_sheetview}{\code{wbWorksheet$set_sheetview()}}
@@ -132,7 +135,8 @@ Creates a new \code{wbWorksheet} object
   paperSize = 9,
   orientation = "portrait",
   hdpi = 300,
-  vdpi = 300
+  vdpi = 300,
+  printGridLines = gridLines
 )}\if{html}{\out{</div>}}
 }
 
@@ -160,6 +164,8 @@ Creates a new \code{wbWorksheet} object
 \item{\code{hdpi}}{hdpi}
 
 \item{\code{vdpi}}{vdpi}
+
+\item{\code{printGridLines}}{printGridLines}
 }
 \if{html}{\out{</div>}}
 }
@@ -278,6 +284,37 @@ add page break
 \item{\code{row}}{row}
 
 \item{\code{col}}{col}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-wbWorksheet-set_print_options"></a>}}
+\if{latex}{\out{\hypertarget{method-wbWorksheet-set_print_options}{}}}
+\subsection{Method \code{set_print_options()}}{
+add print options
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{wbWorksheet$set_print_options(
+  gridLines = NULL,
+  gridLinesSet = NULL,
+  headings = NULL,
+  horizontalCentered = NULL,
+  verticalCentered = NULL
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{gridLines}}{gridLines}
+
+\item{\code{gridLinesSet}}{gridLinesSet}
+
+\item{\code{headings}}{If TRUE prints row and column headings}
+
+\item{\code{horizontalCentered}}{If TRUE the page is horizontally centered}
+
+\item{\code{verticalCentered}}{If TRUE the page is vertically centered}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wbWorksheet.Rd
+++ b/man/wbWorksheet.Rd
@@ -136,7 +136,7 @@ Creates a new \code{wbWorksheet} object
   orientation = "portrait",
   hdpi = 300,
   vdpi = 300,
-  printGridLines = gridLines
+  printGridLines = FALSE
 )}\if{html}{\out{</div>}}
 }
 

--- a/man/wb_grid_lines.Rd
+++ b/man/wb_grid_lines.Rd
@@ -4,7 +4,7 @@
 \alias{wb_grid_lines}
 \title{Set worksheet gridlines to show or hide.}
 \usage{
-wb_grid_lines(wb, sheet = current_sheet(), show = FALSE)
+wb_grid_lines(wb, sheet = current_sheet(), show = FALSE, print = show)
 }
 \arguments{
 \item{wb}{A workbook object}
@@ -12,6 +12,8 @@ wb_grid_lines(wb, sheet = current_sheet(), show = FALSE)
 \item{sheet}{A name or index of a worksheet}
 
 \item{show}{A logical. If \code{FALSE}, grid lines are hidden.}
+
+\item{print}{A logical. If \code{FALSE}, grid lines are not printed.}
 }
 \description{
 Set worksheet gridlines to show or hide.

--- a/tests/testthat/test-class-worksheet.R
+++ b/tests/testthat/test-class-worksheet.R
@@ -78,6 +78,33 @@ test_that("set_sheetview", {
   wb <- wb_workbook()$add_worksheet()
 
   got <- wb$worksheets[[1]]$sheetViews
+
+  expect_equal(exp, got)
+
+})
+
+test_that("print options work", {
+
+  temp <- temp_xlsx()
+
+  wb <- wb_workbook() %>%
+    wb_add_worksheet(gridLines = FALSE) %>%
+    wb_add_data(x = iris) %>%
+    wb_add_worksheet(gridLines = TRUE) %>%
+    wb_add_data(x = mtcars)
+
+  exp <- character()
+  got <- wb$worksheets[[1]]$printOptions
+  expect_equal(exp, got)
+
+  exp <- "<printOptions gridLines=\"1\" gridLinesSet=\"1\"/>"
+  got <- wb$worksheets[[2]]$printOptions
+  expect_equal(exp, got)
+
+  wb$save(temp)
+  wb <- wb_load(temp)
+
+  got <- wb$worksheets[[2]]$printOptions
   expect_equal(exp, got)
 
 })


### PR DESCRIPTION
Only visible change is seen when printing in spreadsheet software that supports openxml [`<printOptions/>`](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.printoptions?view=openxml-2.8.1).