### PR TITLE
skip ordering if cc is ordered

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6411,7 +6411,7 @@ wbWorkbook <- R6::R6Class(
 
 
           if (!is.null(cc)) {
-            cc$r <- stri_join(cc$c_r, cc$row_r)
+            cc$r <- stringi::stri_join(cc$c_r, cc$row_r)
             # prepare data for output
 
             # there can be files, where row_attr is incomplete because a row
@@ -6424,7 +6424,12 @@ wbWorkbook <- R6::R6Class(
             cc_rows <- ws$sheet_data$row_attr$r
             cc_out <- cc[cc$row_r %in% cc_rows, c("row_r", "c_r",  "r", "v", "c_t", "c_s", "c_cm", "c_ph", "c_vm", "f", "f_t", "f_ref", "f_ca", "f_si", "is")]
 
-            ws$sheet_data$cc_out <- cc_out[order(as.integer(cc_out[, "row_r"]), col2int(cc_out[, "c_r"])), ]
+            if (ws$is_ordered) {
+              ws$sheet_data$cc_out <- cc_out
+            } else {
+              ws$sheet_data$cc_out <- cc_out[order(as.integer(cc_out[, "row_r"]), col2int(cc_out[, "c_r"])), ]
+            }
+
           } else {
             ws$sheet_data$row_attr <- NULL
             ws$sheet_data$cc_out <- NULL

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -135,6 +135,9 @@ wbWorksheet <- R6::R6Class(
     #' @field webPublishItems webPublishItems
     webPublishItems = character(),
 
+    # @field is_ordered flag defining if the sheet needs ordering when saving
+    is_ordered = NULL,
+
     #' @description
     #' Creates a new `wbWorksheet` object
     #' @param tabColor tabColor
@@ -212,6 +215,7 @@ wbWorksheet <- R6::R6Class(
       self$extLst                <- character()
       self$freezePane            <- character()
       self$sheet_data            <- wbSheetData$new()
+      self$is_ordered            <- FALSE
 
       invisible(self)
     },

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -754,6 +754,8 @@ wb_load <- function(
 
       # load the data. This function reads sheet_data and returns cc and row_attr
       loadvals(wb$worksheets[[i]]$sheet_data, worksheet_xml)
+
+      wb$is_ordered <- TRUE
     }
   }
 

--- a/R/write.R
+++ b/R/write.R
@@ -68,7 +68,9 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
     # assign to cc
     cc <- rbind(cc, cc_missing)
 
-    # order cc (not really necessary, will be done when saving)
+    # order cc
+    # TODO this reorders cc every time we write to a sheet. We could skip this
+    # here and only order when saving. the output is expected to be ordered.
     cc <- cc[order(as.integer(cc[, "row_r"]), col2int(cc[, "c_r"])), ]
 
     # update dimensions (only required if new cols and rows are added) ------
@@ -104,6 +106,7 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
 
   # push everything back to workbook
   wb$worksheets[[sheet_id]]$sheet_data$cc  <- cc
+  wb$worksheets[[sheet_id]]$is_ordered <- TRUE
 
   wb
 }
@@ -337,6 +340,8 @@ write_data2 <- function(
     wb$worksheets[[sheetno]]$sheet_data$row_attr <- rows_attr
 
     wb$worksheets[[sheetno]]$sheet_data$cc <- cc
+
+    wb$worksheets[[sheetno]]$is_ordered <- TRUE
 
   } else {
     # update cell(s)


### PR DESCRIPTION
Ordering of large files takes a while (roughly ~~a second~~ 300ms on my M1 Mac with the `bhmtrains` dataset). Therefore if the dataset is already ordered, we can skip this step when writing the file. Though, we have to be *really sure* that the data is ordered, otherwise spreadsheet software will bark at the user.

Therefore this is experimental for a future release.