### PR TITLE
[wb_to_df] add skipHiddenCols and skipHiddenRows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Add `dims` argument to `wb_add_image()` and `wb_add_plot()`. This can be used to place images starting at a cell or span a cell range. This deprecates `xy` in `wb_add_plot()`. This adds colOffset and rowOffset to `wb_add_drawing()` and `wb_add_mschart()` and `wb_add_chart_xml()`. [578](https://github.com/JanMarvin/openxlsx2/pull/578)
 
+* Add `skipHiddenCols` and `skipHiddenRows` to `wb_to_df()`. In this way, hidden columns and rows are ignored, assuming that the person who has hidden them assumes that they are not important. [579](https://github.com/JanMarvin/openxlsx2/pull/579)
+
 
 ***************************************************************************
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -216,6 +216,8 @@ style_is_posix <- function(cellXfs, numfmt_date) {
 #' @param convert If TRUE, a conversion to dates and numerics is attempted.
 #' @param skipEmptyCols If TRUE, empty columns are skipped.
 #' @param skipEmptyRows If TRUE, empty rows are skipped.
+#' @param skipHiddenCols If TRUE, hidden columns are skipped.
+#' @param skipHiddenRows If TRUE, hidden rows are skipped.
 #' @param startRow first row to begin looking for data.
 #' @param startCol first column to begin looking for data.
 #' @param rows A numeric vector specifying which rows in the Excel file to read. If NULL, all rows are read.
@@ -306,6 +308,8 @@ wb_to_df <- function(
     colNames        = TRUE,
     skipEmptyRows   = FALSE,
     skipEmptyCols   = FALSE,
+    skipHiddenRows  = FALSE,
+    skipHiddenCols  = FALSE,
     rows            = NULL,
     cols            = NULL,
     detectDates     = TRUE,
@@ -646,6 +650,27 @@ wb_to_df <- function(
       tt[sel] <- NULL
     }
 
+  }
+
+  if (skipHiddenRows) {
+    sel <- row_attr$hidden == "1" | row_attr$hidden == "true"
+    if (any(sel)) {
+      hide   <- rownames(row_attr[!sel, ])
+
+      z  <- z[hide, , drop = FALSE]
+      tt <- tt[hide, , drop = FALSE]
+    }
+  }
+
+  if (skipHiddenCols) {
+    col_attr <- wb$worksheets[[sheet]]$unfold_cols()
+    sel <- col_attr$hidden == "1" | col_attr$hidden == "true"
+    if (any(sel)) {
+      hide     <- as.numeric(col_attr$min[sel])
+
+      z[hide]  <- NULL
+      tt[hide] <- NULL
+    }
   }
 
   # prepare colnames object

--- a/man/wb_to_df.Rd
+++ b/man/wb_to_df.Rd
@@ -13,6 +13,8 @@ wb_to_df(
   colNames = TRUE,
   skipEmptyRows = FALSE,
   skipEmptyCols = FALSE,
+  skipHiddenRows = FALSE,
+  skipHiddenCols = FALSE,
   rows = NULL,
   cols = NULL,
   detectDates = TRUE,
@@ -42,6 +44,10 @@ wb_to_df(
 \item{skipEmptyRows}{If TRUE, empty rows are skipped.}
 
 \item{skipEmptyCols}{If TRUE, empty columns are skipped.}
+
+\item{skipHiddenRows}{If TRUE, hidden rows are skipped.}
+
+\item{skipHiddenCols}{If TRUE, hidden columns are skipped.}
 
 \item{rows}{A numeric vector specifying which rows in the Excel file to read. If NULL, all rows are read.}
 

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -262,3 +262,23 @@ test_that("improve date detection", {
   expect_equal(exp, got)
 
 })
+
+test_that("skip hidden columns and rows works", {
+
+  wb <- wb_workbook()$
+    add_worksheet()$
+    add_data(x = mtcars)$
+    set_col_widths(cols = c(1, 4, 6, 7, 9), hidden = TRUE)$
+    set_row_heights(rows = c(3, 5, 8:30), hidden = TRUE)
+
+  dat <- wb_to_df(wb, skipHiddenRows = TRUE, skipHiddenCols = TRUE)
+
+  exp <- c("2", "4", "6", "7", "31", "32", "33")
+  got <- rownames(dat)
+  expect_equal(exp, got)
+
+  exp <- c("cyl", "disp", "drat", "vs", "gear", "carb")
+  got <- names(dat)
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
``` r
library(openxlsx2)
wb <- wb_workbook()$
  add_worksheet()$
  add_data(x = mtcars)$
  set_col_widths(cols = c(1, 4, 6, 7, 9), hidden = TRUE)$
  set_row_heights(rows = c(3, 5, 8:30), hidden = TRUE)

# wb$open()

dat <- wb_to_df(wb, skipHiddenRows = TRUE, skipHiddenCols = TRUE)
dat
#>    cyl disp drat vs gear carb
#> 2    6  160 3.90  0    4    4
#> 4    4  108 3.85  1    4    1
#> 6    8  360 3.15  0    3    2
#> 7    6  225 2.76  1    3    1
#> 31   6  145 3.62  0    5    6
#> 32   8  301 3.54  0    5    8
#> 33   4  121 4.11  1    4    2
```