### PR TITLE
fix tab selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * Fix reading and saving workbooks with multiple slicers per sheet. [505](https://github.com/JanMarvin/openxlsx2/pull/505)
 
+* Fix tab selection always selecting the first sheet since #303. [506](https://github.com/JanMarvin/openxlsx2/pull/506)
+
 ## Breaking changes
 
 * Do not export `write_data2()` anymore. This was used in development in the early stages of the package and should not be used directly anymore.

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6474,9 +6474,8 @@ wbWorkbook <- R6::R6Class(
         )
 
       # Failsafe: hidden sheet can not be selected.
-      self$worksheets[[visible_sheet_index]]$set_sheetview(tabSelected = TRUE)
-      if (nSheets > 1) {
-        for (i in setdiff(seq_len(nSheets), visible_sheet_index)) {
+      if (any(hidden)) {
+        for (i in which(hidden)) {
           self$worksheets[[i]]$set_sheetview(tabSelected = FALSE)
         }
       }

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -368,3 +368,17 @@ test_that("vml target is updated on load", {
   expect_equal(exp, got)
 
 })
+
+test_that("sheetView is not switched", {
+
+  wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
+
+  exp <- "<sheetViews><sheetView workbookViewId=\"0\"/></sheetViews>"
+  got <- wb$worksheets[[1]]$sheetViews
+  expect_equal(exp, got)
+
+  exp <- "<sheetViews><sheetView tabSelected=\"1\" workbookViewId=\"0\"/></sheetViews>"
+  got <- wb$worksheets[[2]]$sheetViews
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Previously this would select sheet one per default in certain cases. Related to #399 . Similar to #505  fixing old code parts, that were never understood, but updated and fixed incorrectly.

```R
wb <- wb_load(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx2"))
wb$get_sheet_names() # list worksheets
wb ## view object
```