### PR TITLE
Fix fill merged cells

### DIFF
--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -616,6 +616,11 @@ wb_to_df <- function(
       for (i in seq_along(mc)) {
         dms <- dims_to_dataframe(mc[i])
 
+        # Skip if merged cell is empty
+        if(all(is.na(z[rownames(z) %in% rownames(dms),
+                       colnames(z) %in% colnames(dms)])))
+          next
+
         z[rownames(z) %in% rownames(dms),
           colnames(z) %in% colnames(dms)] <- z[rownames(z) %in% rownames(dms[1, 1, drop = FALSE]),
                                                colnames(z) %in% colnames(dms[1, 1, drop = FALSE])]

--- a/tests/testthat/test-fill_merged_cells.R
+++ b/tests/testthat/test-fill_merged_cells.R
@@ -46,3 +46,25 @@ test_that("merge and unmerge cells", {
   expect_silent(wb$merge_cells(rows = 1:2, cols = 1:2))
 
 })
+
+test_that("fill merged NA cells", {
+  wb <- wb_workbook()
+  wb$add_worksheet("sheet1")
+  wb$add_data(1, t(matrix(c(1:3, NA_real_), 4, 4)), startRow = 3, startCol = 1, colNames = FALSE)
+
+  wb$merge_cells(1, rows = 1:4, cols = 4)
+
+  tmp_file <- temp_xlsx()
+  wb_save(wb, tmp_file)
+
+  r1 <- t(matrix(c(1:3, NA_real_), 4, 4))
+  expect_equal(as.matrix(read_xlsx(tmp_file, fillMergedCells = FALSE,
+                                   rowNames = FALSE, colNames = FALSE)),
+               r1,
+               ignore_attr = TRUE)
+
+  expect_equal(as.matrix(read_xlsx(tmp_file, fillMergedCells = TRUE,
+                                   rowNames = FALSE, colNames = FALSE)),
+               r1,
+               ignore_attr = TRUE)
+})


### PR DESCRIPTION
Hi @JanMarvin,

i found a minor problem while reading merged cells. If the merged area only contains NA values the import fails with an error. I saw this error in combination with startRow (after selecting a different startRow the merged cells became all NA)

```
library(openxlsx2)
library(testthat)

wb <- wb_workbook()
wb$add_worksheet("sheet1")
wb$add_data(1, t(matrix(c(1:3, NA_real_), 4, 4)), startRow = 3, startCol = 1, colNames = FALSE)

wb$merge_cells(1, rows = 1:4, cols = 4)

tmp_file <- temp_xlsx()
wb_save(wb, tmp_file)

# runs fine
read_xlsx(tmp_file, fillMergedCells = FALSE)

# Error in x[[jj]][iseq] <- vjj : replacement has length zero
read_xlsx(tmp_file, fillMergedCells = TRUE)
```

A simple solution is checking if the merged cells are all NA and skip this cell range. I created a pull request with a possible solution and a new test.