### PR TITLE
Unsorted cc

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6260,14 +6260,14 @@ wbWorkbook <- R6::R6Class(
       dims <- unname(unlist(dims))
 
       cc <- self$worksheets[[sheet]]$sheet_data$cc
-      sel <- match(dims, cc$r)
+      sel <- cc$r %in% dims
       stls <- cc$c_s[sel]
       nams <- cc$r[sel]
 
       out <- vector("character", length(dims))
       names(out) <- dims
 
-      out[match(names(out), nams)] <- stls
+      out[match(nams, names(out))] <- stls
       out
     },
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6256,15 +6256,19 @@ wbWorkbook <- R6::R6Class(
         dims <- dims_to_dataframe(dims, fill = TRUE)
       sheet <- private$get_sheet_index(sheet)
 
-      # This alters the workbook
-      temp <- self$clone()$.__enclos_env__$private$do_cell_init(sheet, dims)
-
       # if a range is passed (e.g. "A1:B2") we need to get every cell
       dims <- unname(unlist(dims))
 
-      # TODO check that cc$r is alway valid. not sure atm
-      sel <- temp$worksheets[[sheet]]$sheet_data$cc$r %in% dims
-      temp$worksheets[[sheet]]$sheet_data$cc$c_s[sel]
+      cc <- self$worksheets[[sheet]]$sheet_data$cc
+      sel <- match(dims, cc$r)
+      stls <- cc$c_s[sel]
+      nams <- cc$r[sel]
+
+      out <- vector("character", length(dims))
+      names(out) <- dims
+
+      out[match(names(out), nams)] <- stls
+      out
     },
 
     #' @description set sheet style
@@ -6283,9 +6287,11 @@ wbWorkbook <- R6::R6Class(
       # if a range is passed (e.g. "A1:B2") we need to get every cell
       dims <- unname(unlist(dims))
 
-      sel <- self$worksheets[[sheet]]$sheet_data$cc$r %in% dims
+      cc <- self$worksheets[[sheet]]$sheet_data$cc
+      sel <- cc$r %in% dims
+      cc$c_s[sel] <- style
 
-      self$worksheets[[sheet]]$sheet_data$cc$c_s[sel] <- style
+      self$worksheets[[sheet]]$sheet_data$cc <- cc
 
       invisible(self)
     },

