### PR TITLE
[wbWorkbook] provide wb$load() and wb$to_df()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Add cleanup internal comment code in `write_comment()`. This should not impact the workbook wrapper code in `wb_add_comment()`. [586](https://github.com/JanMarvin/openxlsx2/pull/586)
 
+* Added chain functions for `wb_to_df()` and `wb_load()`. [587](https://github.com/JanMarvin/openxlsx2/pull/587)
+
 
 ***************************************************************************
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1325,6 +1325,107 @@ wbWorkbook <- R6::R6Class(
       invisible(self)
     },
 
+    ### to dataframe ----
+    #' @description to_df
+    #' @param sheet Either sheet name or index. When missing the first sheet in the workbook is selected.
+    #' @param colNames If TRUE, the first row of data will be used as column names.
+    #' @param rowNames If TRUE, the first col of data will be used as row names.
+    #' @param dims Character string of type "A1:B2" as optional dimensions to be imported.
+    #' @param detectDates If TRUE, attempt to recognize dates and perform conversion.
+    #' @param showFormula If TRUE, the underlying Excel formulas are shown.
+    #' @param convert If TRUE, a conversion to dates and numerics is attempted.
+    #' @param skipEmptyCols If TRUE, empty columns are skipped.
+    #' @param skipEmptyRows If TRUE, empty rows are skipped.
+    #' @param skipHiddenCols If TRUE, hidden columns are skipped.
+    #' @param skipHiddenRows If TRUE, hidden rows are skipped.
+    #' @param startRow first row to begin looking for data.
+    #' @param startCol first column to begin looking for data.
+    #' @param rows A numeric vector specifying which rows in the Excel file to read. If NULL, all rows are read.
+    #' @param cols A numeric vector specifying which columns in the Excel file to read. If NULL, all columns are read.
+    #' @param named_region Character string with a named_region (defined name or table). If no sheet is selected, the first appearance will be selected.
+    #' @param types A named numeric indicating, the type of the data. 0: character, 1: numeric, 2: date, 3: posixt, 4:logical. Names must match the returned data
+    #' @param na.strings A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.
+    #' @param na.numbers A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.
+    #' @param fillMergedCells If TRUE, the value in a merged cell is given to all cells within the merge.
+    #' @return a data frame
+    to_df = function(
+      sheet,
+      startRow        = 1,
+      startCol        = NULL,
+      rowNames        = FALSE,
+      colNames        = TRUE,
+      skipEmptyRows   = FALSE,
+      skipEmptyCols   = FALSE,
+      skipHiddenRows  = FALSE,
+      skipHiddenCols  = FALSE,
+      rows            = NULL,
+      cols            = NULL,
+      detectDates     = TRUE,
+      na.strings      = "#N/A",
+      na.numbers      = NA,
+      fillMergedCells = FALSE,
+      dims,
+      showFormula     = FALSE,
+      convert         = TRUE,
+      types,
+      named_region
+    ) {
+
+      if (missing(sheet)) sheet <- substitute()
+      if (missing(dims)) dims <- substitute()
+      if (missing(named_region)) named_region <- substitute()
+
+      wb_to_df(
+        xlsxFile        = self,
+        sheet           = sheet,
+        startRow        = startRow,
+        startCol        = startCol,
+        rowNames        = rowNames,
+        colNames        = colNames,
+        skipEmptyRows   = skipEmptyRows,
+        skipEmptyCols   = skipEmptyCols,
+        skipHiddenRows  = skipHiddenRows,
+        skipHiddenCols  = skipHiddenCols,
+        rows            = rows,
+        cols            = cols,
+        detectDates     = detectDates,
+        na.strings      = na.strings,
+        na.numbers      = na.numbers,
+        fillMergedCells = fillMergedCells,
+        dims            = dims,
+        showFormula     = showFormula,
+        convert         = convert,
+        types           = types,
+        named_region    = named_region
+      )
+    },
+
+    ### load workbook ----
+    #' @description load workbook
+    #' @param file file
+    #' @param xlsxFile xlsxFile
+    #' @param sheet sheet
+    #' @param data_only data_only
+    #' @param calc_chain calc_chain
+    #' @return The `wbWorkbook` object invisibly
+    load = function(
+      file,
+      xlsxFile   = NULL,
+      sheet,
+      data_only  = FALSE,
+      calc_chain = FALSE
+    ) {
+      if (missing(file)) file <- substitute()
+      if (missing(sheet)) sheet <- substitute()
+      wb_load(
+        file       = file,
+        xlsxFile   = xlsxFile,
+        sheet      = sheet,
+        data_only  = data_only,
+        calc_chain = calc_chain
+        )
+    },
+
     # TODO wb_save can be shortened a lot by some formatting and by using a
     # function that creates all the temporary directories and subdirectries as a
     # named list

--- a/R/expect-wrapper.R
+++ b/R/expect-wrapper.R
@@ -17,6 +17,8 @@
 #'   executed functions
 #' @param ignore_fields Ignore immediate fields by removing them from the
 #'   objects for comparison
+#' @param ignore_wb for pseudo wbWorkbook wrappers such as wb_load() we have
+#'   to ignore wb
 #' @returns Nothing, called for its side-effects
 #' @noRd
 expect_wrapper <- function(
@@ -26,7 +28,8 @@ expect_wrapper <- function(
   params        = list(),
   ignore        = NULL,
   ignore_attr   = "waldo_opts",
-  ignore_fields = NULL
+  ignore_fields = NULL,
+  ignore_wb     = FALSE
 ) {
   stopifnot(
     requireNamespace("waldo", quietly = TRUE),
@@ -112,7 +115,11 @@ expect_wrapper <- function(
 
     # the style names are generated at random: use matching seeds for both calls
     options("openxlsx2_seed" = NULL)
-    res_fun    <- try(do.call(fun, c(wb = wb_fun, params)), silent = TRUE)
+    if (ignore_wb) {
+      res_fun    <- try(do.call(fun, c(params)), silent = TRUE)
+    } else {
+      res_fun    <- try(do.call(fun, c(wb = wb_fun, params)), silent = TRUE)
+    }
 
     options("openxlsx2_seed" = NULL)
     res_method <- try(do.call(wb_method[[method]], params), silent = TRUE)

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -267,6 +267,8 @@ is created, not when the Excel files are saved.}
 \item \href{#method-wbWorkbook-add_pivot_table}{\code{wbWorkbook$add_pivot_table()}}
 \item \href{#method-wbWorkbook-add_formula}{\code{wbWorkbook$add_formula()}}
 \item \href{#method-wbWorkbook-add_style}{\code{wbWorkbook$add_style()}}
+\item \href{#method-wbWorkbook-to_df}{\code{wbWorkbook$to_df()}}
+\item \href{#method-wbWorkbook-load}{\code{wbWorkbook$load()}}
 \item \href{#method-wbWorkbook-save}{\code{wbWorkbook$save()}}
 \item \href{#method-wbWorkbook-open}{\code{wbWorkbook$open()}}
 \item \href{#method-wbWorkbook-buildTable}{\code{wbWorkbook$buildTable()}}
@@ -791,6 +793,119 @@ add style
 \item{\code{style_name}}{style_name}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-wbWorkbook-to_df"></a>}}
+\if{latex}{\out{\hypertarget{method-wbWorkbook-to_df}{}}}
+\subsection{Method \code{to_df()}}{
+to_df
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$to_df(
+  sheet,
+  startRow = 1,
+  startCol = NULL,
+  rowNames = FALSE,
+  colNames = TRUE,
+  skipEmptyRows = FALSE,
+  skipEmptyCols = FALSE,
+  skipHiddenRows = FALSE,
+  skipHiddenCols = FALSE,
+  rows = NULL,
+  cols = NULL,
+  detectDates = TRUE,
+  na.strings = "#N/A",
+  na.numbers = NA,
+  fillMergedCells = FALSE,
+  dims,
+  showFormula = FALSE,
+  convert = TRUE,
+  types,
+  named_region
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{sheet}}{Either sheet name or index. When missing the first sheet in the workbook is selected.}
+
+\item{\code{startRow}}{first row to begin looking for data.}
+
+\item{\code{startCol}}{first column to begin looking for data.}
+
+\item{\code{rowNames}}{If TRUE, the first col of data will be used as row names.}
+
+\item{\code{colNames}}{If TRUE, the first row of data will be used as column names.}
+
+\item{\code{skipEmptyRows}}{If TRUE, empty rows are skipped.}
+
+\item{\code{skipEmptyCols}}{If TRUE, empty columns are skipped.}
+
+\item{\code{skipHiddenRows}}{If TRUE, hidden rows are skipped.}
+
+\item{\code{skipHiddenCols}}{If TRUE, hidden columns are skipped.}
+
+\item{\code{rows}}{A numeric vector specifying which rows in the Excel file to read. If NULL, all rows are read.}
+
+\item{\code{cols}}{A numeric vector specifying which columns in the Excel file to read. If NULL, all columns are read.}
+
+\item{\code{detectDates}}{If TRUE, attempt to recognize dates and perform conversion.}
+
+\item{\code{na.strings}}{A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.}
+
+\item{\code{na.numbers}}{A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.}
+
+\item{\code{fillMergedCells}}{If TRUE, the value in a merged cell is given to all cells within the merge.}
+
+\item{\code{dims}}{Character string of type "A1:B2" as optional dimensions to be imported.}
+
+\item{\code{showFormula}}{If TRUE, the underlying Excel formulas are shown.}
+
+\item{\code{convert}}{If TRUE, a conversion to dates and numerics is attempted.}
+
+\item{\code{types}}{A named numeric indicating, the type of the data. 0: character, 1: numeric, 2: date, 3: posixt, 4:logical. Names must match the returned data}
+
+\item{\code{named_region}}{Character string with a named_region (defined name or table). If no sheet is selected, the first appearance will be selected.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+a data frame
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-wbWorkbook-load"></a>}}
+\if{latex}{\out{\hypertarget{method-wbWorkbook-load}{}}}
+\subsection{Method \code{load()}}{
+load workbook
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$load(
+  file,
+  xlsxFile = NULL,
+  sheet,
+  data_only = FALSE,
+  calc_chain = FALSE
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{file}}{file}
+
+\item{\code{xlsxFile}}{xlsxFile}
+
+\item{\code{sheet}}{sheet}
+
+\item{\code{data_only}}{data_only}
+
+\item{\code{calc_chain}}{calc_chain}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object invisibly
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-class-workbook-wrappers.R
+++ b/tests/testthat/test-class-workbook-wrappers.R
@@ -33,11 +33,11 @@ test_that("wb_remove_worksheet() is a wrapper", {
 
 # wb_to_df() ---------------------------------------------------------------
 
-# # does not work as expected
-# test_that("wb_to_df() is a wrapper", {
-#   wb <- wb_workbook()$add_worksheet()$add_data(x = iris)
-#   expect_wrapper("to_df", ignore_wb = TRUE, params = list(xlsxFile = wb))
-# })
+# does not work as expected
+test_that("wb_to_df() is a wrapper", {
+  wb <- wb_workbook()$add_worksheet()$add_data(x = iris)
+  expect_pseudo_wrapper("to_df")
+})
 
 # wb_load() ---------------------------------------------------------------
 

--- a/tests/testthat/test-class-workbook-wrappers.R
+++ b/tests/testthat/test-class-workbook-wrappers.R
@@ -30,6 +30,24 @@ test_that("wb_remove_worksheet() is a wrapper", {
   expect_wrapper("remove_worksheet", wb = wb, params = list(sheet = "sheet"))
 })
 
+
+# wb_to_df() ---------------------------------------------------------------
+
+# # does not work as expected
+# test_that("wb_to_df() is a wrapper", {
+#   wb <- wb_workbook()$add_worksheet()$add_data(x = iris)
+#   expect_wrapper("to_df", ignore_wb = TRUE, params = list(xlsxFile = wb))
+# })
+
+# wb_load() ---------------------------------------------------------------
+
+test_that("wb_load() is a wrapper", {
+  tmp_xlsx <- temp_xlsx()
+  wb_workbook()$add_worksheet()$add_data(x = iris)$save(tmp_xlsx)
+  expect_wrapper("load", params = list(file = tmp_xlsx), ignore_wb = TRUE,
+                 ignore_fields = "datetimeCreated")
+})
+
 # wb_save() ---------------------------------------------------------------
 
 test_that("wb_save() is a wrapper", {


### PR DESCRIPTION
I wasn't able to figure out how to fix the `wb_to_df()` wrapper test @jmbarbone . It is commented for now and not all that crucial. I was toying around a little with a `wb` alias, but to no success.

``` r
library(openxlsx2)
tmp_xlsx <- temp_xlsx()
wb_workbook()$add_worksheet()$add_data(x = iris)$save(tmp_xlsx)

df <- wb_workbook()$
  load(file = tmp_xlsx)$
  to_df(dims = "A1:E6")
df
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 2          5.1         3.5          1.4         0.2  setosa
#> 3          4.9         3.0          1.4         0.2  setosa
#> 4          4.7         3.2          1.3         0.2  setosa
#> 5          4.6         3.1          1.5         0.2  setosa
#> 6          5.0         3.6          1.4         0.2  setosa
```