### PR TITLE
[wb_load; cf] fix conditional formatting range. closes #646

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * Previously if `wb_to_df()` was used with argument `cols`, columns that were missing were created at the end of the output frame. Now columns are returned ordered. [631](https://github.com/JanMarvin/openxlsx2/pull/631)
 
+* Fix a bug in `wb_load()` that was modifying the cell range of conditional formatting. [647](https://github.com/JanMarvin/openxlsx2/pull/647)
+
 ## Breaking changes
 
 * Order of arguments in `wb_add_conditional_formatting()` changed, because previously overlooked `dims` argument was added. [642](https://github.com/JanMarvin/openxlsx2/pull/642)

--- a/R/utils.R
+++ b/R/utils.R
@@ -294,6 +294,23 @@ read_xml_files <- function(x) {
          USE.NAMES = FALSE)
 }
 
+#' unlist modifies names
+#' @param x a cf list
+#' @keywords internal
+#' @noRd
+un_list <- function(x) {
+
+  names <- vapply(x, length, NA_integer_)
+  nams <- NULL
+  for (i in seq_along(names)) {
+    nam <- rep(names(names[i]), names[i])
+    nams <- c(nams, nam)
+  }
+  x <- unlist(x, use.names = FALSE)
+  names(x) <- nams
+  x
+}
+
 #' format strings independent of the cell style.
 #' @details
 #' The result is an xml string. It is possible to paste multiple `fmt_txt()`

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -756,8 +756,8 @@ wb_load <- function(
         if (length(cfs)) {
           nms <- unlist(xml_attr(cfs, "conditionalFormatting"))
           cf <- lapply(cfs, function(x) xml_node(x, "conditionalFormatting", "cfRule"))
-          conditionalFormatting <- unlist(cf)
-          names(conditionalFormatting) <- rep(nms, length(conditionalFormatting))
+          names(cf) <- nms
+          conditionalFormatting <- un_list(cf)
           wb$worksheets[[i]]$conditionalFormatting <- conditionalFormatting
         }
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -756,8 +756,8 @@ wb_load <- function(
         if (length(cfs)) {
           nms <- unlist(xml_attr(cfs, "conditionalFormatting"))
           cf <- lapply(cfs, function(x) xml_node(x, "conditionalFormatting", "cfRule"))
-          names(cf) <- nms
           conditionalFormatting <- unlist(cf)
+          names(conditionalFormatting) <- rep(nms, length(conditionalFormatting))
           wb$worksheets[[i]]$conditionalFormatting <- conditionalFormatting
         }
 

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -733,3 +733,37 @@ test_that("warning on cols > 2 and dims", {
   expect_equal(exp, got)
 
 })
+
+test_that("un_list works", {
+
+  tmp <- temp_xlsx()
+
+  dat <- matrix(sample(0:2, 10L, TRUE), 5, 2)
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = dat, colNames = FALSE)
+
+  negStyle <- create_dxfs_style(font_color = wb_color(hex = "FF9C0006"), bgFill = wb_color(hex = "FFFFC7CE"))
+  neuStyle <- create_dxfs_style(font_color = wb_color("red"), bgFill = wb_color("orange"))
+  posStyle <- create_dxfs_style(font_color = wb_color(hex = "FF006100"), bgFill = wb_color(hex = "FFC6EFCE"))
+  wb$styles_mgr$add(negStyle, "negStyle")
+  wb$styles_mgr$add(neuStyle, "neuStyle")
+  wb$styles_mgr$add(posStyle, "posStyle")
+
+  wb$add_conditional_formatting(cols = 1:2, rows = 1:5, rule = "==2", style = "negStyle")
+  wb$add_conditional_formatting(cols = 1:2, rows = 1:5, rule = "==1", style = "neuStyle")
+  wb$add_conditional_formatting(cols = 1:2, rows = 1:5, rule = "==0", style = "posStyle")
+
+  wb$add_conditional_formatting(cols = 5:6, rows = 1:5, rule = "==2", style = "negStyle")
+  wb$add_conditional_formatting(cols = 5:6, rows = 1:5, rule = "==1", style = "neuStyle")
+  wb$add_conditional_formatting(cols = 5:6, rows = 1:5, rule = "==0", style = "posStyle")
+
+  pre_save <- wb$worksheets[[1]]$conditionalFormatting
+
+  wb$save(tmp)
+  wb <- wb_load(tmp)
+
+  post_save <- wb$worksheets[[1]]$conditionalFormatting
+
+  expect_equal(pre_save, post_save)
+
+})


### PR DESCRIPTION
If multiple conditional formatting are available for the same range, the `unlist()` part "fixed" the name by attaching a counter at the end of the name.


library(openxlsx2)
wb <- wb_load("/tmp/cf.xlsx")

wb$worksheets[[1]]$conditionalFormatting
