### PR TITLE
Speedup add data pt3

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,8 +29,8 @@ long_to_wide <- function(z, tt, zz) {
     invisible(.Call(`_openxlsx2_long_to_wide`, z, tt, zz))
 }
 
-wide_to_long <- function(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, inline_strings) {
-    invisible(.Call(`_openxlsx2_wide_to_long`, z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, inline_strings))
+wide_to_long <- function(z, vtyps, ColNames, start_col, start_row, ref, string_nums, inline_strings) {
+    .Call(`_openxlsx2_wide_to_long`, z, vtyps, ColNames, start_col, start_row, ref, string_nums, inline_strings)
 }
 
 #' @param colnames a vector of the names of the data frame

--- a/R/write.R
+++ b/R/write.R
@@ -281,7 +281,7 @@ write_data2 <- function(
   rows_attr$r <- rownames(rtyp)
 
   # original cc data frame
-  cc <- empty_sheet_data_cc(n = nrow(data) * ncol(data))
+  # cc <- empty_sheet_data_cc(n = nrow(data) * ncol(data))
 
 
   sel <- which(dc == openxlsx2_celltype[["logical"]])
@@ -300,10 +300,9 @@ write_data2 <- function(
 
   string_nums <- getOption("openxlsx2.string_nums", default = 0)
 
-  wide_to_long(
+  cc <- wide_to_long(
     data,
     dc,
-    cc,
     ColNames = colNames,
     start_col = startCol,
     start_row = startRow,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -92,21 +92,21 @@ BEGIN_RCPP
 END_RCPP
 }
 // wide_to_long
-void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, int32_t string_nums, bool inline_strings);
-RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP, SEXP inline_stringsSEXP) {
+SEXP wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, int32_t string_nums, bool inline_strings);
+RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP, SEXP inline_stringsSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::DataFrame >::type z(zSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type vtyps(vtypsSEXP);
-    Rcpp::traits::input_parameter< Rcpp::DataFrame >::type zz(zzSEXP);
     Rcpp::traits::input_parameter< bool >::type ColNames(ColNamesSEXP);
     Rcpp::traits::input_parameter< int32_t >::type start_col(start_colSEXP);
     Rcpp::traits::input_parameter< int32_t >::type start_row(start_rowSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type ref(refSEXP);
     Rcpp::traits::input_parameter< int32_t >::type string_nums(string_numsSEXP);
     Rcpp::traits::input_parameter< bool >::type inline_strings(inline_stringsSEXP);
-    wide_to_long(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, inline_strings);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(wide_to_long(z, vtyps, ColNames, start_col, start_row, ref, string_nums, inline_strings));
+    return rcpp_result_gen;
 END_RCPP
 }
 // create_char_dataframe
@@ -833,7 +833,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_copy", (DL_FUNC) &_openxlsx2_copy, 1},
     {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 3},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
-    {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 9},
+    {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 8},
     {"_openxlsx2_create_char_dataframe", (DL_FUNC) &_openxlsx2_create_char_dataframe, 2},
     {"_openxlsx2_col_to_df", (DL_FUNC) &_openxlsx2_col_to_df, 1},
     {"_openxlsx2_df_to_xml", (DL_FUNC) &_openxlsx2_df_to_xml, 2},

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -65,6 +65,16 @@ enum celltype {
 #include <Rcpp.h>
 #endif
 
+#if CE_NATIVE == CE_UTF8
+inline std::string as_string(std::string str) {
+  return(str);
+}
+# else
+inline Rcpp::String as_string(std::string str) {
+  return(Rcpp::String(str));
+}
+#endif
+
 // custom wrap function
 // Converts the imported values from c++ std::vector<xml_col> to an R dataframe.
 // Whenever new fields are spotted they have to be added here
@@ -95,21 +105,21 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
 
   // struct to vector
   for (size_t i = 0; i < n; ++i) {
-    r[i] = Rcpp::String(x[i].r);
-    row_r[i] = Rcpp::String(x[i].row_r);
-    c_r[i]   = Rcpp::String(x[i].c_r);
-    c_s[i]   = Rcpp::String(x[i].c_s);
-    c_t[i]   = Rcpp::String(x[i].c_t);
-    c_cm[i]  = Rcpp::String(x[i].c_cm);
-    c_ph[i]  = Rcpp::String(x[i].c_ph);
-    c_vm[i]  = Rcpp::String(x[i].c_vm);
-    v[i]     = Rcpp::String(x[i].v);
-    f[i]     = Rcpp::String(x[i].f);
-    f_t[i]   = Rcpp::String(x[i].f_t);
-    f_ref[i] = Rcpp::String(x[i].f_ref);
-    f_ca[i]  = Rcpp::String(x[i].f_ca);
-    f_si[i]  = Rcpp::String(x[i].f_si);
-    is[i]    = Rcpp::String(x[i].is);
+    r[i]     = as_string(x[i].r);
+    row_r[i] = as_string(x[i].row_r);
+    c_r[i]   = as_string(x[i].c_r);
+    c_s[i]   = as_string(x[i].c_s);
+    c_t[i]   = as_string(x[i].c_t);
+    c_cm[i]  = as_string(x[i].c_cm);
+    c_ph[i]  = as_string(x[i].c_ph);
+    c_vm[i]  = as_string(x[i].c_vm);
+    v[i]     = as_string(x[i].v);
+    f[i]     = as_string(x[i].f);
+    f_t[i]   = as_string(x[i].f_t);
+    f_ref[i] = as_string(x[i].f_ref);
+    f_ca[i]  = as_string(x[i].f_ca);
+    f_si[i]  = as_string(x[i].f_si);
+    is[i]    = as_string(x[i].is);
   }
 
   // Assign and return a dataframe
@@ -141,7 +151,7 @@ inline SEXP wrap(const vec_string &x) {
   Rcpp::CharacterVector z(no_init(n));
 
   for (size_t i = 0; i < n; ++i) {
-    z[i] = Rcpp::String(x[i]);
+    z[i] = as_string(x[i]);
   }
 
   return Rcpp::wrap(z);

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -23,6 +23,7 @@ typedef struct {
   std::string f_ca;
   std::string f_si;
   std::string is;    // inlineStr
+  std::string typ;
 } xml_col;
 
 
@@ -103,6 +104,8 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
   Rcpp::CharacterVector f_si(no_init(n));      // <f si=""> attribute most likely sharedString
   Rcpp::CharacterVector is(no_init(n));        // <is> tag
 
+  Rcpp::CharacterVector typ(no_init(n));        // openxlsx2 typ
+
   // struct to vector
   for (size_t i = 0; i < n; ++i) {
     r[i]     = as_string(x[i].r);
@@ -119,7 +122,8 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
     f_ref[i] = as_string(x[i].f_ref);
     f_ca[i]  = as_string(x[i].f_ca);
     f_si[i]  = as_string(x[i].f_si);
-    is[i]    = as_string(x[i].is);
+    is[i]    = as_string(x[i].is);;
+    typ[i]   = as_string(x[i].typ);
   }
 
   // Assign and return a dataframe
@@ -138,7 +142,8 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
       Rcpp::Named("f_ref") = f_ref,
       Rcpp::Named("f_ca")  = f_ca,
       Rcpp::Named("f_si")  = f_si,
-      Rcpp::Named("is")    = is
+      Rcpp::Named("is")    = is,
+      Rcpp::Named("typ")   = typ
   )
   );
 }


### PR DESCRIPTION
further speedups.

This replaces the code used in `wide_to_long()` with the one used in `loadvals()`. This is generally quicker, but it is quicker due to not caring about the write order of the dataset. Basically this creates a vector of a vector of strings and returns a data frame. Each vector of strings is a column. All the vectors are the data frame.
This is faster than the previous approach where we create a data frame and assign the values of the data set in the correct order.

Replacing the original approach currently causes errors in the tests because the order is different than what the tests expect.

Overall, I have seen speed improvements of ~50% on larger data sets. However, our approach is not suitable for large data sets. Excel can handle n = 1,048,576 rows and k = 16,384 columns. I couldn't write more than a `n x 50` matrix of `1`s to a workbook on a 16GB machine. So this works:

```R
mm <- matrix(1, nrow = 1048576, ncol = 50)

library(openxlsx2)

wb <- wb_workbook()$add_worksheet()$add_data(x = mm, colNames = FALSE, applyCellStyle = FALSE)
```

The issue is that we have the initial data frame and pivot it longer, to create our `cc` data frame. Once this data frame is created, we can write it to xml. However, at this point we already have two big data frames and this story will not have a happy ending ...

If you want to write large amounts of data, you should use a binary format and a writer that transfers the data directly to the drive, or use a database. Use anything but open xml files.