### PR TITLE
use as_xml_attr() in wb_styles functions. closes #557

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openxlsx2 (in development)
 
+## New features
+
+* Styles arguments now accept logical and numeric arguments where applicable. [558](https://github.com/JanMarvin/openxlsx2/pull/558)
+
 ## Fixes
 
 * `na.strings = NULL` is no longer ignored in `write_xlsx()` [552](https://github.com/JanMarvin/openxlsx2/issues/552)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -153,6 +153,7 @@ write_xml_file <- function(xml_content, escapes) {
 #' @param xml_attributes R vector of named attributes
 #' @param escapes bool if escapes should be used
 #' @param declaration bool if declaration should be imported
+#' @param remove_empty_attr bool remove empty attributes or ignore them
 #'
 #' @examples
 #'   # add single node
@@ -173,8 +174,8 @@ write_xml_file <- function(xml_content, escapes) {
 #'     # "<a qux=\"quux\">openxlsx2</a><b qux=\"quux\"/>"
 #'     xml_attr_mod(xml_node, xml_attr)
 #' @export
-xml_attr_mod <- function(xml_content, xml_attributes, escapes = FALSE, declaration = FALSE) {
-    .Call(`_openxlsx2_xml_attr_mod`, xml_content, xml_attributes, escapes, declaration)
+xml_attr_mod <- function(xml_content, xml_attributes, escapes = FALSE, declaration = FALSE, remove_empty_attr = TRUE) {
+    .Call(`_openxlsx2_xml_attr_mod`, xml_content, xml_attributes, escapes, declaration, remove_empty_attr)
 }
 
 #' create xml_node from R objects

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -2310,7 +2310,8 @@ wbWorkbook <- R6::R6Class(
           windowWidth            = as_xml_attr(windowWidth),
           xWindow                = as_xml_attr(xWindow),
           yWindow                = as_xml_attr(yWindow)
-        )
+        ),
+        remove_empty_attr = FALSE
       )
 
       self$workbook$bookViews <- xml_node_create(

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -648,7 +648,8 @@ wbWorksheet <- R6::R6Class(
           zoomScaleNormal          = as_xml_attr(zoomScaleNormal),
           zoomScalePageLayoutView  = as_xml_attr(zoomScalePageLayoutView),
           zoomScaleSheetLayoutView = as_xml_attr(zoomScaleSheetLayoutView)
-        )
+        ),
+        remove_empty_attr = FALSE
       )
 
       self$sheetViews <- xml_node_create(

--- a/R/utils.R
+++ b/R/utils.R
@@ -118,6 +118,11 @@ as_binary <- function(x) {
 }
 
 as_xml_attr <- function(x) {
+
+  if (is.null(x)) {
+    return("")
+  }
+
   if (inherits(x, "logical")) {
     x <- as_binary(x)
   }

--- a/R/wb_styles.R
+++ b/R/wb_styles.R
@@ -170,8 +170,8 @@ create_border <- function(
 create_numfmt <- function(numFmtId, formatCode) {
 
   df_numfmt <- data.frame(
-    numFmtId = numFmtId,
-    formatCode  = formatCode,
+    numFmtId = as_xml_attr(numFmtId),
+    formatCode  = as_xml_attr(formatCode),
     stringsAsFactors = FALSE
   )
   numfmt <- write_numfmt(df_numfmt)
@@ -228,7 +228,7 @@ create_font <- function(
   standardize_color_names(...)
 
   if (b != "") {
-    b <- xml_node_create("b", xml_attributes = c("val" = b))
+    b <- xml_node_create("b", xml_attributes = c("val" = as_xml_attr(b)))
   }
 
   if (charset != "") {
@@ -241,11 +241,11 @@ create_font <- function(
   }
 
   if (condense != "") {
-    condense <- xml_node_create("condense", xml_attributes = c("val" = condense))
+    condense <- xml_node_create("condense", xml_attributes = c("val" = as_xml_attr(condense)))
   }
 
   if (extend != "") {
-    extend <- xml_node_create("extend", xml_attributes = c("val" = extend))
+    extend <- xml_node_create("extend", xml_attributes = c("val" = as_xml_attr(extend)))
   }
 
   if (family != "") {
@@ -253,7 +253,7 @@ create_font <- function(
   }
 
   if (i != "") {
-    i <- xml_node_create("i", xml_attributes = c("val" = i))
+    i <- xml_node_create("i", xml_attributes = c("val" = as_xml_attr(i)))
   }
 
   if (is.null(name)) name <- ""
@@ -262,7 +262,7 @@ create_font <- function(
   }
 
   if (outline != "") {
-    outline <- xml_node_create("outline", xml_attributes = c("val" = outline))
+    outline <- xml_node_create("outline", xml_attributes = c("val" = as_xml_attr(outline)))
   }
 
   if (scheme != "") {
@@ -270,25 +270,23 @@ create_font <- function(
   }
 
   if (shadow != "") {
-    shadow <- xml_node_create("shadow", xml_attributes = c("val" = shadow))
+    shadow <- xml_node_create("shadow", xml_attributes = c("val" = as_xml_attr(shadow)))
   }
 
   if (strike != "") {
-    strike <- xml_node_create("strike", xml_attributes = c("val" = strike))
+    strike <- xml_node_create("strike", xml_attributes = c("val" = as_xml_attr(strike)))
   }
 
-  if (is.null(sz)) sz <- ""
-
   if (sz != "") {
-    sz <- xml_node_create("sz", xml_attributes = c("val" = sz))
+    sz <- xml_node_create("sz", xml_attributes = c("val" = as_xml_attr(sz)))
   }
 
   if (u != "") {
-    u <- xml_node_create("u", xml_attributes = c("val" = u))
+    u <- xml_node_create("u", xml_attributes = c("val" = as_xml_attr(u)))
   }
 
   if (vertAlign != "") {
-    vertAlign <- xml_node_create("vertAlign", xml_attributes = c("val" = vertAlign))
+    vertAlign <- xml_node_create("vertAlign", xml_attributes = c("val" = as_xml_attr(vertAlign)))
   }
 
   df_font <- data.frame(
@@ -317,7 +315,7 @@ create_font <- function(
 #' create fill
 #'
 #' @param gradientFill complex fills
-#' @param patternType various default is "none", but also "solid", or a color like "gray125"
+#' @param patternType various: default is "none", but also "solid", or a color like "gray125"
 #' @param bgColor hex8 color with alpha, red, green, blue only for patternFill
 #' @param fgColor hex8 color with alpha, red, green, blue only for patternFill
 #' @param ... ...
@@ -467,25 +465,25 @@ create_cell_style <- function(
     applyNumberFormat = rep(applyNumberFormat, n),
     applyProtection = rep(applyProtection, n),
 
-    borderId = rep(borderId, n),
-    fillId = rep(fillId, n),
-    fontId = rep(fontId, n),
-    numFmtId = numFmtId,
-    pivotButton = rep(pivotButton, n),
-    quotePrefix = rep(quotePrefix, n),
-    xfId = rep(xfId, n),
-    horizontal = rep(horizontal, n),
-    indent = rep(indent, n),
-    justifyLastLine = rep(justifyLastLine, n),
-    readingOrder = rep(readingOrder, n),
-    relativeIndent = rep(relativeIndent, n),
-    shrinkToFit = rep(shrinkToFit, n),
-    textRotation = rep(textRotation, n),
-    vertical = rep(vertical, n),
-    wrapText = rep(wrapText, n),
+    borderId = rep(as_xml_attr(borderId), n),
+    fillId = rep(as_xml_attr(fillId), n),
+    fontId = rep(as_xml_attr(fontId), n),
+    numFmtId = as_xml_attr(numFmtId),
+    pivotButton = rep(as_xml_attr(pivotButton), n),
+    quotePrefix = rep(as_xml_attr(quotePrefix), n),
+    xfId = rep(as_xml_attr(xfId), n),
+    horizontal = rep(as_xml_attr(horizontal), n),
+    indent = rep(as_xml_attr(indent), n),
+    justifyLastLine = rep(as_xml_attr(justifyLastLine), n),
+    readingOrder = rep(as_xml_attr(readingOrder), n),
+    relativeIndent = rep(as_xml_attr(relativeIndent), n),
+    shrinkToFit = rep(as_xml_attr(shrinkToFit), n),
+    textRotation = rep(as_xml_attr(textRotation), n),
+    vertical = rep(as_xml_attr(vertical), n),
+    wrapText = rep(as_xml_attr(wrapText), n),
     extLst = rep(extLst, n),
-    hidden = rep(hidden, n),
-    locked = rep(locked, n),
+    hidden = rep(as_xml_attr(hidden), n),
+    locked = rep(as_xml_attr(locked), n),
     stringsAsFactors = FALSE
   )
 
@@ -500,7 +498,7 @@ create_cell_style <- function(
 set_border <- function(xf_node, border_id) {
   z <- read_xf(read_xml(xf_node))
   z$applyBorder <- "1"
-  z$borderId <- border_id
+  z$borderId <- as_xml_attr(border_id)
   write_xf(z)
 }
 
@@ -511,7 +509,7 @@ set_border <- function(xf_node, border_id) {
 set_fill <- function(xf_node, fill_id) {
   z <- read_xf(read_xml(xf_node))
   z$applyFill <- "1"
-  z$fillId <- fill_id
+  z$fillId <- as_xml_attr(fill_id)
   write_xf(z)
 }
 
@@ -522,7 +520,7 @@ set_fill <- function(xf_node, fill_id) {
 set_font <- function(xf_node, font_id) {
   z <- read_xf(read_xml(xf_node))
   z$applyFont <- "1"
-  z$fontId <- font_id
+  z$fontId <- as_xml_attr(font_id)
   write_xf(z)
 }
 
@@ -533,7 +531,7 @@ set_font <- function(xf_node, font_id) {
 set_numfmt <- function(xf_node, numfmt) {
   z <- read_xf(read_xml(xf_node))
   z$applyNumberFormat <- "1"
-  z$numFmtId <- numfmt
+  z$numFmtId <- as_xml_attr(numfmt)
   write_xf(z)
 }
 

--- a/man/create_fill.Rd
+++ b/man/create_fill.Rd
@@ -15,7 +15,7 @@ create_fill(
 \arguments{
 \item{gradientFill}{complex fills}
 
-\item{patternType}{various default is "none", but also "solid", or a color like "gray125"}
+\item{patternType}{various: default is "none", but also "solid", or a color like "gray125"}
 
 \item{bgColor}{hex8 color with alpha, red, green, blue only for patternFill}
 

--- a/man/xml_attr_mod.Rd
+++ b/man/xml_attr_mod.Rd
@@ -4,7 +4,13 @@
 \alias{xml_attr_mod}
 \title{adds or updates attribute(s) in existing xml node}
 \usage{
-xml_attr_mod(xml_content, xml_attributes, escapes = FALSE, declaration = FALSE)
+xml_attr_mod(
+  xml_content,
+  xml_attributes,
+  escapes = FALSE,
+  declaration = FALSE,
+  remove_empty_attr = TRUE
+)
 }
 \arguments{
 \item{xml_content}{some valid xml_node}
@@ -14,6 +20,8 @@ xml_attr_mod(xml_content, xml_attributes, escapes = FALSE, declaration = FALSE)
 \item{escapes}{bool if escapes should be used}
 
 \item{declaration}{bool if declaration should be imported}
+
+\item{remove_empty_attr}{bool remove empty attributes or ignore them}
 }
 \description{
 Needs xml node and named character vector as input. Modifies

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -429,8 +429,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // xml_attr_mod
-Rcpp::CharacterVector xml_attr_mod(std::string xml_content, Rcpp::CharacterVector xml_attributes, bool escapes, bool declaration);
-RcppExport SEXP _openxlsx2_xml_attr_mod(SEXP xml_contentSEXP, SEXP xml_attributesSEXP, SEXP escapesSEXP, SEXP declarationSEXP) {
+Rcpp::CharacterVector xml_attr_mod(std::string xml_content, Rcpp::CharacterVector xml_attributes, bool escapes, bool declaration, bool remove_empty_attr);
+RcppExport SEXP _openxlsx2_xml_attr_mod(SEXP xml_contentSEXP, SEXP xml_attributesSEXP, SEXP escapesSEXP, SEXP declarationSEXP, SEXP remove_empty_attrSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -438,7 +438,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type xml_attributes(xml_attributesSEXP);
     Rcpp::traits::input_parameter< bool >::type escapes(escapesSEXP);
     Rcpp::traits::input_parameter< bool >::type declaration(declarationSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_attr_mod(xml_content, xml_attributes, escapes, declaration));
+    Rcpp::traits::input_parameter< bool >::type remove_empty_attr(remove_empty_attrSEXP);
+    rcpp_result_gen = Rcpp::wrap(xml_attr_mod(xml_content, xml_attributes, escapes, declaration, remove_empty_attr));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -873,7 +874,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_getXMLXPtr3attr", (DL_FUNC) &_openxlsx2_getXMLXPtr3attr, 4},
     {"_openxlsx2_printXPtr", (DL_FUNC) &_openxlsx2_printXPtr, 4},
     {"_openxlsx2_write_xml_file", (DL_FUNC) &_openxlsx2_write_xml_file, 2},
-    {"_openxlsx2_xml_attr_mod", (DL_FUNC) &_openxlsx2_xml_attr_mod, 4},
+    {"_openxlsx2_xml_attr_mod", (DL_FUNC) &_openxlsx2_xml_attr_mod, 5},
     {"_openxlsx2_xml_node_create", (DL_FUNC) &_openxlsx2_xml_node_create, 5},
     {"_openxlsx2_xml_append_child1", (DL_FUNC) &_openxlsx2_xml_append_child1, 3},
     {"_openxlsx2_xml_append_child2", (DL_FUNC) &_openxlsx2_xml_append_child2, 4},

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -458,6 +458,7 @@ XPtrXML write_xml_file(std::string xml_content, bool escapes) {
 //' @param xml_attributes R vector of named attributes
 //' @param escapes bool if escapes should be used
 //' @param declaration bool if declaration should be imported
+//' @param remove_empty_attr bool remove empty attributes or ignore them
 //'
 //' @examples
 //'   # add single node
@@ -480,7 +481,8 @@ XPtrXML write_xml_file(std::string xml_content, bool escapes) {
 //' @export
 // [[Rcpp::export]]
 Rcpp::CharacterVector xml_attr_mod(std::string xml_content, Rcpp::CharacterVector xml_attributes,
-                                   bool escapes = false, bool declaration = false) {
+                                   bool escapes = false, bool declaration = false,
+                                   bool remove_empty_attr = true) {
 
   pugi::xml_document doc;
   pugi::xml_parse_result result;
@@ -507,7 +509,8 @@ Rcpp::CharacterVector xml_attr_mod(std::string xml_content, Rcpp::CharacterVecto
       // check if attribute_val is empty. if yes, remove the attribute.
       // otherwise add or update the attribute
       if (new_attr_val[i].empty()) {
-        cld.remove_attribute(new_attr_nam[i].c_str());
+        if (remove_empty_attr)
+          cld.remove_attribute(new_attr_nam[i].c_str());
       } else {
         // update attribute if found else add attribute
         if (cld.attribute(new_attr_nam[i].c_str())) {

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -506,7 +506,7 @@ Rcpp::CharacterVector xml_attr_mod(std::string xml_content, Rcpp::CharacterVecto
 
       // check if attribute_val is empty. if yes, remove the attribute.
       // otherwise add or update the attribute
-      if (new_attr_val[i] == "") {
+      if (new_attr_val[i].empty()) {
         cld.remove_attribute(new_attr_nam[i].c_str());
       } else {
         // update attribute if found else add attribute
@@ -601,7 +601,8 @@ Rcpp::CharacterVector xml_node_create(
     std::vector<std::string> new_attr_val = Rcpp::as<std::vector<std::string>>(xml_attr);
 
     for (auto i = 0; i < xml_attr.length(); ++i){
-      cld.append_attribute(new_attr_nam[i].c_str()) = new_attr_val[i].c_str();
+      if (!new_attr_val[i].empty())
+        cld.append_attribute(new_attr_nam[i].c_str()) = new_attr_val[i].c_str();
     }
   }
 

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -326,6 +326,13 @@ test_that("xml_attr_mod", {
   xml_got <- xml_attr_mod(xml_node, xml_attr)
   expect_identical(xml_exp, xml_got)
 
+  # only add node
+  xml_node <- "<a foo=\"bar\">openxlsx2</a><b />"
+  xml_attr <- c(foo = "", qux = "quux")
+  xml_exp <- "<a foo=\"bar\" qux=\"quux\">openxlsx2</a><b qux=\"quux\"/>"
+  xml_got <- xml_attr_mod(xml_node, xml_attr, remove_empty_attr = FALSE)
+  expect_identical(xml_exp, xml_got)
+
 })
 
 test_that("xml_node_create", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -99,3 +99,17 @@ test_that("relship", {
   expect_equal(exp, got)
 
 })
+
+test_that("as_xml_attr works", {
+
+  mm <- matrix("", 2, 2)
+  mm[1, 1] <- openxlsx2:::as_xml_attr(TRUE)
+  mm[2, 1] <- openxlsx2:::as_xml_attr(FALSE)
+
+  mm[1, 2] <- openxlsx2:::as_xml_attr(1)
+  mm[2, 2] <- openxlsx2:::as_xml_attr(NULL)
+
+  exp <- matrix(c("1", "0", "1", ""), 2, 2)
+  expect_equal(exp, mm)
+
+})

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -148,8 +148,7 @@ test_that("select_active_sheet", {
   # change the selected sheet to IrisSample
   exp <- structure(
      list(tabSelected = c("1", "0", "0", "0"),
-          # # TODO: this is dropped silently
-          # workbookViewId = c("0", "0", "0", "0"),
+          workbookViewId = c("0", "0", "0", "0"),
           names = c("IrisSample", "testing", "mtcars", "mtCars Pivot")),
      row.names = c(NA, 4L), class = "data.frame")
 

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -148,7 +148,8 @@ test_that("select_active_sheet", {
   # change the selected sheet to IrisSample
   exp <- structure(
      list(tabSelected = c("1", "0", "0", "0"),
-          workbookViewId = c("0", "0", "0", "0"),
+          # # TODO: this is dropped silently
+          # workbookViewId = c("0", "0", "0", "0"),
           names = c("IrisSample", "testing", "mtcars", "mtCars Pivot")),
      row.names = c(NA, 4L), class = "data.frame")
 

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -515,3 +515,18 @@ test_that("add numfmt is no longer slow", {
   )
 
 })
+
+test_that("logical and numeric work too", {
+
+  wb <- wb_workbook() %>% wb_add_worksheet("S1") %>% wb_add_data("S1", mtcars)
+
+  wb2 <- wb %>% wb_add_font("S1", "A1:K1", name = "Arial", bold = "1", size = "14")
+
+  wb3 <- wb %>% wb_add_font("S1", "A2:K2", name = "Arial", bold = TRUE, size = 14)
+
+  expect_equal(
+    wb2$styles_mgr$styles$fonts,
+    wb3$styles_mgr$styles$fonts
+  )
+
+})


### PR DESCRIPTION
Needs some real world testing and might be needed in more cases

* [x] Update NEWS
* [x] Add tests

This brings behavior changes: empty elements will be treated as missing, they wont be written with `xml_node_create()` and are removed from xml strings with `xml_mod_attr()`. Need to check if this is desired or if there are cases where we do not want this.

In `wb_set_selected()` we drop additional arguments because they default to `NULL`. This becomes `""` with `as_xml_attr(NULL)` and will be treated as xml node removal in `xml_mod_attr()`. Previously argument `NULL` would simply be ignored in `xml_mod_attr()` and we probably should think about cases where we pass `NULL` arguments to `xml_mod_attr()`