--- a/R/write.R
+++ b/R/write.R
@@ -80,6 +80,7 @@ inner_update <- function(
     if (is.null(cc$typ)) cc$typ <- ""
     if (is.null(cc_missing$typ)) cc_missing$typ <- ""
 
+    rownames(cc_missing) <- seq.int(nrow(cc) + 1L, length.out = nrow(cc_missing))
     cc <- rbind(cc, cc_missing)
 
     # update dimensions (only required if new cols and rows are added) ------
@@ -118,6 +119,7 @@ inner_update <- function(
   }
 
   # push everything back to workbook
+  # cc <- cc[order(as.integer(cc[, "row_r"]), col2int(cc[, "c_r"])), ]
   wb$worksheets[[sheet_id]]$sheet_data$cc  <- cc
 
   wb
@@ -358,7 +360,7 @@ write_data2 <- function(
   rows_attr <- vector("list", data_nrow)
 
   # create <rows ...>
-  want_rows <- startRow:endRow
+  want_rows <- seq.int(startRow, endRow)
   rows_attr <- empty_row_attr(n = length(want_rows))
   rows_attr$r <- rownames(rtyp)
 
@@ -420,6 +422,11 @@ write_data2 <- function(
 
     wb$worksheets[[sheetno]]$sheet_data$row_attr <- rows_attr
 
+    # ordr <- stringi::stri_order(
+    #   rownames(cc),
+    #   opts_collator = stringi::stri_opts_collator(numeric = TRUE)
+    # )
+    # cc <- cc[ordr,]
     wb$worksheets[[sheetno]]$sheet_data$cc <- cc
 
   } else {

--- a/R/write.R
+++ b/R/write.R
@@ -179,6 +179,18 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
   inner_update(wb, sheet_id, x, rows, cells_needed, colNames, removeCellStyle, na.strings)
 }
 
+## create a cell style format for specific types at the end of the existing
+# styles. gets the reference an passes it on.
+get_data_class_dims <- function(sel, rtyp, colNames) {
+  sel_cols <- names(rtyp[sel == TRUE])
+  sel_rows <- rownames(rtyp)
+
+  # ignore first row if colNames
+  if (colNames) sel_rows <- sel_rows[-1]
+
+  dataframe_to_dims(rtyp[rownames(rtyp) %in% sel_rows, sel_cols, drop = FALSE])
+}
+
 #' dummy function to write data
 #' @param wb workbook
 #' @param sheet sheet
@@ -429,24 +441,11 @@ write_data2 <- function(
 
   if (applyCellStyle) {
 
-    ## create a cell style format for specific types at the end of the existing
-    # styles. gets the reference an passes it on.
-    get_data_class_dims <- function(data_class) {
-      sel <- dc == openxlsx2_celltype[[data_class]]
-      sel_cols <- names(rtyp[sel == TRUE])
-      sel_rows <- rownames(rtyp)
-
-      # ignore first row if colNames
-      if (colNames) sel_rows <- sel_rows[-1]
-
-      dataframe_to_dims(rtyp[rownames(rtyp) %in% sel_rows, sel_cols, drop = FALSE])
-    }
-
     # if hyperlinks are found, Excel sets something like the following font
     # blue with underline
     if (any(dc == openxlsx2_celltype[["hyperlink"]])) {
 
-      dim_sel <- get_data_class_dims("hyperlink")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["hyperlink"]], rtyp, colNames)
       # message("hyperlink: ", dim_sel)
 
       wb$add_font(
@@ -463,7 +462,7 @@ write_data2 <- function(
 
         # # we cannot select every cell like this, because it is terribly slow.
         # dim_sel <- paste0(cc$r[sel], collapse = ";")
-        dim_sel <- get_data_class_dims("character")
+        dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["character"]], rtyp, colNames)
         # message("character: ", dim_sel)
 
         wb$add_cell_style(
@@ -482,7 +481,7 @@ write_data2 <- function(
 
         numfmt_numeric <- unlist(options("openxlsx2.numFmt"))
 
-        dim_sel <- get_data_class_dims("numeric")
+        dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["numeric"]], rtyp, colNames)
         # message("numeric: ", dim_sel)
 
         wb$add_numfmt(
@@ -499,7 +498,7 @@ write_data2 <- function(
         numfmt_dt <- unlist(options("openxlsx2.dateFormat"))
       }
 
-      dim_sel <- get_data_class_dims("short_date")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["short_date"]], rtyp, colNames)
       # message("short_date: ", dim_sel)
 
       wb$add_numfmt(
@@ -515,7 +514,7 @@ write_data2 <- function(
         numfmt_posix <- unlist(options("openxlsx2.datetimeFormat"))
       }
 
-      dim_sel <- get_data_class_dims("long_date")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["long_date"]], rtyp, colNames)
       # message("long_date: ", dim_sel)
 
       wb$add_numfmt(
@@ -531,7 +530,7 @@ write_data2 <- function(
         numfmt_hms <- unlist(options("openxlsx2.hmsFormat"))
       }
 
-      dim_sel <- get_data_class_dims("hms_time")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["hms_time"]], rtyp, colNames)
       # message("hms: ", dim_sel)
 
       wb$add_numfmt(
@@ -547,7 +546,7 @@ write_data2 <- function(
         numfmt_accounting <- unlist(options("openxlsx2.accountingFormat"))
       }
 
-      dim_sel <- get_data_class_dims("accounting")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["accounting"]], rtyp, colNames)
       # message("accounting: ", dim_sel)
 
       wb$add_numfmt(
@@ -562,7 +561,7 @@ write_data2 <- function(
         numfmt_percentage <- unlist(options("openxlsx2.percentageFormat"))
       }
 
-      dim_sel <- get_data_class_dims("percentage")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["percentage"]], rtyp, colNames)
       # message("percentage: ", dim_sel)
 
       wb$add_numfmt(
@@ -578,7 +577,7 @@ write_data2 <- function(
         numfmt_scientific <- unlist(options("openxlsx2.scientificFormat"))
       }
 
-      dim_sel <- get_data_class_dims("scientific")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["scientific"]], rtyp, colNames)
       # message("scientific: ", dim_sel)
 
       wb$add_numfmt(
@@ -594,7 +593,7 @@ write_data2 <- function(
         numfmt_comma <- unlist(options("openxlsx2.commaFormat"))
       }
 
-      dim_sel <- get_data_class_dims("comma")
+      dim_sel <- get_data_class_dims(dc == openxlsx2_celltype[["comma"]], rtyp, colNames)
       # message("comma: ", dim_sel)
 
       wb$add_numfmt(

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -348,6 +348,8 @@ void wide_to_long(
   Rcpp::CharacterVector zz_typ   = Rcpp::as<Rcpp::CharacterVector>(zz["typ"]);
   Rcpp::CharacterVector zz_r     = Rcpp::as<Rcpp::CharacterVector>(zz["r"]);
 
+  Rcpp::IntegerVector rownames(zz.nrow());
+
   auto itr = 0;
   for (auto i = 0; i < m; ++i) {
     Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(z[i]);
@@ -363,6 +365,7 @@ void wide_to_long(
       std::string col = int_to_col(startcol);
 
       auto pos = (j * m) + i;
+      rownames[itr] = pos + 1L;
 
       // create struct
       celltyp cell;
@@ -488,6 +491,8 @@ void wide_to_long(
     }
     ++startcol;
   }
+
+  zz.attr("row.names") = rownames;
 }
 
 // simple helper function to create a data frame of type character

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -348,6 +348,7 @@ void wide_to_long(
   Rcpp::CharacterVector zz_typ   = Rcpp::as<Rcpp::CharacterVector>(zz["typ"]);
   Rcpp::CharacterVector zz_r     = Rcpp::as<Rcpp::CharacterVector>(zz["r"]);
 
+  auto itr = 0;
   for (auto i = 0; i < m; ++i) {
     Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(z[i]);
 
@@ -466,6 +467,8 @@ void wide_to_long(
       cell.typ = std::to_string(vtyp);
       cell.r =  col + row;
 
+      pos = itr;
+
       zz_row_r[pos] = row;
       zz_c_r[pos]   = col;
       if (!cell.v.empty())     zz_v[pos]     = cell.v;
@@ -478,6 +481,8 @@ void wide_to_long(
       if (!cell.f_ref.empty()) zz_f_ref[pos] = cell.f_ref;
       if (!cell.typ.empty())   zz_typ[pos]   = cell.typ;
       if (!cell.r.empty())     zz_r[pos]     = cell.r;
+
+      ++itr;
 
       ++startrow;
     }

--- a/tests/testthat/test-class-hyperlink.R
+++ b/tests/testthat/test-class-hyperlink.R
@@ -16,10 +16,10 @@ test_that("encode Hyperlink works", {
     add_formula(dims = "B1", x = formula_old)$
     add_formula(dims = "B2", x = formula_new)
 
-  got <- wb$worksheets[[1]]$sheet_data$cc["11", "f"]
+  got <- wb$worksheets[[1]]$sheet_data$cc["6", "f"]
   expect_equal(formula_old, got)
 
-  got <- wb$worksheets[[1]]$sheet_data$cc["12", "f"]
+  got <- wb$worksheets[[1]]$sheet_data$cc["7", "f"]
   expect_equal(formula_old, got)
 
   expect_equal(formula_new, wb_to_df(wb, colNames = FALSE, showFormula = TRUE)[1, "B"])
@@ -37,7 +37,7 @@ test_that("formulas with hyperlinks works", {
     add_formula(dims = "B2", x = '=IF(2017 = VALUE(A1), HYPERLINK("github.com","github.com"), A1)')
 
   exp <- "=IF(2017 = VALUE(A1), HYPERLINK(\"github.com\",\"github.com\"), A1)"
-  got <- wb$worksheets[[1]]$sheet_data$cc["12", "f"]
+  got <- wb$worksheets[[1]]$sheet_data$cc["7", "f"]
   expect_equal(exp, got)
 
 })

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -271,9 +271,10 @@ test_that("write cells without data", {
       f_t = c("", "", "", ""),
       f_ref = c("", "", "", ""),
       f_ca = c("", "", "", ""),
-      f_si = c("", "", "",
-                                                                                                                                  ""), is = c("", "", "", ""), typ = c("3", "3", "3", "3")), row.names = c(NA,
-                                                                                                                                                                                                           4L), class = "data.frame")
+      f_si = c("", "", "", ""),
+      is = c("", "", "", ""),
+      typ = c("3", "3", "3", "3")
+    ), row.names = c(1L, 3L, 2L, 4L), class = "data.frame")
   got <- wb$worksheets[[1]]$sheet_data$cc
   expect_equal(exp, got)
 

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -258,9 +258,9 @@ test_that("write cells without data", {
 
   exp <- structure(
     list(
-      r = c("B2", "C2", "B3", "C3"),
-      row_r = c("2", "2", "3", "3"),
-      c_r = c("B", "C", "B", "C"),
+      r = c("B2", "B3", "C2", "C3"),
+      row_r = c("2", "3", "2", "3"),
+      c_r = c("B", "B", "C", "C"),
       c_s = c("", "", "", ""),
       c_t = c("", "", "", ""),
       c_cm = c("", "", "", ""),
@@ -271,12 +271,9 @@ test_that("write cells without data", {
       f_t = c("", "", "", ""),
       f_ref = c("", "", "", ""),
       f_ca = c("", "", "", ""),
-      f_si = c("", "", "", ""),
-      is = c("", "", "", ""),
-      typ = c("3", "3", "3", "3")
-    ),
-    row.names = c(NA, 4L),
-    class = "data.frame")
+      f_si = c("", "", "",
+                                                                                                                                  ""), is = c("", "", "", ""), typ = c("3", "3", "3", "3")), row.names = c(NA,
+                                                                                                                                                                                                           4L), class = "data.frame")
   got <- wb$worksheets[[1]]$sheet_data$cc
   expect_equal(exp, got)
 

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -329,21 +329,21 @@ test_that("get & set cell style(s)", {
 
   # get style from b1 to assign it to a1
   numfmt <- wb$get_cell_style(dims = "B1")
-  expect_equal("1", numfmt)
+  expect_equal(c(B1 = "1"), numfmt)
 
   # assign style to a1
   pre <- wb$get_cell_style(dims = "A1")
-  expect_equal("", pre)
+  expect_equal(c(A1 = ""), pre)
 
   expect_silent(wb$set_cell_style(dims = "A1", style = numfmt))
 
   post <- wb$get_cell_style(dims = "A1")
-  expect_equal("1", post)
+  expect_equal(c(A1 = "1"), post)
 
   s_a1_b1 <- wb$get_cell_style(dims = "A1:B1")
   expect_silent(wb$set_cell_style(dims = "A2:B2", style = s_a1_b1))
   s_a2_b2 <- wb$get_cell_style(dims = "A2:B2")
-  expect_equal(s_a1_b1, s_a2_b2)
+  expect_equal(unname(s_a1_b1), unname(s_a2_b2))
 
 })
 
@@ -365,7 +365,7 @@ test_that("get_cell_styles()", {
                right_border = "",
                top_border = "")
 
-  exp <- "1"
+  exp <- c(B2 = "1")
   got <- wb$get_cell_style(dims = "B2")
   expect_equal(exp, got)
 
@@ -373,7 +373,7 @@ test_that("get_cell_styles()", {
   got <- get_cell_styles(wb, 1, "B2")
   expect_equal(exp, got)
 
-  exp <- "3"
+  exp <- c(B3 = "3")
   got <- wb$get_cell_style(dims = "B3")
   expect_equal(exp, got)
 

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -129,8 +129,8 @@ test_that("test add_fill()", {
   expect_equal(exp, got)
 
   # check the actual styles
-  exp <- c("", "1", "", "1", "", "2", "2", "2", "2", "2", "", "1", "",
-           "1", "", "2", "2", "2", "2", "2", "", "1", "", "1", "", "2",
+  exp <- c("", "2", "", "2", "", "1", "2", "1", "2", "1", "", "2", "",
+           "2", "", "1", "2", "1", "2", "1", "", "2", "", "2", "", "2",
            "2", "2", "2", "2")
   got <- wb$worksheets[[1]]$sheet_data$cc$c_s
   expect_equal(exp, got)
@@ -171,8 +171,8 @@ test_that("test add_font()", {
   expect_equal(exp, got)
 
   # check the actual styles
-  exp <- c("1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "",
-           "", "", "", "", "", "", "", "")
+  exp <- c("1", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+           "", "", "", "", "")
   got <- head(wb$worksheets[[1]]$sheet_data$cc$c_s, 20)
   expect_equal(exp, got)
 
@@ -209,8 +209,8 @@ test_that("test add_numfmt()", {
   expect_equal(exp, got)
 
   # check the actual styles
-  exp <- c("1", "", "", "", "", "2", "", "", "", "", "", "1", "", "",
-           "", "", "2", "", "", "")
+  exp <- c("1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1",
+           "1", "1", "1", "1", "1", "1", "1", "1")
   got <- head(wb$worksheets[[1]]$sheet_data$cc$c_s, 20)
   expect_equal(exp, got)
 
@@ -241,8 +241,8 @@ test_that("test add_cell_style()", {
   expect_equal(exp, got)
 
   # check the actual styles
-  exp <- c("1", "", "", "", "", "2", "", "", "", "", "", "1", "", "",
-           "", "", "2", "", "", "")
+  exp <- c("1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1",
+           "1", "1", "1", "1", "1", "1", "1", "1")
   got <- head(wb$worksheets[[1]]$sheet_data$cc$c_s, 20)
   expect_equal(exp, got)
 
@@ -404,7 +404,7 @@ test_that("applyCellStyle works", {
     add_data(dims = "A1", x = Sys.Date())
 
   cc <- wb$worksheets[[1]]$sheet_data$cc
-  exp <- c("3", "2", "1", "3")
+  exp <- c("2", "1", "3", "3")
   got <- cc[cc$r %in% c("A1", "C3", "E3", "E5"), "c_s"]
   expect_equal(exp, got)
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -101,7 +101,7 @@ test_that("update_cells", {
   data <- matrix(NA, 2, 2)
   wb <- wb_workbook()$add_worksheet()$add_data(x = data)$add_data(x = data, na.strings = "N/A")
 
-  exp <- c("<is><t>V1</t></is>", "<is><t>V2</t></is>", "<is><t>N/A</t></is>")
+  exp <- c("<is><t>V1</t></is>", "<is><t>N/A</t></is>", "<is><t>V2</t></is>")
   got <- unique(wb$worksheets[[1]]$sheet_data$cc$is)
   expect_equal(exp, got)
 
@@ -126,8 +126,8 @@ test_that("update_cells", {
     list(c_t = c("", "str", "str"),
          f = c("SUM(C2:C11*D2:D11)", "C3 + D3", "=HYPERLINK(\"https://www.google.com\")"),
          f_t = c("array", "", "")),
-    row.names = c("23", "110", "111"), class = "data.frame")
-  got <- wb$worksheets[[1]]$sheet_data$cc[c(5, 8, 11), c("c_t", "f", "f_t")]
+    row.names = c(23L, 24L, 25L), class = "data.frame")
+  got <- wb$worksheets[[1]]$sheet_data$cc[c(23, 24, 25), c("c_t", "f", "f_t")]
   expect_equal(exp, got)
 
   ### write logical
@@ -137,7 +137,7 @@ test_that("update_cells", {
   data <- head(wb_to_df(wb1, sheet = 3))
   wb <- wb_workbook()$add_worksheet()$add_data(x = data)$add_data(x = data)
 
-  exp <- c("inlineStr", "", "b", "e")
+  exp <- c("inlineStr", "", "e", "b")
   got <- unique(wb$worksheets[[1]]$sheet_data$cc$c_t)
   expect_equal(exp, got)
 
@@ -208,9 +208,9 @@ test_that("update cell(s)", {
     add_fill(dims = "B2:G8", color = wb_colour("yellow"))$
     add_data(dims = "C3", x = Sys.Date())$
     add_data(dims = "E4", x = Sys.Date(), removeCellStyle = TRUE)
-  exp <- structure(list(r = c("B2", "C2", "D2", "E2", "F2", "G2"),
-                        row_r = c("2", "2", "2", "2", "2", "2"),
-                        c_r = c("B", "C", "D", "E", "F", "G"),
+  exp <- structure(list(r = c("B2", "B3", "B4", "B5", "B6", "B7"),
+                        row_r = c("2", "3", "4", "5", "6", "7"),
+                        c_r = c("B", "B", "B", "B", "B", "B"),
                         c_s = c("1", "1", "1", "1", "1", "1"),
                         c_t = c("", "", "", "", "", ""),
                         c_cm = c("", "", "", "", "", ""),
@@ -223,9 +223,8 @@ test_that("update cell(s)", {
                         f_ca = c("", "", "", "", "", ""),
                         f_si = c("", "", "", "", "", ""),
                         is = c("", "", "", "", "", ""),
-                        typ = c("4", "4", "4", "4", "4", "4")),
-                   row.names = 1:6,
-                   class = "data.frame")
+                        typ = c("4", "4", "4", "4", "4", "4")
+                      ), row.names = c(NA, 6L), class = "data.frame")
   got <- head(wb$worksheets[[1]]$sheet_data$cc)
   expect_equal(exp, got)
 
@@ -300,8 +299,8 @@ test_that("writeData() forces evaluation of x (#264)", {
   wb$add_data(startCol = 5, x = df2)
 
   exp <- c(
-    "<is><t>a</t></is>", "<is><t>b</t></is>", "<is><t>c</t></is>",
-    "<is><t>d</t></is>", "<is><t>e</t></is>", "<is><t>123.4</t></is>"
+    "<is><t>a</t></is>", "<is><t>123.4</t></is>", "<is><t>b</t></is>",
+    "<is><t>c</t></is>", "<is><t>d</t></is>", "<is><t>e</t></is>"
   )
   got <- unique(wb$worksheets[[1]]$sheet_data$cc$is)
   expect_equal(exp, got)

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -224,7 +224,9 @@ test_that("update cell(s)", {
                         f_si = c("", "", "", "", "", ""),
                         is = c("", "", "", "", "", ""),
                         typ = c("4", "4", "4", "4", "4", "4")
-                      ), row.names = c(NA, 6L), class = "data.frame")
+                      ),
+                   row.names = c(1L, 7L, 13L, 19L, 25L, 31L),
+                   class = "data.frame")
   got <- head(wb$worksheets[[1]]$sheet_data$cc)
   expect_equal(exp, got)
 

--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -17,8 +17,8 @@ test_that("Writing Posixct with write_data & write_datatable", {
   wd <- wb$worksheets[[1]]$sheet_data$cc
   wdt <- wb$worksheets[[2]]$sheet_data$cc
 
-  expect_equal(wd$v[[3]], "42885.3541666667")
-  expect_equal(wd$is[[4]], "<is><t>2017-05-30 08:30</t></is>")
+  expect_equal(wd$v[[3]], "42885.3576388889")
+  expect_equal(wd$is[[15]], "<is><t>2017-05-30 08:30</t></is>")
 
   options("openxlsx2.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")
 })


### PR DESCRIPTION
This PR is removing a few fail safes from our write and update process. Previously we were constructing `cc` as a sorted data frame. Sorted, so that our `cc` order matches the open xml specifications, everythings sorted row wise and not column wise.

This is now skipped. We only sort once, when we write the file and keep our `cc` data frame unsorted. This speeds things up, with the example below I got speed improvements of roughly 20% my Macbook with this 44k x 3 data frame written twice.

There are two downsides
* This impacts a very delicate part of the package
* The improvements are not stable. They vary between 0% and 30%, which makes me wonder what is going on. In addition, this is all based on `milliseconds` 500ms vs 650ms ... It simply might not be worth the risk

```R
beg <- "1900-1-1"
end <- "2022-11-18"

dat <- seq(
  from = as.POSIXct(beg, tz = "UTC"),
  to   = as.POSIXct(end, tz = "UTC"),
  by   = "day"
)

# when writing this creates the 29Feb1900 (#421)
out <- data.frame(
  date = dat,
  chr  = as.character(dat),
  num  = seq_along(dat) - 1
)

### lets go nuts!
library(openxlsx2)

old <- microbenchmark::microbenchmark(
  wb <- wb_workbook()$add_worksheet()$add_data(dims = "D1", x = out)$add_data(x = out),
  times = 25,
  unit = "millisecond"
)

print(old)

### yeeeha!
library(openxlsx2)

new <- microbenchmark::microbenchmark(
  wb <- wb_workbook()$add_worksheet()$add_data(dims = "D1", x = out)$add_data(x = out),
  times = 25,
  unit = "millisecond"
)

print(new)

median(sort(new$time) / sort(old$time) - 1)
```