### PR TITLE
improve fillMergedCells. closes #324

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * It is now possible to add form control types `Checkbox`, `Radio` and `Drop` to a workbook using `wb_add_form_control()`. [533](https://github.com/JanMarvin/openxlsx2/pull/533)
 
+* Improve `wb_to_df(fillMergedCells = TRUE)` to work better with dimensions. It is now possible to fill cells where the merged cells intersect with the selected dimensions. [541](https://github.com/JanMarvin/openxlsx2/pull/541)
+
 ## Fixes
 
 * Fixed a bug when loading input with multiple sheets where not every sheet contains a drawing/comment. Previously we assumed that every sheet had a comment and ordered them incorrectly. This caused confusion in spreadsheet software. [536](https://github.com/JanMarvin/openxlsx2/pull/536)

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -621,9 +621,13 @@ wb_to_df <- function(
         # that we do not have to go through large xlsx files multiple times
         z_fill <- wb_to_df(
             dims = filler,
-            xlsxFile = xlsxFile, sheet = sheet,
+            xlsxFile = xlsxFile,
+            sheet = sheet,
             na.strings = na.strings,
-            convert = FALSE, colNames = FALSE
+            convert = FALSE,
+            colNames = FALSE,
+            detectDates = detectDates,
+            showFormula = showFormula
         )
 
         tt_fill <- attr(z_fill, "tt")

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -615,19 +615,25 @@ wb_to_df <- function(
       mc <- unlist(xml_attr(mc, "mergeCell"))
 
       for (i in seq_along(mc)) {
+        filler <- stringi::stri_split_fixed(mc[i], pattern = ":")[[1]][1]
+
+        # TODO there probably is a better way in not reducing cc above, so
+        # that we do not have to go through large xlsx files multiple times
+        z_fill <- wb_to_df(
+            dims = filler,
+            xlsxFile = xlsxFile, sheet = sheet,
+            na.strings = na.strings,
+            convert = FALSE, colNames = FALSE
+        )
+
+        tt_fill <- attr(z_fill, "tt")
+
         dms <- dims_to_dataframe(mc[i])
 
-        # Skip if merged cell is empty
-        if (all(is.na(z[rownames(z) %in% rownames(dms),
-                        colnames(z) %in% colnames(dms)])))
-          next
-
         z[rownames(z) %in% rownames(dms),
-          colnames(z) %in% colnames(dms)] <- z[rownames(z) %in% rownames(dms[1, 1, drop = FALSE]),
-                                               colnames(z) %in% colnames(dms[1, 1, drop = FALSE])]
+          colnames(z) %in% colnames(dms)] <- z_fill
         tt[rownames(tt) %in% rownames(dms),
-           colnames(tt) %in% colnames(dms)] <- tt[rownames(tt) %in% rownames(dms[1, 1, drop = FALSE]),
-                                                  colnames(tt) %in% colnames(dms[1, 1, drop = FALSE])]
+           colnames(tt) %in% colnames(dms)] <- tt_fill
       }
 
     }

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -223,3 +223,28 @@ test_that("handle 29Feb1900", {
   expect_equal(as_posix, got)
 
 })
+
+
+test_that("fillMergedCells works with dims", {
+
+  # create data frame with emtpy second row
+  wb <- wb_workbook()$
+    add_worksheet()$
+    add_data(x = t(letters[1:4]), colNames = FALSE)$
+    add_data(1, t(matrix(c(1:3, NA_real_), 4, 4)),
+             startRow = 3, startCol = 1, colNames = FALSE)
+
+  # merge rows 1 and 2 in each column
+  wb$merge_cells(1, rows = 1:2, cols = 1)
+  wb$merge_cells(1, rows = 1:2, cols = 2)
+  wb$merge_cells(1, rows = 1:2, cols = 3)
+  wb$merge_cells(1, rows = 1:2, cols = 4)
+
+  # read from second column and fill merged cells
+  got <- wb_to_df(wb, dims = "A2:D4", fillMergedCells = TRUE)
+
+  exp <- c("a", "b", "c", "d")
+  got <- names(got)
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Now the following is possible

``` r
library(openxlsx2)

# Create a workbook where the second row are merged cells from the first row
wb <- wb_workbook()$
  add_worksheet()$
  add_data(x = t(letters[1:4]), colNames = FALSE)$
  add_data(dims = "A3:D6", x = t(matrix(c(1:3, NA_real_), 4, 4)), colNames = FALSE)$
  merge_cells(1, rows = 1:2, cols = 1)$
  merge_cells(1, rows = 1:2, cols = 2)$
  merge_cells(1, rows = 1:2, cols = 3)$
  merge_cells(1, rows = 1:2, cols = 4)

# read the workbook from the second row and fill the merged 
# cells, even though they are outside the selected dimension
wb_to_df(wb, dims = "A2:D4", fillMergedCells = TRUE)
#>   a b c  d
#> 3 1 2 3 NA
#> 4 1 2 3 NA
```

Presumably with large xlsxFiles it is faster to read from a `wbWorkbook` instead of reading from a file.