### PR TITLE
Fix deprecation code for start_col/start_row. closes #706

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4278,8 +4278,10 @@ wbWorkbook <- R6::R6Class(
       arguments <- c(ls(), "start_row", "start_col")
       standardize_case_names(..., arguments = arguments)
 
-      if (exists("start_row") && !is.null(start_row) &&
-          exists("start_col") && !is.null(start_col)) {
+      if ((exists("start_row") && !is.null(start_row)) ||
+          (exists("start_col") && !is.null(start_col))) {
+        if (!exists("start_row") || is.null(start_row)) start_row <- 1
+        if (!exists("start_row") || is.null(start_col)) start_col <- 1
         .Deprecated(old = "start_col/start_row", new = "dims", package = "openxlsx2")
         start_col <- col2int(start_col)
         start_row <- as.integer(start_row)
@@ -4423,12 +4425,15 @@ wbWorkbook <- R6::R6Class(
       ...
     ) {
 
-      standardize_case_names(...)
+      arguments <- c(ls(), "start_row", "start_col")
+      standardize_case_names(..., arguments = arguments)
 
-      if (exists("start_row") && !is.null(start_row) &&
-          exists("start_col") && !is.null(start_col)) {
+      if ((exists("start_row") && !is.null(start_row)) ||
+          (exists("start_col") && !is.null(start_col))) {
+        if (!exists("start_row") || is.null(start_row)) start_row <- 1
+        if (!exists("start_row") || is.null(start_col)) start_col <- 1
         .Deprecated(old = "start_row/start_col", new = "dims", package = "openxlsx2")
-        dims <- rowcol_to_dims(start_row, start_col)
+        dims <- rowcol_to_dim(start_row, start_col)
       }
 
       if (is.null(dev.list()[[1]])) {
@@ -4674,14 +4679,15 @@ wbWorkbook <- R6::R6Class(
       ...
     ) {
 
-      args <- list(...)
+      arguments <- c(ls(), "start_row", "start_col")
+      standardize_case_names(..., arguments = arguments)
 
-      standardize_case_names(...)
-
-      if (exists("start_row") && !is.null(start_row) &&
-          exists("start_col") && !is.null(start_col)) {
+      if ((exists("start_row") && !is.null(start_row)) ||
+          (exists("start_col") && !is.null(start_col))) {
+        if (!exists("start_row") || is.null(start_row)) start_row <- 1
+        if (!exists("start_row") || is.null(start_col)) start_col <- 1
         .Deprecated(old = "start_col/start_row", new = "dims", package = "openxlsx2")
-        dims <- rowcol_to_dims(args$start_row, args$start_col)
+        dims <- rowcol_to_dim(start_row, start_col)
       }
 
       sheet <- private$get_sheet_index(sheet)


### PR DESCRIPTION
At least this throws the correct warning and `rowcol_to_dim()` was required, otherwise you get very tiny pictures :smile: 

```R
library(openxlsx2)
wb <- wb_workbook()
wb$add_worksheet("Sheet 1", gridLines = FALSE)

require(ggplot2)
p1 <- ggplot(mtcars, aes(x = mpg, fill = as.factor(gear))) +
  ggtitle("Distribution of Gas Mileage") +
  geom_density(alpha = 0.5)

print(p1) # plot needs to be showing
wb$add_plot(startCol = 4)
```