### PR TITLE
add calc_chain argument to wb_load. closes #432 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openxlsx2 (in development)
 
+## New features
+
+* Provide new argument `calc_chain` to `wb_load()`. This is set to `FALSE` per default, to ignore the calculation chain if it is found. This change only reflects files imported from third party spreadsheet software and should not be visible to the user. [461](https://github.com/JanMarvin/openxlsx2/pull/461)
+
 ## Fixes
 
 * Previously, adding mscharts to sheets was only possible if (1) the worksheet already contained a drawing (if the workbook was loaded) or (2) to the last sheet of the workbook. This has now been fixed. Adding mscharts to any worksheet in the workbook is now possible as intended. [458](https://github.com/JanMarvin/openxlsx2/pull/458)

--- a/man/wb_load.Rd
+++ b/man/wb_load.Rd
@@ -4,7 +4,7 @@
 \alias{wb_load}
 \title{Load an existing .xlsx file}
 \usage{
-wb_load(file, xlsxFile = NULL, sheet, data_only = FALSE)
+wb_load(file, xlsxFile = NULL, sheet, data_only = FALSE, calc_chain = FALSE)
 }
 \arguments{
 \item{file}{A path to an existing .xlsx or .xlsm file}
@@ -16,6 +16,13 @@ sheet will be loaded.}
 
 \item{data_only}{mode to import if only a data frame should be returned. This
 strips the wbWorkbook to a bare minimum.}
+
+\item{calc_chain}{optionally you can keep the calculation chain intact. This
+is used by spreadsheet software to identify the order in which formulas are
+evaluated. Removing the calculation chain is considered harmless. The calc
+chain will be created upon the next time the worksheet is loaded in
+spreadsheet software. Keeping it, might only speed loading time in said
+software.}
 }
 \value{
 Workbook object.

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -342,6 +342,20 @@ test_that("loading slicers works", {
   got <- wb$workbook$calcPr
   expect_null(got)
 
+  exp <- character()
+  got <- wb$calcChain
+  expect_equal(exp, got)
+
+  # check the default once again
+  wb <- wb_load(file = fl)
+
+  got <- wb$workbook$calcPr
+  expect_null(got)
+
+  exp <- character()
+  got <- wb$calcChain
+  expect_equal(exp, got)
+
 })
 
 test_that("vml target is updated on load", {

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -302,7 +302,12 @@ test_that("Sheet not found", {
 
 test_that("loading slicers works", {
 
-  wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
+  fl <- system.file("extdata", "loadExample.xlsx", package = "openxlsx2")
+  wb <- wb_load(file = fl, calc_chain = TRUE)
+
+  exp <- "<calcPr calcId=\"152511\" fullCalcOnLoad=\"1\"/>"
+  got <- wb$workbook$calcPr
+  expect_equal(exp, got)
 
   exp <- c(
     "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>",
@@ -320,16 +325,22 @@ test_that("loading slicers works", {
   got <- wb$workbook.xml.rels
   expect_equal(exp, got)
 
-  exp <- "<calcPr calcId=\"152511\" fullCalcOnLoad=\"1\"/>"
-  got <- wb$workbook$calcPr
-  expect_equal(exp, got)
+  wb <- wb_load(file = fl, calc_chain = FALSE)
+  got <- wb$workbook.xml.rels
+  expect_equal(exp[-8], got)
+
 
   options("openxlsx2.disableFullCalcOnLoad" = TRUE)
-  wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
+  wb <- wb_load(file = fl, calc_chain = TRUE)
 
   exp <- "<calcPr calcId=\"152511\"/>"
   got <- wb$workbook$calcPr
   expect_equal(exp, got)
+
+  wb <- wb_load(file = fl, calc_chain = FALSE)
+
+  got <- wb$workbook$calcPr
+  expect_null(got)
 
 })
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -255,14 +255,19 @@ test_that("calcChain is updated", {
 
   fl <- "https://github.com/JanMarvin/openxlsx-data/raw/main/overwrite_formula.xlsx"
 
-  wb <- wb_load(fl, calc_chain = TRUE)$
-    add_data(dims = "A1", x = "Formula overwritten")
+  wb <- wb_load(fl, calc_chain = TRUE)
 
-  exp <- character()
+  exp <- "<calcChain xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><c r=\"A1\" i=\"1\" l=\"1\"/></calcChain>"
   got <- wb$calcChain
   expect_equal(exp, got)
 
   expect_silent(wb$save(temp))
+
+  wb$add_data(dims = "A1", x = "Formula overwritten")
+
+  exp <- character()
+  got <- wb$calcChain
+  expect_equal(exp, got)
 
 })
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -251,6 +251,8 @@ test_that("calcChain is updated", {
 
   skip_if_offline()
 
+  temp <- temp_xlsx()
+
   fl <- "https://github.com/JanMarvin/openxlsx-data/raw/main/overwrite_formula.xlsx"
 
   wb <- wb_load(fl, calc_chain = TRUE)$
@@ -259,6 +261,8 @@ test_that("calcChain is updated", {
   exp <- character()
   got <- wb$calcChain
   expect_equal(exp, got)
+
+  expect_silent(wb$save(temp))
 
 })
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -253,7 +253,7 @@ test_that("calcChain is updated", {
 
   fl <- "https://github.com/JanMarvin/openxlsx-data/raw/main/overwrite_formula.xlsx"
 
-  wb <- wb_load(fl)$
+  wb <- wb_load(fl, calc_chain = TRUE)$
     add_data(dims = "A1", x = "Formula overwritten")
 
   exp <- character()

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -269,6 +269,8 @@ test_that("calcChain is updated", {
   got <- wb$calcChain
   expect_equal(exp, got)
 
+  expect_silent(wb$save(temp))
+
 })
 
 test_that("read workbook with chart extension", {


### PR DESCRIPTION
Previously I wanted to improve calculation chain modifications in #432, but they remain a nuisance. Therefore this PR adds a new argument `calc_chain` to `wb_load()` to entirely ignore loading the calculation chain, which will be the default.

Basically
* the sheet id in the calculation chain must not match our internal sheet id. Adding or removing sheets on our end might change the id. Therefore if the user overwrites a cell in the calculation chain, we might update the wrong calculation chain cell. Ergo: unless someone puts in some work to really improve this situation, our way of dealing with the file remains error prone and will leave the user with the usual useless Excel error message.
* The calculation chain is only partially supported in other spreadsheet software. LibreOffice supports only a fraction, Numbers simply ignores it.

@nicojx This PR should fix the issue you mailed me about.