### PR TITLE
Chartsheet cleanup

### DIFF
--- a/R/class-chart-sheet.R
+++ b/R/class-chart-sheet.R
@@ -15,14 +15,35 @@ wbChartSheet <- R6::R6Class(
     #' @field sheetViews Something
     sheetViews = character(),
 
+    #' @field sheetProtection sheetProtection
+    sheetProtection = character(),
+
+    #' @field customSheetViews customSheetViews
+    customSheetViews = character(),
+
     #' @field pageMargins page margins
     pageMargins = character(),
+
+    #' @field pageSetup pageSetup
+    pageSetup = character(),
+
+    #' @field headerFooter headerFooter
+    headerFooter = character(),
 
     #' @field drawing drawing
     drawing = character(),
 
-    #' @field hyperlinks hyperlinks
-    hyperlinks = NULL,
+    #' @field drawingHF drawingHF
+    drawingHF = character(),
+
+    #' @field picture picture
+    picture = character(),
+
+    #' @field webPublishItems webPublishItems
+    webPublishItems = character(),
+
+    #' #' @field hyperlinks hyperlinks
+    #' hyperlinks = NULL,
 
     #' @field relships relships
     relships = NULL,
@@ -42,7 +63,6 @@ wbChartSheet <- R6::R6Class(
       self$sheetViews  <- character()
       self$pageMargins <- '<pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>'
       self$drawing     <- '<drawing r:id=\"rId1\"/>'
-      self$hyperlinks  <- NULL
       self$relships              <- list(
         comments         = integer(),
         drawing          = integer(),
@@ -65,8 +85,15 @@ wbChartSheet <- R6::R6Class(
         '<chartsheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" mc:Ignorable="xr xr3">',
         self$sheetPr,
         self$sheetViews,
+        self$customSheetViews,
+        # self$hyperlinks,
         self$pageMargins,
+        self$pageSetup,
+        self$headerFooter,
         self$drawing,
+        self$drawingHF,
+        self$picture,
+        self$webPublishItems,
         "</chartsheet>",
         sep = " "
       )

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -3064,8 +3064,8 @@ wbWorkbook <- R6::R6Class(
 
       }
 
-      nCharts <- max(which(self$is_chartsheet))
-      nWorks  <- max(which(!self$is_chartsheet))
+      nCharts <- max(which(self$is_chartsheet), nSheets)
+      nWorks  <- max(which(!self$is_chartsheet), nSheets)
 
       # run only once. This is required if chartsheets are in front of worksheets.
       # Maybe need to add this in wb_load and wb_add_worksheet/wb_add_chartsheet

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -147,6 +147,9 @@ wbWorkbook <- R6::R6Class(
     #' @field worksheets_rels worksheets_rels
     worksheets_rels = list(),
 
+    #' @field min_worksheet min_worksheet
+    min_worksheet = NULL,
+
     #' @field sheetOrder The sheet order.  Controls ordering for worksheets and
     #'   worksheet names.
     sheetOrder = integer(),
@@ -3061,11 +3064,26 @@ wbWorkbook <- R6::R6Class(
 
       }
 
+      nCharts <- max(which(self$is_chartsheet))
+      nWorks  <- max(which(!self$is_chartsheet))
+
+      # run only once. This is required if chartsheets are in front of worksheets.
+      # Maybe need to add this in wb_load and wb_add_worksheet/wb_add_chartsheet
+      if (is.null(self$min_worksheet))
+        self$min_worksheet <- min(which(!self$is_chartsheet)) - 1L
+
+      is_chartsheet <- self$is_chartsheet[sheet]
       self$is_chartsheet <- self$is_chartsheet[-sheet]
 
       ## remove highest sheet
       # (don't chagne this to a "grep(value = TRUE)" ... )
-      self$Content_Types <- self$Content_Types[!grepl(sprintf("sheet%s.xml", nSheets), self$Content_Types)]
+
+      if (is_chartsheet) {
+        self$Content_Types <- self$Content_Types[!grepl(sprintf("chartsheets/sheet%s.xml", nCharts), self$Content_Types)]
+      } else {
+        self$Content_Types <- self$Content_Types[!grepl(sprintf("worksheets/sheet%s.xml", nWorks), self$Content_Types)]
+      }
+
 
       # The names for the other drawings have changed
       de <- xml_node(read_xml(self$Content_Types), "Default")
@@ -3171,7 +3189,12 @@ wbWorkbook <- R6::R6Class(
 
       ## Can remove highest sheet
       # (don't use grepl(value = TRUE))
-      self$workbook.xml.rels <- self$workbook.xml.rels[!grepl(sprintf("sheet%s.xml", nSheets), self$workbook.xml.rels)]
+      if (is_chartsheet) {
+        self$workbook.xml.rels <- self$workbook.xml.rels[!grepl(sprintf("chartsheets/sheet%s.xml", nCharts), self$workbook.xml.rels)]
+      } else {
+        self$workbook.xml.rels <- self$workbook.xml.rels[!grepl(sprintf("worksheets/sheet%s.xml", nWorks), self$workbook.xml.rels)]
+      }
+
 
       invisible(self)
     },
@@ -6633,6 +6656,8 @@ wbWorkbook <- R6::R6Class(
 
       # TODO just seq_along()
       nSheets <- length(self$worksheets)
+      min_ws   <- self$min_worksheet
+      if (is.null(min_ws)) min_ws <- 0
 
       for (i in seq_len(nSheets)) {
 
@@ -6707,7 +6732,7 @@ wbWorkbook <- R6::R6Class(
             post = post,
             sheet_data = ws$sheet_data
           )
-          write_xmlPtr(doc = sheet_xml, fl = file.path(xlworksheetsDir, sprintf("sheet%s.xml", i)))
+          write_xmlPtr(doc = sheet_xml, fl = file.path(xlworksheetsDir, sprintf("sheet%s.xml", i + min_ws)))
 
           ## write worksheet rels
           if (length(self$worksheets_rels[[i]])) {
@@ -6745,7 +6770,7 @@ wbWorkbook <- R6::R6Class(
               head = '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
               body = pxml(ws_rels),
               tail = "</Relationships>",
-              fl = file.path(xlworksheetsRelsDir, sprintf("sheet%s.xml.rels", i))
+              fl = file.path(xlworksheetsRelsDir, sprintf("sheet%s.xml.rels", i + min_ws))
             )
           }
         } ## end of is_chartsheet[i]

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6506,9 +6506,9 @@ wbWorkbook <- R6::R6Class(
 
           if (!is.null(unlist(self$vml_rels)) && length(self$vml_rels) >= i && self$vml_rels[[i]] != "") {
             write_file(
-              head = '',
+              head = '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
               body = pxml(self$vml_rels[[i]]),
-              tail = '',
+              tail = '</Relationships>',
               fl = file.path(dir_rel, sprintf("vmlDrawing%s.vml.rels", i))
             )
           }

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -300,6 +300,8 @@ xml_add_child <- function(xml_node, xml_child, level, pointer = FALSE, ...) {
   if (missing(xml_child))
     stop("need xml_child")
 
+  if (xml_child == "") return(xml_node)
+
   xml_node <- read_xml(xml_node, ...)
   xml_child <- read_xml(xml_child, ...)
 

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -300,7 +300,7 @@ xml_add_child <- function(xml_node, xml_child, level, pointer = FALSE, ...) {
   if (missing(xml_child))
     stop("need xml_child")
 
-  if (xml_child == "") return(xml_node)
+  if (all(xml_child == "")) return(xml_node)
 
   xml_node <- read_xml(xml_node, ...)
   xml_child <- read_xml(xml_child, ...)

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -645,7 +645,15 @@ wb_load <- function(
       chartsheet_xml <- read_xml(sheets$target[i])
       wb$worksheets[[i]]$sheetPr <- xml_node(chartsheet_xml, "chartsheet", "sheetPr")
       wb$worksheets[[i]]$sheetViews    <- xml_node(chartsheet_xml, "chartsheet", "sheetViews")
+      wb$worksheets[[i]]$sheetProtection    <- xml_node(chartsheet_xml, "chartsheet", "sheetProtection")
+      wb$worksheets[[i]]$customSheetViews    <- xml_node(chartsheet_xml, "chartsheet", "customSheetViews")
       wb$worksheets[[i]]$pageMargins <- xml_node(chartsheet_xml, "chartsheet", "pageMargins")
+      wb$worksheets[[i]]$pageSetup <- xml_node(chartsheet_xml, "chartsheet", "pageSetup")
+      wb$worksheets[[i]]$headerFooter <- xml_node(chartsheet_xml, "chartsheet", "headerFooter")
+      wb$worksheets[[i]]$drawing <- xml_node(chartsheet_xml, "chartsheet", "drawing")
+      wb$worksheets[[i]]$drawingHF <- xml_node(chartsheet_xml, "chartsheet", "drawingHF")
+      wb$worksheets[[i]]$picture <- xml_node(chartsheet_xml, "chartsheet", "picture")
+      wb$worksheets[[i]]$webPublishItems <- xml_node(chartsheet_xml, "chartsheet", "webPublishItems")
     } else {
       worksheet_xml <- read_xml(sheets$target[i])
       if (!data_only) {
@@ -1144,7 +1152,8 @@ wb_load <- function(
   ## convert hyperliks to hyperlink objects
   if (!data_only)
     for (i in seq_len(nSheets)) {
-      wb$worksheets[[i]]$hyperlinks <- xml_to_hyperlink(wb$worksheets[[i]]$hyperlinks)
+      if (!wb$is_chartsheet[i])
+        wb$worksheets[[i]]$hyperlinks <- xml_to_hyperlink(wb$worksheets[[i]]$hyperlinks)
     }
 
   ## queryTables

--- a/man/wbChartSheet.Rd
+++ b/man/wbChartSheet.Rd
@@ -21,11 +21,25 @@ A chart sheet
 
 \item{\code{sheetViews}}{Something}
 
+\item{\code{sheetProtection}}{sheetProtection}
+
+\item{\code{customSheetViews}}{customSheetViews}
+
 \item{\code{pageMargins}}{page margins}
+
+\item{\code{pageSetup}}{pageSetup}
+
+\item{\code{headerFooter}}{headerFooter}
 
 \item{\code{drawing}}{drawing}
 
-\item{\code{hyperlinks}}{hyperlinks}
+\item{\code{drawingHF}}{drawingHF}
+
+\item{\code{picture}}{picture}
+
+\item{\code{webPublishItems}}{webPublishItems
+#' @field hyperlinks hyperlinks
+hyperlinks = NULL,}
 
 \item{\code{relships}}{relships}
 }

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -231,6 +231,8 @@ create_border
 
 \item{\code{worksheets_rels}}{worksheets_rels}
 
+\item{\code{min_worksheet}}{min_worksheet}
+
 \item{\code{sheetOrder}}{The sheet order.  Controls ordering for worksheets and
 worksheet names.}
 

--- a/tests/testthat/test-remove_worksheets.R
+++ b/tests/testthat/test-remove_worksheets.R
@@ -58,3 +58,25 @@ test_that("Deleting worksheets", {
   expect_silent(wb$remove_worksheet())
 
 })
+
+test_that("removing leading chartsheets works", {
+
+  # We remove sheet 1 which is a chartsheet and the only chartsheet in the file.
+  # We remember the first worksheet id. And even though the first worksheet
+  # could be sheet 1, we keep it at 2. Otherwise our reference counter would get
+  # in trouble. Similar things could happen if all worksheets are removed and
+  # only chartsheets remain. Though that is currently not implemented.
+  fl <- system.file("extdata", "mtcars_chart.xlsx", package = "openxlsx2")
+  tmp <- temp_xlsx()
+  wb <- wb_load(fl)$
+    remove_worksheet(1)$
+    save(tmp)
+  tmp_dir <- tempdir()
+  unzip(tmp, exdir = tmp_dir)
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+
+  exp <- c("sheet2.xml", "sheet3.xml", "sheet4.xml")
+  got <- dir(paste0(tmp_dir, "/xl/worksheets"), pattern = "*.xml")
+  expect_equal(exp, got)
+
+})

--- a/tests/testthat/test-remove_worksheets.R
+++ b/tests/testthat/test-remove_worksheets.R
@@ -71,12 +71,13 @@ test_that("removing leading chartsheets works", {
   wb <- wb_load(fl)$
     remove_worksheet(1)$
     save(tmp)
-  tmp_dir <- tempdir()
+  tmp_dir <- paste0(tempdir(), "/openxlsx2_unzip")
+  dir.create(tmp_dir)
   unzip(tmp, exdir = tmp_dir)
-  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
 
   exp <- c("sheet2.xml", "sheet3.xml", "sheet4.xml")
   got <- dir(paste0(tmp_dir, "/xl/worksheets"), pattern = "*.xml")
   expect_equal(exp, got)
 
+  unlink(tmp_dir, recursive = TRUE)
 })


### PR DESCRIPTION
A couple of cleanups
* add Relationships tag when writing `vml_ref` (took me hours to find that ...!)
* add remaining openxml 2.8.1 fields to wbChartsheet
* enabled chartsheet removal
* fixed a bug, where our worksheet counter got lost: Remove a chartsheet in front of a worksheet and now the worksheet counter resets. This is a nasty one and most likely it is not fixed entirely. Fingers crossed no one will want to remove a sheet in worksheet/chartsheet combinations. Once you know what to look for, it is way to easy to find issues ... #620 