### PR TITLE
release 0.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openxlsx2
 Title: Read, Write and Edit 'xlsx' Files
-Version: 0.5.1.9000
+Version: 0.6
 Language: en-US
 Authors@R: c(
   person("Jordan Mark", "Barbone", email = "jmbarbone@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-9788-3628")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# openxlsx2 (in development)
+# openxlsx2 (0.6)
 
 ## New features
 

--- a/R/readWorkbook.R
+++ b/R/readWorkbook.R
@@ -57,11 +57,6 @@
 #'   sheet = 2, skipEmptyRows = FALSE,
 #'   cols = c(1, 4), rows = c(1, 3, 4)
 #' )
-#'
-#' ## URL
-#' ##
-#' xlsxFile <- "https://github.com/JanMarvin/openxlsx2/raw/main/inst/extdata/readTest.xlsx"
-#' head(read_xlsx(xlsxFile))
 #' @export
 read_xlsx <- function(
   xlsxFile,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -91,7 +91,6 @@ datatable
 datetime
 datetimes
 defaultGridColor
-definedName
 detectDates
 df
 displayEmptyCellsAs

--- a/man/read_xlsx.Rd
+++ b/man/read_xlsx.Rd
@@ -105,11 +105,6 @@ df3 <- read_xlsx(wb,
   sheet = 2, skipEmptyRows = FALSE,
   cols = c(1, 4), rows = c(1, 3, 4)
 )
-
-## URL
-##
-xlsxFile <- "https://github.com/JanMarvin/openxlsx2/raw/main/inst/extdata/readTest.xlsx"
-head(read_xlsx(xlsxFile))
 }
 \seealso{
 \code{\link[=wb_get_named_regions]{wb_get_named_regions()}} \code{\link[=wb_to_df]{wb_to_df()}}

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -2,22 +2,22 @@
 
 |field    |value                        |
 |:--------|:----------------------------|
-|version  |R version 4.2.2 (2022-10-31) |
-|os       |Ubuntu 20.04.5 LTS           |
+|version  |R version 4.2.3 (2023-03-15) |
+|os       |Ubuntu 20.04.6 LTS           |
 |system   |x86_64, linux-gnu            |
 |ui       |X11                          |
 |language |(EN)                         |
 |collate  |C.UTF-8                      |
 |ctype    |C.UTF-8                      |
 |tz       |UTC                          |
-|date     |2023-02-26                   |
+|date     |2023-04-02                   |
 |pandoc   |2.19.2 @ /usr/bin/pandoc     |
 
 # Dependencies
 
 |package   |old    |new    |Δ  |
 |:---------|:------|:------|:--|
-|openxlsx2 |0.5    |0.5.1  |*  |
+|openxlsx2 |0.5.1  |0.6    |*  |
 |magrittr  |2.0.3  |2.0.3  |   |
 |R6        |2.5.1  |2.5.1  |   |
 |Rcpp      |1.0.10 |1.0.10 |   |


### PR DESCRIPTION
## prepare
* [x] `roxygen2::roxygenize()`
* [x] `spelling::update_wordlist()`
* [x] `spelling::spell_check_package()`
* [x] `lintr::lint_package()`
* [x] `R CMD build openxlsx2`
* [x] `R CMD check --as-cran`
* [x] run revdep
* [x] update NEWS

## submission
* 2023-04-02: first submission
* 2023-04-02: second submission win builder had a note on a long running example. I have removed the URL example.