### PR TITLE
fix diagonal in create border

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4758,20 +4758,23 @@ wbWorkbook <- R6::R6Class(
     #' wb$add_border(1, dims = "A2:K33", inner_vgrid = "thin", inner_vcolor = c(rgb="FF808080"))
     #' @return The `wbWorksheetObject`, invisibly
     add_border = function(
-      sheet         = current_sheet(),
-      dims          = "A1",
-      bottom_color  = wb_colour(hex = "FF000000"),
-      left_color    = wb_colour(hex = "FF000000"),
-      right_color   = wb_colour(hex = "FF000000"),
-      top_color     = wb_colour(hex = "FF000000"),
-      bottom_border = "thin",
-      left_border   = "thin",
-      right_border  = "thin",
-      top_border    = "thin",
-      inner_hgrid   = NULL,
-      inner_hcolor  = NULL,
-      inner_vgrid   = NULL,
-      inner_vcolor  = NULL
+      sheet          = current_sheet(),
+      dims           = "A1",
+      bottom_color   = wb_colour(hex = "FF000000"),
+      left_color     = wb_colour(hex = "FF000000"),
+      right_color    = wb_colour(hex = "FF000000"),
+      top_color      = wb_colour(hex = "FF000000"),
+      bottom_border  = "thin",
+      left_border    = "thin",
+      right_border   = "thin",
+      top_border     = "thin",
+      inner_hgrid    = NULL,
+      inner_hcolor   = NULL,
+      inner_vgrid    = NULL,
+      inner_vcolor   = NULL,
+      diagonal_down  = NULL,
+      diagonal_up    = NULL,
+      diagonal_color = NULL
     ) {
 
       # TODO merge styles and if a style is already present, only add the newly
@@ -4790,7 +4793,9 @@ wbWorkbook <- R6::R6Class(
         top = top_border, top_color = top_color,
         bottom = bottom_border, bottom_color = bottom_color,
         left = left_border, left_color = left_color,
-        right = right_border, right_color = right_color
+        right = right_border, right_color = right_color,
+        diagonal_up = diagonal_up, diagonal_down = diagonal_down,
+        diagonal_color = diagonal_color
       )
 
       top_single <- create_border(

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4772,9 +4772,9 @@ wbWorkbook <- R6::R6Class(
       inner_hcolor   = NULL,
       inner_vgrid    = NULL,
       inner_vcolor   = NULL,
-      diagonal_down  = NULL,
-      diagonal_up    = NULL,
-      diagonal_color = NULL
+      diagonal       = NULL,
+      diagonal_color = NULL,
+      diagonal_type  = NULL
     ) {
 
       # TODO merge styles and if a style is already present, only add the newly
@@ -4794,8 +4794,8 @@ wbWorkbook <- R6::R6Class(
         bottom = bottom_border, bottom_color = bottom_color,
         left = left_border, left_color = left_color,
         right = right_border, right_color = right_color,
-        diagonal_up = diagonal_up, diagonal_down = diagonal_down,
-        diagonal_color = diagonal_color
+        diagonal = diagonal, diagonal_color = diagonal_color,
+        diagonal_type = diagonal_type
       )
 
       top_single <- create_border(

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -97,7 +97,8 @@ import_styles <- function(x) {
 #' @param outline x
 #' @param bottom X
 #' @param bottom_color X
-#' @param diagonal X
+#' @param diagonal_up X
+#' @param diagonal_down X
 #' @param diagonal_color X,
 #' @param end x,
 #' @param horizontal x
@@ -117,7 +118,8 @@ create_border <- function(
     outline = "",
     bottom = NULL,
     bottom_color = NULL,
-    diagonal = NULL,
+    diagonal_up = NULL,
+    diagonal_down = NULL,
     diagonal_color = NULL,
     end = "",
     horizontal = "",
@@ -138,11 +140,14 @@ create_border <- function(
   if (!is.null(diagonal_color)) diagonal_color <- xml_node_create("color", xml_attributes = diagonal_color)
 
   # excel dies on style=\"\"
-  if (!is.null(left))     left     <- c(style = left)
-  if (!is.null(right))    right    <- c(style = right)
-  if (!is.null(top))      top      <- c(style = top)
-  if (!is.null(bottom))   bottom   <- c(style = bottom)
-  if (!is.null(diagonal)) diagonal <- c(style = diagonal)
+  if (!is.null(left))          left     <- c(style = left)
+  if (!is.null(right))         right    <- c(style = right)
+  if (!is.null(top))           top      <- c(style = top)
+  if (!is.null(bottom))        bottom   <- c(style = bottom)
+  # there is only one diagonal: up or down
+  diagonal <- NULL
+  if (!is.null(diagonal_down)) diagonal <- c(style = diagonal_down)
+  if (!is.null(diagonal_up))   diagonal <- c(style = diagonal_up)
 
   left     <- xml_node_create("left", xml_children = left_color, xml_attributes = left)
   right    <- xml_node_create("right", xml_children = right_color, xml_attributes = right)
@@ -157,15 +162,26 @@ create_border <- function(
     right = right,
     top = top,
     bottom = bottom,
-    diagonalDown = diagonalDown,
-    diagonalUp = diagonalUp,
     diagonal = diagonal,
     vertical = vertical,
     horizontal = horizontal,
-    outline = outline, # unknown position in border
+    outline = outline, # attribute
     stringsAsFactors = FALSE
   )
   border <- write_border(df_border)
+  if (!is.null(diagonal_up) || !is.null(diagonal_down)) {
+
+    if (!is.null(diagonal_up))   diagonal_up   <- "1"
+    if (!is.null(diagonal_down)) diagonal_down <- "1"
+
+    border <- xml_attr_mod(
+      border,
+      xml_attributes = c(
+        diagonalDown = diagonal_down,
+        diagonalUp = diagonal_up
+      )
+    )
+  }
 
   return(border)
 }

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -92,14 +92,11 @@ import_styles <- function(x) {
 #' @description
 #' Border styles can any of the following: "thin", "thick", "slantDashDot", "none", "mediumDashed", "mediumDashDot", "medium", "hair", "double", "dotted", "dashed", "dashedDotDot", "dashDot"
 #' Border colors are of the following type: c(rgb="FF000000")
-#' @param diagonalDown x
-#' @param diagonalUp x
-#' @param outline x
 #' @param bottom X
 #' @param bottom_color X
 #' @param diagonal_up X
-#' @param diagonal_down X
 #' @param diagonal_color X,
+#' @param diagonal_type c("up", "down")
 #' @param end x,
 #' @param horizontal x
 #' @param left x
@@ -113,14 +110,12 @@ import_styles <- function(x) {
 #'
 #' @export
 create_border <- function(
-    diagonalDown = "",
-    diagonalUp = "",
-    outline = "",
+    # outline = "",
     bottom = NULL,
     bottom_color = NULL,
-    diagonal_up = NULL,
-    diagonal_down = NULL,
+    diagonal = NULL,
     diagonal_color = NULL,
+    diagonal_type = NULL,
     end = "",
     horizontal = "",
     left = NULL,
@@ -140,14 +135,11 @@ create_border <- function(
   if (!is.null(diagonal_color)) diagonal_color <- xml_node_create("color", xml_attributes = diagonal_color)
 
   # excel dies on style=\"\"
-  if (!is.null(left))          left     <- c(style = left)
-  if (!is.null(right))         right    <- c(style = right)
-  if (!is.null(top))           top      <- c(style = top)
-  if (!is.null(bottom))        bottom   <- c(style = bottom)
-  # there is only one diagonal: up or down
-  diagonal <- NULL
-  if (!is.null(diagonal_down)) diagonal <- c(style = diagonal_down)
-  if (!is.null(diagonal_up))   diagonal <- c(style = diagonal_up)
+  if (!is.null(left))     left     <- c(style = left)
+  if (!is.null(right))    right    <- c(style = right)
+  if (!is.null(top))      top      <- c(style = top)
+  if (!is.null(bottom))   bottom   <- c(style = bottom)
+  if (!is.null(diagonal)) diagonal <- c(style = diagonal)
 
   left     <- xml_node_create("left", xml_children = left_color, xml_attributes = left)
   right    <- xml_node_create("right", xml_children = right_color, xml_attributes = right)
@@ -165,14 +157,17 @@ create_border <- function(
     diagonal = diagonal,
     vertical = vertical,
     horizontal = horizontal,
-    outline = outline, # attribute
     stringsAsFactors = FALSE
   )
   border <- write_border(df_border)
-  if (!is.null(diagonal_up) || !is.null(diagonal_down)) {
 
-    if (!is.null(diagonal_up))   diagonal_up   <- "1"
-    if (!is.null(diagonal_down)) diagonal_down <- "1"
+  # diagonalDown, diagonalUp and outline (only draw border around cell region)
+  # are attributes to the border node
+  if (length(diagonal_type)) {
+    diagonal_down <- NULL
+    diagonal_up   <- NULL
+    if (any(diagonal_type == "down")) diagonal_down <- "1"
+    if (any(diagonal_type == "up"))   diagonal_up   <- "1"
 
     border <- xml_attr_mod(
       border,


### PR DESCRIPTION
We can have one line style and either up, down or both.

```R
wb <- wb_workbook()$add_worksheet()$
  add_border(dims = "A1", diagonal = "medium", diagonal_type = c("down"))$
  add_border(dims = "A2", diagonal = "medium", diagonal_type = c("up"))$
  add_border(dims = "A3", diagonal = "medium", diagonal_type = c("down", "up"))$
  add_border(dims = "A4")
```

Probably `diagonal`, `diagonal_color` and `diagonal_type = c("up", "down")` would be a better way to approach this.