### PR TITLE
Group depending on outlinePr

### DIFF
--- a/tests/testthat/test-outlines.R
+++ b/tests/testthat/test-outlines.R
@@ -29,7 +29,7 @@ test_that("group columns", {
 
   exp <- c(
     "<col min=\"1\" max=\"1\" collapsed=\"1\" hidden=\"1\" outlineLevel=\"1\" width=\"8.43\"/>",
-    "<col min=\"2\" max=\"2\" bestFit=\"1\" collapsed=\"1\" customWidth=\"1\" width=\"18.711\"/>",
+    "<col min=\"2\" max=\"2\" bestFit=\"1\" collapsed=\"1\" customWidth=\"1\" hidden=\"false\" width=\"18.711\"/>",
     "<col min=\"3\" max=\"3\" bestFit=\"1\" customWidth=\"1\" hidden=\"false\" width=\"18.711\"/>"
   )
   got <- wb$worksheets[[1]]$cols_attr
@@ -136,5 +136,103 @@ test_that("ungroup rows", {
 
   got <- wb$worksheets[[1]]$sheet_data$row_attr$outlineLevel
   expect_true(all(got == ""))
+
+})
+
+test_that("with outlinePr", {
+
+  # create matrix
+  t1 <- AirPassengers
+  t2 <- do.call(cbind, split(t1, cycle(t1)))
+  dimnames(t2) <- dimnames(.preformat.ts(t1))
+
+  wb <- wb_workbook()
+  wb$add_worksheet("AirPass")
+  wb$add_data("AirPass", t2, rowNames = TRUE)
+
+  wb$worksheets[[1]]$sheetPr <-
+    xml_node_create(
+      "sheetPr",
+      xml_children = c(
+        xml_node_create(
+          "outlinePr",
+          xml_attributes = c(
+            summaryBelow = "0",
+            summaryRight = "0"
+          )
+        )
+      ))
+
+  # groups will always end on/show the last row. in the example 1950, 1955, and 1960
+  wb <- wb_group_rows(wb, "AirPass", 2:3, collapsed = TRUE) # group years < 1950
+  wb <- wb_group_rows(wb, "AirPass", 4:8, collapsed = TRUE) # group years 1951-1955
+  wb <- wb_group_rows(wb, "AirPass", 9:13)                  # group years 1956-1960
+
+  wb$createCols("AirPass", 13)
+
+  wb <- wb_group_cols(wb, "AirPass", 2:4, collapsed = TRUE)
+  wb <- wb_group_cols(wb, "AirPass", 5:7, collapsed = TRUE)
+  wb <- wb_group_cols(wb, "AirPass", 8:10, collapsed = TRUE)
+  wb <- wb_group_cols(wb, "AirPass", 11:13)
+
+
+  exp <- c(
+    "<col min=\"2\" max=\"2\" collapsed=\"1\" width=\"8.43\"/>",
+    "<col min=\"3\" max=\"4\" collapsed=\"1\" hidden=\"1\" outlineLevel=\"1\" width=\"8.43\"/>"
+  )
+  got <- wb$worksheets[[1]]$cols_attr[2:3]
+  expect_equal(exp, got)
+
+  exp <- c("", "1")
+  got <- wb$worksheets[[1]]$sheet_data$row_attr$outlineLevel[2:3]
+  expect_equal(exp, got)
+
+  ### with group levels
+  grp_rows <- list(
+    "1" = seq(2, 3),
+    "2" = seq(4, 8),
+    "3" = seq(9, 13)
+  )
+
+  grp_cols <- list(
+    "1" = seq(2, 4),
+    "2" = seq(5, 7),
+    "3" = seq(8, 10),
+    "4" = seq(11, 13)
+  )
+
+  wb <- wb_workbook()
+  wb$add_worksheet("AirPass")
+  wb$add_data("AirPass", t2, rowNames = TRUE)
+
+  wb$worksheets[[1]]$sheetPr <-
+    xml_node_create(
+      "sheetPr",
+      xml_children = c(
+        xml_node_create(
+          "outlinePr",
+          xml_attributes = c(
+            summaryBelow = "0",
+            summaryRight = "0"
+          )
+        )
+      ))
+
+  wb$createCols("AirPass", 13)
+
+  wb$group_cols("AirPass", cols = grp_cols)
+  wb$group_rows("AirPass", rows = grp_rows)
+
+  exp <- c(
+    "<col min=\"2\" max=\"2\" collapsed=\"0\" width=\"8.43\"/>",
+    "<col min=\"3\" max=\"4\" collapsed=\"0\" hidden=\"0\" outlineLevel=\"1\" width=\"8.43\"/>"
+  )
+  got <- wb$worksheets[[1]]$cols_attr[2:3]
+  expect_equal(exp, got)
+
+  exp <- c("", "1")
+  got <- wb$worksheets[[1]]$sheet_data$row_attr$outlineLevel[2:3]
+  expect_equal(exp, got)
+
 
 })


### PR DESCRIPTION
group above/below or left/right, depending on the worksheet outlinePr. Currently this only works with the current worksheet value to avoid strange grouping results and there is no internal function to set this.