### PR TITLE
[wb_to_df] modify skipEmptyCols/skipEmptyRows. closes #554

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * `na.strings = NULL` is no longer ignored in `write_xlsx()` [552](https://github.com/JanMarvin/openxlsx2/issues/552)
 
+## Breaking changes
+
+* `skipEmptyCols` and `skipEmptyRows` behavior in `wb_to_df()` related functions was switched to include empty columns that have a name. Previously we would exclude columns if they were empty, even if they had a name. [555](https://github.com/JanMarvin/openxlsx2/pull/555)
+
 # openxlsx2 (0.5.1)
 
 ## New features

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -595,10 +595,6 @@ wb_to_df <- function(
   if (any(zz$val == "", na.rm = TRUE)) zz <- zz[zz$val != "", ]
   long_to_wide(z, tt, zz)
 
-  # prepare colnames object
-  xlsx_cols_names <- colnames(z)
-  names(xlsx_cols_names) <- xlsx_cols_names
-
   # backward compatible option. get the mergedCells dimension and fill it with
   # the value of the first cell in the range. do the same for tt.
   if (fillMergedCells) {
@@ -638,6 +634,30 @@ wb_to_df <- function(
     }
 
   }
+
+  # is.na needs convert
+  if (skipEmptyRows) {
+    empty <- apply(z, 1, function(x) all(is.na(x)), simplify = TRUE)
+
+    z  <- z[!empty, , drop = FALSE]
+    tt <- tt[!empty, , drop = FALSE]
+  }
+
+  if (skipEmptyCols) {
+
+    empty <- vapply(z, function(x) all(is.na(x)), NA)
+
+    if (any(empty)) {
+      sel <- which(names(empty) %in% names(empty[empty == TRUE]))
+      z[sel]  <- NULL
+      tt[sel] <- NULL
+    }
+
+  }
+
+  # prepare colnames object
+  xlsx_cols_names <- colnames(z)
+  names(xlsx_cols_names) <- xlsx_cols_names
 
   # if colNames, then change tt too
   if (colNames) {
@@ -694,26 +714,6 @@ wb_to_df <- function(
   if (colNames) {
     names(z)  <- xlsx_cols_names
     names(tt) <- xlsx_cols_names
-  }
-
-  # is.na needs convert
-  if (skipEmptyRows) {
-    empty <- apply(z, 1, function(x) all(is.na(x)), simplify = TRUE)
-
-    z  <- z[!empty, , drop = FALSE]
-    tt <- tt[!empty, , drop = FALSE]
-  }
-
-  if (skipEmptyCols) {
-
-    empty <- vapply(z, function(x) all(is.na(x)), NA)
-
-    if (any(empty)) {
-      sel <- which(names(empty) %in% names(empty[empty == TRUE]))
-      z[sel]  <- NULL
-      tt[sel] <- NULL
-    }
-
   }
 
   attr(z, "tt") <- tt

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -637,7 +637,7 @@ wb_to_df <- function(
 
   # is.na needs convert
   if (skipEmptyRows) {
-    empty <- apply(z, 1, function(x) all(is.na(x)), simplify = TRUE)
+    empty <- vapply(seq_len(nrow(z)), function(x) all(is.na(z[x, ])), NA)
 
     z  <- z[!empty, , drop = FALSE]
     tt <- tt[!empty, , drop = FALSE]

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -648,7 +648,7 @@ wb_to_df <- function(
     empty <- vapply(z, function(x) all(is.na(x)), NA)
 
     if (any(empty)) {
-      sel <- which(names(empty) %in% names(empty[empty == TRUE]))
+      sel <- which(empty)
       z[sel]  <- NULL
       tt[sel] <- NULL
     }

--- a/tests/testthat/test-read_from_created_wb.R
+++ b/tests/testthat/test-read_from_created_wb.R
@@ -138,7 +138,7 @@ test_that("skipEmtpyCols keeps empty named columns", {
   na_mat <- matrix(NA, nrow = 22, ncol = 7)
 
   ## create artificial data with empty column
-  dat    <- iris[1:20,]
+  dat    <- iris[1:20, ]
   dat$Species <- NA_real_
   dat <- rbind(dat, NA)
 

--- a/tests/testthat/test-read_from_created_wb.R
+++ b/tests/testthat/test-read_from_created_wb.R
@@ -131,3 +131,24 @@ test_that("reading with multiple sections in freezePane works", {
   wb$save(temp)
   expect_silent(wb <- wb_load(temp))
 })
+
+test_that("skipEmtpyCols keeps empty named columns", {
+
+  ## initialize empty cells
+  na_mat <- matrix(NA, nrow = 22, ncol = 7)
+
+  ## create artificial data with empty column
+  dat    <- iris[1:20,]
+  dat$Species <- NA_real_
+  dat <- rbind(dat, NA)
+
+  ## create the workbook
+  wb <- wb_workbook()$
+    add_worksheet()$
+    add_data(x = na_mat, colNames = FALSE)$
+    add_data(x = dat)
+
+  got <- wb_to_df(wb, skipEmptyCols = TRUE)
+  expect_equal(dat, got, ignore_attr = TRUE)
+
+})


### PR DESCRIPTION
The part was moved up in the function and is now before `rowNames` and `colNames`. Therefore it allows reading empty named columns and remove only columns that have no header.

This is a breaking change, because it changes the default behavior of the output. I have nothing against this, but I am not really a user of the `skipEmptyCols`/`skipEmptyRows` argument. Do you have any suggestions @jmbarbone ?