### PR TITLE
[clone_worksheet] copy worksheet across workbooks

### DIFF
--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -737,6 +737,7 @@ wb_add_worksheet <- function(
 #' @param wb A `wbWorkbook` object
 #' @param old Name of existing worksheet to copy
 #' @param new Name of the new worksheet to create
+#' @param from (optional) Workbook to clone old from
 #' @return The `wbWorkbook` object, invisibly.
 #'
 #' @export
@@ -751,9 +752,9 @@ wb_add_worksheet <- function(
 #' wb$clone_worksheet("Sheet 1", new = "Sheet 2")
 #' # Take advantage of waiver functions
 #' wb$clone_worksheet(old = "Sheet 1")
-wb_clone_worksheet <- function(wb, old = current_sheet(), new = next_sheet()) {
+wb_clone_worksheet <- function(wb, old = current_sheet(), new = next_sheet(), from = NULL) {
   assert_workbook(wb)
-  wb$clone()$clone_worksheet(old = old, new = new)
+  wb$clone()$clone_worksheet(old = old, new = new, from = from)
 }
 
 # worksheets --------------------------------------------------------------

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -734,6 +734,13 @@ wb_add_worksheet <- function(
 #' formulas, charts, pivot tables, etc. may not be updated. Some elements like
 #' named ranges and slicers cannot be cloned yet.
 #'
+#' Cloning from another workbook is still an experimental feature and might not
+#' work reliably. Cloning data, media, charts and tables should work. Slicers
+#' and pivot tables as well as everything everything relying on dxfs styles
+#' (e.g. custom table styles and conditional formatting) is currently not
+#' implemented.
+#' Formula references are not updated to reflect interactions between workbooks.
+#'
 #' @param wb A `wbWorkbook` object
 #' @param old Name of existing worksheet to copy
 #' @param new Name of the new worksheet to create
@@ -752,6 +759,23 @@ wb_add_worksheet <- function(
 #' wb$clone_worksheet("Sheet 1", new = "Sheet 2")
 #' # Take advantage of waiver functions
 #' wb$clone_worksheet(old = "Sheet 1")
+#'
+#' ## cloning from another workbook
+#'
+#' # create a workbook
+#' wb <- wb_workbook()$
+#' add_worksheet("NOT_SUM")$
+#'   add_data(x = head(iris))$
+#'   add_fill(dims = "A1:B2", color = wb_color("yellow"))$
+#'   add_border(dims = "B2:C3")
+#'
+#' # we will clone this styled chart into another workbook
+#' fl <- system.file("extdata", "oxlsx2_sheet.xlsx", package = "openxlsx2")
+#' wb_from <- wb_load(fl)
+#'
+#' # clone styles and shared strings
+#' wb$clone_worksheet(old = "SUM", new = "SUM", from = wb_from)
+#'
 wb_clone_worksheet <- function(wb, old = current_sheet(), new = next_sheet(), from = NULL) {
   assert_workbook(wb)
   wb$clone()$clone_worksheet(old = old, new = new, from = from)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -846,7 +846,7 @@ wbWorkbook <- R6::R6Class(
 
         drawing_id <- from$worksheets[[old_drawing_sheet]]$relships$drawing
 
-        new_drawing_sheet <- length(from$drawings) + 1L
+        new_drawing_sheet <- length(self$drawings) + 1L
 
         self$append("drawings_rels", from$drawings_rels[[drawing_id]])
 
@@ -861,7 +861,7 @@ wbWorkbook <- R6::R6Class(
               chartfiles <- reg_match(rl, "(?<=charts/)chart[0-9]+\\.xml")
 
               for (cf in chartfiles) {
-                chartid <- nrow(self$charts) + 1L
+                chartid <- NROW(self$charts) + 1L
                 newname <- stri_join("chart", chartid, ".xml")
                 old_chart <- as.integer(gsub("\\D+", "", cf))
                 self$charts <- rbind(self$charts, from$charts[old_chart, ])

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1080,6 +1080,18 @@ wbWorkbook <- R6::R6Class(
       #   - Slicers
 
       if (external_wb) {
+
+        # FIXME we copy all references from a workbook over to this workbook.
+        # This is not going to work, if multiple images from different
+        # workbooks are used. The references are called imageX.jpg and will
+        # overwrite each other. This needs a better solution
+        if (length(from$media)) {
+          if (!any(grepl("Default Extension=\"jpg\"", self$Content_Types))) {
+            self$append("Content_Types", "<Default Extension=\"jpg\" ContentType=\"image/jpg\"/>")
+          }
+          self$media <- append(self$media, from$media)
+        }
+
         # update sheet styles
         style   <- get_cellstyle(from, sheet = old)
         # only if styles are present

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1098,6 +1098,7 @@ wbWorkbook <- R6::R6Class(
         if (!is.null(style)) {
           new_sty <- set_cellstyles(self, style = style)
           new_s   <- unname(new_sty[match(self$worksheets[[newSheetIndex]]$sheet_data$cc$c_s, names(new_sty))])
+          new_s[is.na(new_s)] <- ""
           self$worksheets[[newSheetIndex]]$sheet_data$cc$c_s <- new_s
         }
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1059,6 +1059,343 @@ wbWorkbook <- R6::R6Class(
       invisible(self)
     },
 
+    #' @description
+    #' Clone a workbooksheet to another workbook
+    #' @param old name of worksheet to clone
+    #' @param new name of new worksheet to add
+    #' @param to name of new worksheet to add
+    clone_worksheet_to = function(old = current_sheet(), new = next_sheet(), to = NULL) {
+
+      assert_workbook(to)
+
+      sheet <- new
+      to$.__enclos_env__$private$validate_new_sheet(sheet)
+      new <- sheet
+
+      old <- private$get_sheet_index(old)
+
+      newSheetIndex <- length(to$worksheets) + 1L
+      to$.__enclos_env__$private$set_current_sheet(newSheetIndex)
+      sheetId <- to$.__enclos_env__$private$get_sheet_id_max() # checks for length of worksheets
+
+      if (!all(self$charts$chartEx == "")) {
+        warning(
+          "The file you have loaded contains chart extensions. At the moment,",
+          " cloning worksheets can damage the output."
+        )
+      }
+
+      # not the best but a quick fix
+      new_raw <- new
+      new <- replace_legal_chars(new)
+
+      ## copy visibility from cloned sheet!
+      visible <- rbindlist(xml_attr(self$workbook$sheets[[old]], "sheet"))$state
+
+      ##  Add sheet to workbook.xml
+      to$append_sheets(
+        xml_node_create(
+          "sheet",
+          xml_attributes = c(
+            name = new,
+            sheetId = sheetId,
+            state = visible,
+            `r:id` = paste0("rId", newSheetIndex)
+          )
+        )
+      )
+
+      ## append to worksheets list
+      to$append("worksheets", self$worksheets[[old]]$clone(deep = TRUE))
+
+      ## TODO why do we have sheet names all over the place ...
+      to$.__enclos_env__$private$original_sheet_names <- c(
+        to$.__enclos_env__$private$original_sheet_names,
+        new
+      )
+
+      ## update content_tyes
+      ## add a drawing.xml for the worksheet
+      # FIXME only add what is needed. If no previous drawing is found, don't
+      # add a new one
+      to$append("Content_Types", c(
+        if (self$is_chartsheet[old]) {
+          sprintf('<Override PartName="/xl/chartsheets/sheet%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml"/>', newSheetIndex)
+        } else {
+          sprintf('<Override PartName="/xl/worksheets/sheet%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>', newSheetIndex)
+        }
+      ))
+
+      ## Update xl/rels
+      to$append(
+        "workbook.xml.rels",
+        if (self$is_chartsheet[old]) {
+          sprintf('<Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet" Target="chartsheets/sheet%s.xml"/>', newSheetIndex)
+        } else {
+          sprintf('<Relationship Id="rId0" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet%s.xml"/>', newSheetIndex)
+        }
+      )
+
+      ## create sheet.rels to simplify id assignment
+      to$worksheets_rels[[newSheetIndex]] <- self$worksheets_rels[[old]]
+
+      old_drawing_sheet <- NULL
+
+      if (length(self$worksheets_rels[[old]])) {
+        relship <- rbindlist(xml_attr(self$worksheets_rels[[old]], "Relationship"))
+        relship$typ <- basename(relship$Type)
+        old_drawing_sheet  <- as.integer(gsub("\\D+", "", relship$Target[relship$typ == "drawing"]))
+      }
+
+      if (length(old_drawing_sheet) && length(self$worksheets[[old_drawing_sheet]]$relships$drawing)) {
+
+        drawing_id <- self$worksheets[[old_drawing_sheet]]$relships$drawing
+
+        new_drawing_sheet <- length(self$drawings) + 1L
+
+        to$append("drawings_rels", self$drawings_rels[[drawing_id]])
+
+        # give each chart its own filename (images can re-use the same file, but charts can't)
+        to$drawings_rels[[new_drawing_sheet]] <-
+          # TODO Can this be simplified?  There's a bit going on here
+          vapply(
+            to$drawings_rels[[new_drawing_sheet]],
+            function(rl) {
+              # is rl here a length of 1?
+              stopifnot(length(rl) == 1L) # lets find out...  if this fails, just remove it
+              chartfiles <- reg_match(rl, "(?<=charts/)chart[0-9]+\\.xml")
+
+              for (cf in chartfiles) {
+                chartid <- nrow(to$charts) + 1L
+                newname <- stri_join("chart", chartid, ".xml")
+                old_chart <- as.integer(gsub("\\D+", "", cf))
+                to$charts <- rbind(to$charts, self$charts[old_chart, ])
+
+                # Read the chartfile and adjust all formulas to point to the new
+                # sheet name instead of the clone source
+
+                chart <- to$charts$chart[chartid]
+                to$charts$rels[chartid] <- gsub("?drawing[0-9]+.xml", paste0("drawing", chartid, ".xml"), to$charts$rels[chartid])
+
+                guard_ws <- function(x) {
+                  if (grepl(" ", x)) x <- shQuote(x, type = "sh")
+                  x
+                }
+
+                old_sheet_name <- guard_ws(self$sheet_names[[old]])
+                new_sheet_name <- guard_ws(new)
+
+                ## we need to replace "'oldname'" as well as "oldname"
+                chart <- gsub(
+                  old_sheet_name,
+                  new_sheet_name,
+                  chart,
+                  perl = TRUE
+                )
+
+                to$charts$chart[chartid] <- chart
+
+                # two charts can not point to the same rels
+                if (to$charts$rels[chartid] != "") {
+                  to$charts$rels[chartid] <- gsub(
+                    stri_join(old_chart, ".xml"),
+                    stri_join(chartid, ".xml"),
+                    to$charts$rels[chartid]
+                  )
+                }
+
+                rl <- gsub(stri_join("(?<=charts/)", cf), newname, rl, perl = TRUE)
+              }
+
+              rl
+
+            },
+            NA_character_,
+            USE.NAMES = FALSE
+          )
+
+
+        to$append("drawings", self$drawings[[drawing_id]])
+      }
+
+      ## TODO Currently it is not possible to clone a sheet with a slicer in a
+      #  safe way. It will always result in a broken xlsx file which is fixable
+      #  but will not contain a slicer.
+
+      # most likely needs to add slicerCache for each slicer with updated names
+
+      ## SLICERS
+
+      rid <- as.integer(sub("\\D+", "", get_relship_id(obj = to$worksheets_rels[[newSheetIndex]], "slicer")))
+      if (length(rid)) {
+
+        warning("Cloning slicers is not yet supported. It will not appear on the sheet.")
+        to$worksheets_rels[[newSheetIndex]] <- relship_no(obj = to$worksheets_rels[[newSheetIndex]], x = "slicer")
+
+        newid <- length(to$slicers) + 1
+
+        cloned_slicers <- self$slicers[[old]]
+        slicer_attr <- xml_attr(cloned_slicers, "slicers")
+
+        # Replace name with name_n. This will prevent the slicer from loading,
+        # but the xlsx file is not broken
+        slicer_child <- xml_node(cloned_slicers, "slicers", "slicer")
+        slicer_df <- rbindlist(xml_attr(slicer_child, "slicer"))[c("name", "cache", "caption", "rowHeight")]
+        slicer_df$name <- paste0(slicer_df$name, "_n")
+        slicer_child <- df_to_xml("slicer", slicer_df)
+
+        to$slicers[[newid]] <- xml_node_create("slicers", slicer_child, slicer_attr[[1]])
+
+        to$worksheets_rels[[newSheetIndex]] <- c(
+          to$worksheets_rels[[newSheetIndex]],
+          sprintf("<Relationship Id=\"rId%s\" Type=\"http://schemas.microsoft.com/office/2007/relationships/slicer\" Target=\"../slicers/slicer%s.xml\"/>",
+                  rid,
+                  newid)
+        )
+
+        to$Content_Types <- c(
+          to$Content_Types,
+          sprintf("<Override PartName=\"/xl/slicers/slicer%s.xml\" ContentType=\"application/vnd.ms-excel.slicer+xml\"/>", newid)
+        )
+
+      }
+
+      # The IDs in the drawings array are sheet-specific, so within the new
+      # cloned sheet the same IDs can be used => no need to modify drawings
+      vml_id <- self$worksheets[[old]]$relships$vml
+      cmt_id <- self$worksheets[[old]]$relships$comments
+      trd_id <- self$worksheets[[old]]$relships$threadedComment
+
+      if (length(vml_id)) {
+        to$append("vml",      self$vml[[vml_id]])
+        to$append("vml_rels", self$vml_rels[[vml_id]])
+        to$worksheets[[old]]$relships$vml <- length(self$vml)
+      }
+
+      if (length(cmt_id)) {
+        to$append("comments", self$comments[cmt_id])
+        to$worksheets[[old]]$relships$comments <- length(self$comments)
+      }
+
+      if (length(trd_id)) {
+        to$append("threadComments", self$threadComments[cmt_id])
+        to$worksheets[[old]]$relships$threadedComment <- length(self$threadComments)
+      }
+
+      to$is_chartsheet[[newSheetIndex]]  <- self$is_chartsheet[[old]]
+
+      to$append("sheetOrder", as.integer(newSheetIndex))
+      to$append("sheet_names", new)
+      to$clone()$.__enclos_env__$private$set_single_sheet_name(pos = newSheetIndex, clean = new, raw = new_raw)
+
+
+      ############################
+      ## DRAWINGS
+
+      # if we have drawings to clone, remove every table reference from Relationship
+
+      rid <- as.integer(sub("\\D+", "", get_relship_id(obj = to$worksheets_rels[[newSheetIndex]], x = "drawing")))
+
+      if (length(rid)) {
+
+        to$worksheets_rels[[newSheetIndex]] <- relship_no(obj = to$worksheets_rels[[newSheetIndex]], x = "drawing")
+
+        to$worksheets_rels[[newSheetIndex]] <- c(
+          to$worksheets_rels[[newSheetIndex]],
+          sprintf(
+            '<Relationship Id="rId%s" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing%s.xml"/>',
+            rid,
+            new_drawing_sheet
+          )
+        )
+
+      }
+
+      ############################
+      ## TABLES
+      ## ... are stored in the $tables list, with the name and sheet as attr
+      ## and in the worksheets[]$tableParts list. We also need to adjust the
+      ## worksheets_rels and set the content type for the new table
+
+      # if we have tables to clone, remove every table referece from Relationship
+      rid <- as.integer(sub("\\D+", "", get_relship_id(obj = to$worksheets_rels[[newSheetIndex]], x = "table")))
+
+      if (length(rid)) {
+
+        to$worksheets_rels[[newSheetIndex]] <- relship_no(obj = to$worksheets_rels[[newSheetIndex]], x = "table")
+
+        # make this the new sheets object
+        tbls <- self$tables[self$tables$tab_sheet == old, ]
+        if (NROW(tbls)) {
+
+          # newid and rid can be different. ids must be unique
+          if (!is.null(to$tables$tab_xml))
+            newid <- max(as.integer(rbindlist(xml_attr(to$tables$tab_xml, "table"))$id)) + seq_along(rid)
+          else
+            newid <- 1L
+
+          # add _n to all table names found
+          tbls$tab_name <- stri_join(tbls$tab_name, "_n")
+          tbls$tab_sheet <- newSheetIndex
+          # modify tab_xml with updated name, displayName and id
+          tbls$tab_xml <- vapply(seq_len(nrow(tbls)), function(x) {
+            xml_attr_mod(tbls$tab_xml[x],
+                         xml_attributes = c(name = tbls$tab_name[x],
+                                            displayName = tbls$tab_name[x],
+                                            id = newid[x])
+            )
+          },
+          NA_character_
+          )
+
+          # add new tables to old tables
+          to$tables <- rbind(
+            to$tables,
+            tbls
+          )
+
+          to$worksheets[[newSheetIndex]]$tableParts                    <- sprintf('<tablePart r:id="rId%s"/>', rid)
+          attr(to$worksheets[[newSheetIndex]]$tableParts, "tableName") <- tbls$tab_name
+
+          ## hint: Content_Types will be created once the sheet is written. no need to add tables there
+
+          # increase tables.xml.rels
+          to$append("tables.xml.rels", rep("", nrow(tbls)))
+
+          # add table.xml to worksheet relationship
+          to$worksheets_rels[[newSheetIndex]] <- c(
+            to$worksheets_rels[[newSheetIndex]],
+            sprintf(
+              '<Relationship Id="rId%s" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" Target="../tables/table%s.xml"/>',
+              rid,
+              newid
+            )
+          )
+        }
+
+      }
+
+      # TODO: The following items are currently NOT copied/duplicated for the cloned sheet:
+      #   - Comments ???
+      #   - Slicers
+
+      # update sheet styles
+      assign("WORKBOOK", self, globalenv())
+      style   <- get_cellstyle(self, sheet = old)
+      # only if styles are present
+      if (!is.null(style)) {
+        new_sty <- set_cellstyles(to, style = style)
+        new_s   <- unname(new_sty[match(to$worksheets[[newSheetIndex]]$sheet_data$cc$c_s, names(new_sty))])
+        to$worksheets[[newSheetIndex]]$sheet_data$cc$c_s <- new_s
+      }
+
+      clone_shared_strings(self, old, to, newSheetIndex)
+
+      message("cloned worksheet into workbook")
+
+      invisible(self)
+    },
+
     ### add data ----
 
     #' @description add data

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -882,8 +882,8 @@ wbWorkbook <- R6::R6Class(
 
                 ## we need to replace "'oldname'" as well as "oldname"
                 chart <- gsub(
-                  old_sheet_name,
-                  new_sheet_name,
+                  paste0(">", old_sheet_name, "!"),
+                  paste0(">", new_sheet_name, "!"),
                   chart,
                   perl = TRUE
                 )
@@ -1030,7 +1030,7 @@ wbWorkbook <- R6::R6Class(
             newid <- 1L
 
 
-          if (stri_join(tbls$tab_name, "_n") %in% self$tables$tab_name) {
+          if (any(stri_join(tbls$tab_name, "_n") %in% self$tables$tab_name)) {
             tbls$tab_name <- stri_join(tbls$tab_name, "1")
           }
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1029,6 +1029,11 @@ wbWorkbook <- R6::R6Class(
           else
             newid <- 1L
 
+
+          if (stri_join(tbls$tab_name, "_n") %in% self$tables$tab_name) {
+            tbls$tab_name <- stri_join(tbls$tab_name, "1")
+          }
+
           # add _n to all table names found
           tbls$tab_name <- stri_join(tbls$tab_name, "_n")
           tbls$tab_sheet <- newSheetIndex

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -1463,6 +1463,11 @@ clone_shared_strings <- function(wb_old, old, wb_new, new) {
   if (identical(wb_new$sharedStrings, empty)) {
 
     wb_new$append(
+      "Content_Types",
+      "<Override PartName=\"/xl/sharedStrings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\"/>"
+    )
+
+    wb_new$append(
       "workbook.xml.rels",
       "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\" Target=\"sharedStrings.xml\"/>"
     )
@@ -1479,7 +1484,7 @@ clone_shared_strings <- function(wb_old, old, wb_new, new) {
 
   wb_new$sharedStrings <- c(as.character(wb_new$sharedStrings), sst_old)
   sst  <- xml_node_create("sst", xml_children = wb_new$sharedStrings)
-  teyt <- xml_si_to_txt(read_xml(sst))
+  text <- xml_si_to_txt(read_xml(sst))
   attr(wb_new$sharedStrings, "uniqueCount") <- as.character(length(text))
   attr(wb_new$sharedStrings, "text") <- text
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -125,7 +125,6 @@ greatful
 gridLines
 hasDrawing
 hdpi
-headFoot
 headerRow
 hms
 lastColumn
@@ -224,7 +223,6 @@ tableStyle
 tablename
 textLength
 th
-threadComments
 totalRow
 totalsRowCount
 twoCellAnchor

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -110,6 +110,7 @@ worksheet names.}
 \item \href{#method-wbWorkbook-add_chartsheet}{\code{wbWorkbook$add_chartsheet()}}
 \item \href{#method-wbWorkbook-add_worksheet}{\code{wbWorkbook$add_worksheet()}}
 \item \href{#method-wbWorkbook-clone_worksheet}{\code{wbWorkbook$clone_worksheet()}}
+\item \href{#method-wbWorkbook-clone_worksheet_to}{\code{wbWorkbook$clone_worksheet_to()}}
 \item \href{#method-wbWorkbook-add_data}{\code{wbWorkbook$add_data()}}
 \item \href{#method-wbWorkbook-add_data_table}{\code{wbWorkbook$add_data_table()}}
 \item \href{#method-wbWorkbook-add_pivot_table}{\code{wbWorkbook$add_pivot_table()}}
@@ -424,6 +425,31 @@ Clone a workbooksheet
 \item{\code{old}}{name of worksheet to clone}
 
 \item{\code{new}}{name of new worksheet to add}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-wbWorkbook-clone_worksheet_to"></a>}}
+\if{latex}{\out{\hypertarget{method-wbWorkbook-clone_worksheet_to}{}}}
+\subsection{Method \code{clone_worksheet_to()}}{
+Clone a workbooksheet to another workbook
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$clone_worksheet_to(
+  old = current_sheet(),
+  new = next_sheet(),
+  to = NULL
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{old}}{name of worksheet to clone}
+
+\item{\code{new}}{name of new worksheet to add}
+
+\item{\code{to}}{name of new worksheet to add}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -110,7 +110,6 @@ worksheet names.}
 \item \href{#method-wbWorkbook-add_chartsheet}{\code{wbWorkbook$add_chartsheet()}}
 \item \href{#method-wbWorkbook-add_worksheet}{\code{wbWorkbook$add_worksheet()}}
 \item \href{#method-wbWorkbook-clone_worksheet}{\code{wbWorkbook$clone_worksheet()}}
-\item \href{#method-wbWorkbook-clone_worksheet_to}{\code{wbWorkbook$clone_worksheet_to()}}
 \item \href{#method-wbWorkbook-add_data}{\code{wbWorkbook$add_data()}}
 \item \href{#method-wbWorkbook-add_data_table}{\code{wbWorkbook$add_data_table()}}
 \item \href{#method-wbWorkbook-add_pivot_table}{\code{wbWorkbook$add_pivot_table()}}
@@ -414,31 +413,12 @@ The \code{wbWorkbook} object, invisibly
 \if{html}{\out{<a id="method-wbWorkbook-clone_worksheet"></a>}}
 \if{latex}{\out{\hypertarget{method-wbWorkbook-clone_worksheet}{}}}
 \subsection{Method \code{clone_worksheet()}}{
-Clone a workbooksheet
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$clone_worksheet(old = current_sheet(), new = next_sheet())}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{old}}{name of worksheet to clone}
-
-\item{\code{new}}{name of new worksheet to add}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-wbWorkbook-clone_worksheet_to"></a>}}
-\if{latex}{\out{\hypertarget{method-wbWorkbook-clone_worksheet_to}{}}}
-\subsection{Method \code{clone_worksheet_to()}}{
 Clone a workbooksheet to another workbook
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$clone_worksheet_to(
+\if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$clone_worksheet(
   old = current_sheet(),
   new = next_sheet(),
-  to = NULL
+  from = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -449,7 +429,7 @@ Clone a workbooksheet to another workbook
 
 \item{\code{new}}{name of new worksheet to add}
 
-\item{\code{to}}{name of new worksheet to add}
+\item{\code{from}}{name of new worksheet to add}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wb_clone_worksheet.Rd
+++ b/man/wb_clone_worksheet.Rd
@@ -4,7 +4,7 @@
 \alias{wb_clone_worksheet}
 \title{Create copies of a worksheet within a workbook}
 \usage{
-wb_clone_worksheet(wb, old = current_sheet(), new = next_sheet())
+wb_clone_worksheet(wb, old = current_sheet(), new = next_sheet(), from = NULL)
 }
 \arguments{
 \item{wb}{A \code{wbWorkbook} object}
@@ -12,6 +12,8 @@ wb_clone_worksheet(wb, old = current_sheet(), new = next_sheet())
 \item{old}{Name of existing worksheet to copy}
 
 \item{new}{Name of the new worksheet to create}
+
+\item{from}{(optional) Workbook to clone old from}
 }
 \value{
 The \code{wbWorkbook} object, invisibly.

--- a/man/wb_clone_worksheet.Rd
+++ b/man/wb_clone_worksheet.Rd
@@ -24,6 +24,13 @@ Create a copy of a worksheet in the same \code{wbWorkbook} object.
 Cloning is possible only to a limited extent. References to sheet names in
 formulas, charts, pivot tables, etc. may not be updated. Some elements like
 named ranges and slicers cannot be cloned yet.
+
+Cloning from another workbook is still an experimental feature and might not
+work reliably. Cloning data, media, charts and tables should work. Slicers
+and pivot tables as well as everything everything relying on dxfs styles
+(e.g. custom table styles and conditional formatting) is currently not
+implemented.
+Formula references are not updated to reflect interactions between workbooks.
 }
 \examples{
 # Create a new workbook
@@ -34,6 +41,23 @@ wb$add_worksheet("Sheet 1")
 wb$clone_worksheet("Sheet 1", new = "Sheet 2")
 # Take advantage of waiver functions
 wb$clone_worksheet(old = "Sheet 1")
+
+## cloning from another workbook
+
+# create a workbook
+wb <- wb_workbook()$
+add_worksheet("NOT_SUM")$
+  add_data(x = head(iris))$
+  add_fill(dims = "A1:B2", color = wb_color("yellow"))$
+  add_border(dims = "B2:C3")
+
+# we will clone this styled chart into another workbook
+fl <- system.file("extdata", "oxlsx2_sheet.xlsx", package = "openxlsx2")
+wb_from <- wb_load(fl)
+
+# clone styles and shared strings
+wb$clone_worksheet(old = "SUM", new = "SUM", from = wb_from)
+
 }
 \seealso{
 Other workbook wrappers: 


### PR DESCRIPTION
Early attempt at #380

There are a couple of things to do and this is just a first step

* copy elements
  * [x] actual copy for `wb$worksheet[[n]]`
  * [ ] required bits from `wb$workbook`, `wb$workbook.xml.rels`, `wb$worksheet_rels`
  * [ ] required charts, comments, drawings, embeddings, shared strings, tables, pivot tables, slicers, vmls

* update copy elements
  * [x] copy styles from one workbook onto the next
  * [ ] update `wb$worksheet_rels` (most likely everything will require a new file name)

Hopefully we can build on `wb_clone_worksheet()`, but even then there is still a lot to do.

## a first draft of what could be possible

```R
# we will clone this styled chart into another workbook
fl <- system.file("extdata", "oxlsx2_sheet.xlsx", package = "openxlsx2")
wb_in <- wb_load(fl)

# create a second workbook
wb <- wb_workbook()$
  add_worksheet("NOT_SUM")$
  add_data(x = head(iris))$
  add_fill(dims = "A1:B2", color = wb_color("yellow"))$
  add_border(dims = "B2:C3")

# hack copy the workbook
wb$add_worksheet("SUM")
wb$worksheets[[2]] <- wb_in$clone(deep = TRUE)$worksheets[[1]]
wb$sharedStrings <- wb_in$sharedStrings
wb$append("Content_Types", "<Override PartName=\"/xl/sharedStrings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\"/>")
wb$append("workbook.xml.rels", "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\" Target=\"sharedStrings.xml\"/>")

# update sheet styles
style <- get_cellstyle(wb_in)
new_sty <- set_cellstyles(wb, style = style)
new_s <- unname(new_sty[match(wb$worksheets[[2]]$sheet_data$cc$c_s, names(new_sty))])
wb$worksheets[[2]]$sheet_data$cc$c_s <- new_s
```