### PR TITLE
[wb_to_df] Fix cols

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: MIT + file LICENSE
 URL: https://github.com/JanMarvin/openxlsx2
 BugReports: https://github.com/JanMarvin/openxlsx2/issues
 Depends:
-    R (>= 3.4.0)
+    R (>= 3.5.0)
 Imports:
     R6,
     Rcpp,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * On load `app.xml` is now assigned to `wb$app`. Previously it was loaded but not assigned.
 
+* Previously if `wb_to_df()` was used with argument `cols`, columns that were missing were created at the end of the output frame. Now columns are returned ordered.
+
 
 ***************************************************************************
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1386,6 +1386,7 @@ wbWorkbook <- R6::R6Class(
     #' @param na.strings A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.
     #' @param na.numbers A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.
     #' @param fillMergedCells If TRUE, the value in a merged cell is given to all cells within the merge.
+    #' @param keep_attributes If TRUE additional attributes are returned. (These are used internally to define a cell type.)
     #' @return a data frame
     to_df = function(
       sheet,
@@ -1407,7 +1408,8 @@ wbWorkbook <- R6::R6Class(
       showFormula     = FALSE,
       convert         = TRUE,
       types,
-      named_region
+      named_region,
+      keep_attributes = FALSE
     ) {
 
       if (missing(sheet)) sheet <- substitute()

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -526,14 +526,12 @@ wb_to_df <- function(
       z[keep_col]  <- NA_character_
       tt[keep_col] <- NA_character_
 
-      # return expected order of columns
       z  <- z[keep_cols]
       tt <- tt[keep_cols]
     }
 
-
-    z  <- z[, colnames(z) %in% keep_cols, drop = FALSE]
-    tt <- tt[, colnames(tt) %in% keep_cols, drop = FALSE]
+    z  <- z[, match(keep_cols, colnames(z)), drop = FALSE]
+    tt <- tt[, match(keep_cols, colnames(tt)), drop = FALSE]
   }
 
   if (!is.null(cols)) {
@@ -546,8 +544,8 @@ wb_to_df <- function(
       tt[keep_col] <- NA_character_
     }
 
-    z  <- z[, colnames(z) %in% keep_cols, drop = FALSE]
-    tt <- tt[, colnames(tt) %in% keep_cols, drop = FALSE]
+    z  <- z[, match(keep_cols, colnames(z)), drop = FALSE]
+    tt <- tt[, match(keep_cols, colnames(tt)), drop = FALSE]
   }
 
   keep_rows <- keep_rows[keep_rows %in% rnams]

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -290,6 +290,7 @@ style_is_hms <- function(cellXfs, numfmt_date) {
 #' @param na.strings A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.
 #' @param na.numbers A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.
 #' @param fillMergedCells If TRUE, the value in a merged cell is given to all cells within the merge.
+#' @param keep_attributes If TRUE additional attributes are returned. (These are used internally to define a cell type.)
 #' @details
 #' Depending if the R package `hms` is loaded, `wb_to_df()` returns `hms` variables or string variables in the `hh:mm:ss` format.
 #' @examples
@@ -385,7 +386,8 @@ wb_to_df <- function(
     showFormula     = FALSE,
     convert         = TRUE,
     types,
-    named_region
+    named_region,
+    keep_attributes = FALSE
 ) {
 
   # .mc <- match.call() # not (yet) used?
@@ -690,14 +692,15 @@ wb_to_df <- function(
           # TODO there probably is a better way in not reducing cc above, so
           # that we do not have to go through large xlsx files multiple times
           z_fill <- wb_to_df(
-            dims = filler,
-            xlsxFile = xlsxFile,
+            xlsxFile = wb,
             sheet = sheet,
+            dims = filler,
             na.strings = na.strings,
             convert = FALSE,
             colNames = FALSE,
             detectDates = detectDates,
-            showFormula = showFormula
+            showFormula = showFormula,
+            keep_attributes = TRUE
           )
 
           tt_fill <- attr(z_fill, "tt")
@@ -824,10 +827,12 @@ wb_to_df <- function(
     names(tt) <- xlsx_cols_names
   }
 
-  attr(z, "tt") <- tt
-  attr(z, "types") <- types
-  # attr(z, "sd") <- sd
-  if (!missing(named_region)) attr(z, "dn") <- nr
+  if (keep_attributes) {
+    attr(z, "tt") <- tt
+    attr(z, "types") <- types
+    # attr(z, "sd") <- sd
+    if (!missing(named_region)) attr(z, "dn") <- nr
+  }
   z
 }
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -826,7 +826,8 @@ to_df
   showFormula = FALSE,
   convert = TRUE,
   types,
-  named_region
+  named_region,
+  keep_attributes = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -872,6 +873,8 @@ to_df
 \item{\code{types}}{A named numeric indicating, the type of the data. 0: character, 1: numeric, 2: date, 3: posixt, 4:logical. Names must match the returned data}
 
 \item{\code{named_region}}{Character string with a named_region (defined name or table). If no sheet is selected, the first appearance will be selected.}
+
+\item{\code{keep_attributes}}{If TRUE additional attributes are returned. (These are used internally to define a cell type.)}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wb_to_df.Rd
+++ b/man/wb_to_df.Rd
@@ -25,7 +25,8 @@ wb_to_df(
   showFormula = FALSE,
   convert = TRUE,
   types,
-  named_region
+  named_region,
+  keep_attributes = FALSE
 )
 }
 \arguments{
@@ -70,6 +71,8 @@ wb_to_df(
 \item{types}{A named numeric indicating, the type of the data. 0: character, 1: numeric, 2: date, 3: posixt, 4:logical. Names must match the returned data}
 
 \item{named_region}{Character string with a named_region (defined name or table). If no sheet is selected, the first appearance will be selected.}
+
+\item{keep_attributes}{If TRUE additional attributes are returned. (These are used internally to define a cell type.)}
 }
 \description{
 Simple function to create a dataframe from a workbook. Simple as in simply

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -498,19 +498,6 @@ test_that("add_drawing works", {
     ),
     row.names = 3:6,
     class = c("data.frame", "wb_data"),
-    tt = structure(
-      list(
-        name = c("s", "s", "s", "s"),
-        mpg = c("n", "n", "n", "n"),
-        cyl = c("n", "n", "n", "n"),
-        disp = c("n", "n", "n", "n"),
-        hp = c("n", "n", "n", "n"),
-        drat = c("n", "n", "n", "n"),
-        wt = c("n", "n", "n", "n")
-      ),
-      row.names = 3:6,
-      class = "data.frame"),
-    types = c(A = 0, B = 1, C = 1, D = 1, E = 1, F = 1, G = 1),
     dims = structure(
       list(
         A = c("A2", "A3", "A4", "A5", "A6"),

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -52,7 +52,7 @@ test_that("convert hms works", {
   got <- wb$worksheets[[1]]$sheet_data$cc
   expect_equal(exp, got)
 
-  z <- wb_to_df(wb, colNames = FALSE)
+  z <- wb_to_df(wb, colNames = FALSE, keep_attributes = TRUE)
   expect_equal(z$A, "12:13:14")
   expect_equal(attr(z, "tt")$A, "h")
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -116,7 +116,7 @@ test_that("encoding", {
                                   row.names = 2L, class = "data.frame"),
                    types = c(A = 0, B = 0))
 
-  expect_equal(exp, wb_to_df(wb))
+  expect_equal(exp, wb_to_df(wb, keep_attributes = TRUE))
 
   fl <- system.file("extdata", "eurosymbol.xlsx", package = "openxlsx2")
   wb <- wb_load(fl)

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -215,18 +215,18 @@ test_that("writing NA, NaN and Inf", {
   wb$add_worksheet("Test3")$add_data(x = x, na.strings = "N/A")$save(tmp)
 
   exp <- c(NA, "s", "s", "s")
-  got <- unname(unlist(attr(wb_to_df(tmp, "Test1"), "tt")))
+  got <- unname(unlist(attr(wb_to_df(tmp, "Test1", keep_attributes = TRUE), "tt")))
   expect_equal(exp, got)
 
   exp <- c("N/A", "#NUM!", "#NUM!", "#VALUE!")
-  got <- unname(unlist(wb_to_df(tmp, "Test2")))
+  got <- unname(unlist(wb_to_df(tmp, "Test2", keep_attributes = TRUE)))
   expect_equal(exp, got)
 
   wb$clone_worksheet("Test1", "Clone1")$add_data(x = x, na.strings = NULL)$save(tmp)
   wb$clone_worksheet("Test3", "Clone3")$add_data(x = x, na.strings = "N/A")$save(tmp)
 
   exp <- c(NA, "s", "s", "s")
-  got <- unname(unlist(attr(wb_to_df(tmp, "Test1"), "tt")))
+  got <- unname(unlist(attr(wb_to_df(tmp, "Test1", keep_attributes = TRUE), "tt")))
   expect_equal(exp, got)
 
   exp <- c("N/A", "#NUM!", "#NUM!", "#VALUE!")

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -283,3 +283,22 @@ test_that("skip hidden columns and rows works", {
   expect_equal(exp, got)
 
 })
+
+test_that("cols return order is correct", {
+
+  wb <- wb_workbook()$add_worksheet()$add_data(dims = "B2", x = head(iris))
+
+  exp <- structure(
+    list(
+      c(NA_real_, NA_real_, NA_real_, NA_real_, NA_real_, NA_real_),
+      c(5.1, 4.9, 4.7, 4.6, 5, 5.4),
+      c(3.5, 3, 3.2, 3.1, 3.6, 3.9)
+    ),
+    names = c(NA, "Sepal.Length", "Sepal.Width"),
+    row.names = 3:8,
+    class = "data.frame"
+  )
+  got <- wb_to_df(wb, cols = c(1:3))
+  expect_equal(exp, got)
+
+})

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -246,7 +246,7 @@ test_that("write_rownames", {
       class = "data.frame"),
     types = c(A = 0, B = 0)
   )
-  got <- wb_to_df(wb, 1, dims = "A1:B2", colNames = FALSE)
+  got <- wb_to_df(wb, 1, dims = "A1:B2", colNames = FALSE, keep_attributes = TRUE)
   expect_equal(exp, got)
 
   exp <- structure(
@@ -259,7 +259,7 @@ test_that("write_rownames", {
       class = "data.frame"),
     types = c(A = 0, B = 0)
   )
-  got <- wb_to_df(wb, 2, dims = "A1:B2", colNames = FALSE)
+  got <- wb_to_df(wb, 2, dims = "A1:B2", colNames = FALSE, keep_attributes = TRUE)
   expect_equal(exp, got)
 
 })


### PR DESCRIPTION
When working on #345 I added a new xlsx file to replace many of the older files we use and spotted a faulted behavior in `wb_to_df()`. If `cols` references an empty column, this column is added to the end of the returned data frame. This fixes the behavior.

* added `keep_attributes = FALSE` (most of the time we do not need the `tt` data frame)
* `fillMergedCells` now uses the already loaded workbook object
* Bump R dependency to 3.5.0 as suggested by R check