### PR TITLE
[wb_add_data] string_nums option. closes #503

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,13 @@
 
 * Add `wb_copy_cells()` a wrapper that allows copying cell ranges in a workbook as direct copy, as reference or as value. [515](https://github.com/JanMarvin/openxlsx2/pull/515)
 
+* Experimental option: `openxlsx2.string_nums` to write string numerics differently. A string numeric is a numeric in a string like: `as.character(1.5)`. The option can be
+  * 0 = the current default. Writes string numeric as string (the incorrect way according to spreadsheet software)
+  * 1 = writes string numeric as numeric with a character flag (the correct way according to spreadsheet software)
+  * 2 = convert all string numeric to numeric when writing
+  
+  This is experimental, because the impact is somewhat unknown. It might trigger unintended side effects. Feedback is requested.
+
 ## Fixes
 
 * Reading of files with frozen panes and more than one section node was restored. [495](https://github.com/JanMarvin/openxlsx2/pull/495)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,8 +29,8 @@ long_to_wide <- function(z, tt, zz) {
     invisible(.Call(`_openxlsx2_long_to_wide`, z, tt, zz))
 }
 
-wide_to_long <- function(z, vtyps, zz, ColNames, start_col, start_row, ref) {
-    invisible(.Call(`_openxlsx2_wide_to_long`, z, vtyps, zz, ColNames, start_col, start_row, ref))
+wide_to_long <- function(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums) {
+    invisible(.Call(`_openxlsx2_wide_to_long`, z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums))
 }
 
 #' @param colnames a vector of the names of the data frame

--- a/R/openxlsx2.R
+++ b/R/openxlsx2.R
@@ -78,5 +78,6 @@ openxlsx2_celltype <- c(
   comma          = 9,
   hyperlink      = 10,
   array_formula  = 11,
-  factor         = 12
+  factor         = 12,
+  string_nums    = 13
 )

--- a/R/write.R
+++ b/R/write.R
@@ -296,7 +296,7 @@ write_data2 <- function(
     data[sel][is.na(data[sel])] <- "_openxlsx_NA"
   }
 
-  string_nums <- getOption("openxlsx2.string_nums", default = FALSE)
+  string_nums <- getOption("openxlsx2.string_nums", default = 0)
 
   wide_to_long(
     data,
@@ -408,9 +408,9 @@ write_data2 <- function(
     }
 
     if (any(dc == openxlsx2_celltype[["character"]])) {
-      if (any(cc$typ == "6")) {
+      if (any(sel <- cc$typ == openxlsx2_celltype[["string_nums"]])) {
 
-        dim_sel <- paste0(cc$r[cc$typ == "6"], collapse = ";")
+        dim_sel <- paste0(cc$r[sel], collapse = ";")
 
         wb$add_cell_style(
           sheet = sheetno,

--- a/R/write.R
+++ b/R/write.R
@@ -93,7 +93,7 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
   }
 
   replacement <- c("r", cell_style, "c_t", "c_cm", "c_ph", "c_vm", "v",
-                   "f", "f_t", "f_ref", "f_ca", "f_si", "is")
+                   "f", "f_t", "f_ref", "f_ca", "f_si", "is", "typ")
 
   sel <- match(x$r, cc$r)
   cc[sel, replacement] <- x[replacement]
@@ -296,6 +296,8 @@ write_data2 <- function(
     data[sel][is.na(data[sel])] <- "_openxlsx_NA"
   }
 
+  string_nums <- getOption("openxlsx2.string_nums", default = FALSE)
+
   wide_to_long(
     data,
     dc,
@@ -303,7 +305,8 @@ write_data2 <- function(
     ColNames = colNames,
     start_col = startCol,
     start_row = startRow,
-    ref = dims
+    ref = dims,
+    string_nums = string_nums
   )
 
   # if any v is missing, set typ to 'e'. v is only filled for non character
@@ -402,6 +405,21 @@ write_data2 <- function(
           name = wb_get_base_font(wb)$name$val,
           u = "single"
       )
+    }
+
+    if (any(dc == openxlsx2_celltype[["character"]])) {
+      if (any(cc$typ == "6")) {
+
+        dim_sel <- paste0(cc$r[cc$typ == "6"], collapse = ";")
+
+        wb$add_cell_style(
+          sheet = sheetno,
+          dim = dim_sel,
+          applyNumberFormat = "1",
+          quotePrefix = "1",
+          numFmtId = "49"
+        )
+      }
     }
 
     # options("openxlsx2.numFmt" = NULL)

--- a/R/write.R
+++ b/R/write.R
@@ -410,7 +410,10 @@ write_data2 <- function(
     if (any(dc == openxlsx2_celltype[["character"]])) {
       if (any(sel <- cc$typ == openxlsx2_celltype[["string_nums"]])) {
 
-        dim_sel <- paste0(cc$r[sel], collapse = ";")
+        # # we cannot select every cell like this, because it is terribly slow.
+        # dim_sel <- paste0(cc$r[sel], collapse = ";")
+        dim_sel <- get_data_class_dims("character")
+        # message("character: ", dim_sel)
 
         wb$add_cell_style(
           sheet = sheetno,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -92,7 +92,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // wide_to_long
-void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, bool string_nums);
+void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, int32_t string_nums);
 RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -103,7 +103,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int32_t >::type start_col(start_colSEXP);
     Rcpp::traits::input_parameter< int32_t >::type start_row(start_rowSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type ref(refSEXP);
-    Rcpp::traits::input_parameter< bool >::type string_nums(string_numsSEXP);
+    Rcpp::traits::input_parameter< int32_t >::type string_nums(string_numsSEXP);
     wide_to_long(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums);
     return R_NilValue;
 END_RCPP

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -92,8 +92,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // wide_to_long
-void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref);
-RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP) {
+void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, bool string_nums);
+RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::DataFrame >::type z(zSEXP);
@@ -103,7 +103,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int32_t >::type start_col(start_colSEXP);
     Rcpp::traits::input_parameter< int32_t >::type start_row(start_rowSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type ref(refSEXP);
-    wide_to_long(z, vtyps, zz, ColNames, start_col, start_row, ref);
+    Rcpp::traits::input_parameter< bool >::type string_nums(string_numsSEXP);
+    wide_to_long(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums);
     return R_NilValue;
 END_RCPP
 }
@@ -820,7 +821,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_copy", (DL_FUNC) &_openxlsx2_copy, 1},
     {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 3},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
-    {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 7},
+    {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 8},
     {"_openxlsx2_create_char_dataframe", (DL_FUNC) &_openxlsx2_create_char_dataframe, 2},
     {"_openxlsx2_col_to_df", (DL_FUNC) &_openxlsx2_col_to_df, 1},
     {"_openxlsx2_df_to_xml", (DL_FUNC) &_openxlsx2_df_to_xml, 2},

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -280,7 +280,7 @@ bool is_double(std::string x) {
 // [[Rcpp::export]]
 void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz,
                   bool ColNames, int32_t start_col, int32_t start_row,
-                  Rcpp::CharacterVector ref, bool string_nums) {
+                  Rcpp::CharacterVector ref, int32_t string_nums) {
 
   auto n = z.nrow();
   auto m = z.ncol();
@@ -323,7 +323,11 @@ void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame 
       case character:
         if (string_nums && is_double(vals)) {
           cell.v   = vals;
-          vtyp = 6;
+          if (string_nums == 1) {
+            vtyp = string_num;
+          } else {
+            vtyp = numeric;
+          }
         } else {
           cell.c_t = "inlineStr";
           cell.is  = txt_to_is(vals, 0, 1, 1);

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -54,7 +54,8 @@ enum celltype {
   comma          = 9,
   hyperlink      = 10,
   array_formula  = 11,
-  factor         = 12
+  factor         = 12,
+  string_num     = 13
 };
 
 // check for 1.0.8.0

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -324,15 +324,31 @@ test_that("writeData() forces evaluation of x (#264)", {
 
 test_that("write character numerics with a correct cell style", {
 
-  options("openxlsx2.string_nums" = TRUE)
+  ## current default
+  options("openxlsx2.string_nums" = 0)
+
+  wb <- wb_workbook() %>%
+    wb_add_worksheet() %>%
+    wb_add_data(x = c("One", "2", "Three", "1.7976931348623157E+309", "2.5"))
+
+  exp <- NA_character_
+  got <- wb$styles_mgr$styles$cellXfs[2]
+  expect_equal(exp, got)
+
+  exp <- c("4", "4", "4", "4", "4")
+  got <- wb$worksheets[[1]]$sheet_data$cc$typ
+  expect_equal(exp, got)
+
+  ## string numerics correctly flagged
+  options("openxlsx2.string_nums" = 1)
 
   wb <- wb_workbook() %>%
     wb_add_worksheet() %>%
     wb_add_data(x = c("One", "2", "Three", "1.7976931348623157E+309", "2.5")) %>%
     wb_add_worksheet() %>%
     wb_add_data(dims = "A1", x = "1992") %>%
-    wb_add_data(dims = "A2", x = 1992)%>%
-    wb_add_data(dims = "A3", x = "1992.a")%>%
+    wb_add_data(dims = "A2", x = 1992) %>%
+    wb_add_data(dims = "A3", x = "1992.a") %>%
     wb_add_worksheet() %>%
     wb_add_data(dims = "A1", x = 1e5) %>%
     wb_add_data(dims = "A2", x = "1e5") %>%
@@ -343,16 +359,31 @@ test_that("write character numerics with a correct cell style", {
   got <- wb$styles_mgr$styles$cellXfs[2]
   expect_equal(exp, got)
 
-  exp <- c("4", "6", "4", "4", "6")
+  exp <- c("4", "13", "4", "4", "13")
   got <- wb$worksheets[[1]]$sheet_data$cc$typ
   expect_equal(exp, got)
 
-  exp <- c("6", "2", "4")
+  exp <- c("13", "2", "4")
   got <- wb$worksheets[[2]]$sheet_data$cc$typ
   expect_equal(exp, got)
 
-  exp <- c("2", "6", "2", "6")
+  exp <- c("2", "13", "2", "13")
   got <- wb$worksheets[[3]]$sheet_data$cc$typ
+  expect_equal(exp, got)
+
+  ## write string numerics as numerics (on the fly conversion)
+  options("openxlsx2.string_nums" = 2)
+
+  wb <- wb_workbook() %>%
+    wb_add_worksheet() %>%
+    wb_add_data(x = c("One", "2", "Three", "1.7976931348623157E+309", "2.5"))
+
+  exp <- NA_character_
+  got <- wb$styles_mgr$styles$cellXfs[2]
+  expect_equal(exp, got)
+
+  exp <- c("4", "2", "4", "4", "2")
+  got <- wb$worksheets[[1]]$sheet_data$cc$typ
   expect_equal(exp, got)
 
 })

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -11,7 +11,7 @@ test_that("write_formula", {
          v = "", f = "SUM(C2:C11*D2:D11)",
          f_t = "array", f_ref = "E2:E2",
          f_ca = "", f_si = "",
-         is = "", typ = ""),
+         is = "", typ = "11"),
     row.names = 23L, class = "data.frame")
 
   # write data add array formula later
@@ -236,7 +236,7 @@ test_that("update cell(s)", {
                         f_ca = c("", "", "", "", "", ""),
                         f_si = c("", "", "", "", "", ""),
                         is = c("", "", "", "", "", ""),
-                        typ = c("3", "", "", "", "", "")),
+                        typ = c("3", "3", "3", "3", "3", "3")),
                    row.names = c("1", "8", "17", "114", "121", "128"),
                    class = "data.frame")
   got <- head(wb$worksheets[[1]]$sheet_data$cc)
@@ -317,6 +317,42 @@ test_that("writeData() forces evaluation of x (#264)", {
     "<is><t>d</t></is>", "<is><t>e</t></is>", "<is><t>123.4</t></is>"
   )
   got <- unique(wb$worksheets[[1]]$sheet_data$cc$is)
+  expect_equal(exp, got)
+
+})
+
+
+test_that("write character numerics with a correct cell style", {
+
+  options("openxlsx2.string_nums" = TRUE)
+
+  wb <- wb_workbook() %>%
+    wb_add_worksheet() %>%
+    wb_add_data(x = c("One", "2", "Three", "1.7976931348623157E+309", "2.5")) %>%
+    wb_add_worksheet() %>%
+    wb_add_data(dims = "A1", x = "1992") %>%
+    wb_add_data(dims = "A2", x = 1992)%>%
+    wb_add_data(dims = "A3", x = "1992.a")%>%
+    wb_add_worksheet() %>%
+    wb_add_data(dims = "A1", x = 1e5) %>%
+    wb_add_data(dims = "A2", x = "1e5") %>%
+    wb_add_data(dims = "A3", x = 1e+05) %>%
+    wb_add_data(dims = "A4", x = "1e+05")
+
+  exp <- "<xf applyNumberFormat=\"1\" borderId=\"0\" fillId=\"0\" fontId=\"0\" numFmtId=\"49\" quotePrefix=\"1\" xfId=\"0\"/>"
+  got <- wb$styles_mgr$styles$cellXfs[2]
+  expect_equal(exp, got)
+
+  exp <- c("4", "6", "4", "4", "6")
+  got <- wb$worksheets[[1]]$sheet_data$cc$typ
+  expect_equal(exp, got)
+
+  exp <- c("6", "2", "4")
+  got <- wb$worksheets[[2]]$sheet_data$cc$typ
+  expect_equal(exp, got)
+
+  exp <- c("2", "6", "2", "6")
+  got <- wb$worksheets[[3]]$sheet_data$cc$typ
   expect_equal(exp, got)
 
 })


### PR DESCRIPTION
This PR provides a `string_nums` option for `openxlsx2` to control if strings that can be expressed as numerics should be written as styled numerics and not as character strings (e.g. `"1"` as `1`). ~~This does not provide on the fly conversions from strings to numerics (which ... would be possible as well; simply avoid writing the style to the cell).~~

This needs some testing (accuracy and speed) and for now I have hidden it with an option. This option knows states 0 (the current default), 1 (write string as number with cell style) and 2 (write string as number). The entire conversion part likely will have an impact on writing time, due to the call to `is_double()`.

``` r
library(openxlsx2)

dat <- data.frame(x = "2023", y = 2023)
wb <- wb_workbook()

options("openxlsx2.string_nums" = 1)

wb <- wb %>% 
  wb_add_worksheet() %>% 
  wb_add_data(x = dat)

options("openxlsx2.string_nums" = 0)

wb <-  wb %>% 
  wb_add_worksheet() %>% 
  wb_add_data(x = dat)
  

# new
str(wb_to_df(wb, 1))
#> 'data.frame':    1 obs. of  2 variables:
#>  $ x: num 2023
#>  $ y: num 2023
#>  - attr(*, "tt")='data.frame':   1 obs. of  2 variables:
#>   ..$ x: chr "n"
#>   ..$ y: chr "n"
#>  - attr(*, "types")= Named num [1:2] 1 1
#>   ..- attr(*, "names")= chr [1:2] "A" "B"

# old
str(wb_to_df(wb, 2))
#> 'data.frame':    1 obs. of  2 variables:
#>  $ x: chr "2023"
#>  $ y: num 2023
#>  - attr(*, "tt")='data.frame':   1 obs. of  2 variables:
#>   ..$ x: chr "s"
#>   ..$ y: chr "n"
#>  - attr(*, "types")= Named num [1:2] 0 1
#>   ..- attr(*, "names")= chr [1:2] "A" "B"
```

## Update
With the latest push on my Arch Linux desktop I see the following. It is quite fast, though I'm not sure about the effects of setting this style `applyNumberFormat = "1", quotePrefix = "1", numFmtId = "49"` on every character cell, if any cell requires  it. That somehow seems like overkill. Setting it only to those cells that need it, slows the example terribly down.

``` r
n <- 10000
k <- 10

mm <- matrix(rnorm(n = n * k), nrow = n, ncol = k)
mc <- matrix(as.character(mm), nrow = n, ncol = k)


library(openxlsx2)

wb <- wb_workbook()

t1 <- Sys.time()
options("openxlsx2.string_nums" = 0)
wb$add_worksheet()$add_data(x = mc)
t2 <- Sys.time()
options("openxlsx2.string_nums" = 1)
wb$add_worksheet()$add_data(x = mc)
t3 <- Sys.time()
options("openxlsx2.string_nums" = 2)
wb$add_worksheet()$add_data(x = mc)
t4 <- Sys.time()

t2 - t1 # initial matrix as character
#> Time difference of 0.6670108 secs
t3 - t2 # matrix as numeric with style
#> Time difference of 0.963567 secs
t4 - t3 # matrix as numeric
#> Time difference of 0.3893292 secs
```