### PR TITLE
Improve `wbWorkbook` documentation.

### DIFF
--- a/R/class-chart-sheet.R
+++ b/R/class-chart-sheet.R
@@ -1,6 +1,7 @@
 
 #' R6 class for a Workbook Chart Sheet
 #'
+#' @description
 #' A chart sheet
 #'
 #' @export

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -336,7 +336,7 @@ wbWorkbook <- R6::R6Class(
 
     #' @description validate sheet
     #' @param sheet A character sheet name or integer location
-    #' @returns The integer position of the sheet
+    #' @return The integer position of the sheet
     validate_sheet = function(sheet) {
 
       # workbook has no sheets
@@ -1147,7 +1147,7 @@ wbWorkbook <- R6::R6Class(
     #'   `na_strings()` uses the special `#N/A` value within the workbook.
     #' @param inline_strings write characters as inline strings
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_data_table = function(
         sheet             = current_sheet(),
         x,
@@ -1212,7 +1212,7 @@ wbWorkbook <- R6::R6Class(
     #' @details
     #' `fun` can be either of AVERAGE, COUNT, COUNTA, MAX, MIN, PRODUCT, STDEV,
     #' STDEVP, SUM, VAR, VARP
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_pivot_table = function(
       x,
       sheet = next_sheet(),
@@ -1357,7 +1357,7 @@ wbWorkbook <- R6::R6Class(
     #' @param apply_cell_style applyCellStyle
     #' @param remove_cell_style if writing into existing cells, should the cell style be removed?
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_formula = function(
         sheet             = current_sheet(),
         x,
@@ -1390,7 +1390,7 @@ wbWorkbook <- R6::R6Class(
     #' @description add style
     #' @param style style
     #' @param style_name style_name
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_style = function(style = NULL, style_name = NULL) {
 
       assert_class(style, "character")
@@ -2663,7 +2663,7 @@ wbWorkbook <- R6::R6Class(
     ### sheet names ----
 
     #' @description Get sheet names
-    #' @returns A `named` `character` vector of sheet names in their order.  The
+    #' @return A `named` `character` vector of sheet names in their order.  The
     #'   names represent the original value of the worksheet prior to any
     #'   character substitutions.
     get_sheet_names = function() {
@@ -2934,7 +2934,7 @@ wbWorkbook <- R6::R6Class(
     #' @description ungroup cols
     #' @param sheet sheet
     #' @param cols = cols
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     ungroup_cols = function(sheet = current_sheet(), cols) {
       sheet <- private$get_sheet_index(sheet)
 
@@ -3422,7 +3422,7 @@ wbWorkbook <- R6::R6Class(
     #' @param prompt_title The prompt title
     #' @param prompt The prompt text
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_data_validation = function(
       sheet          = current_sheet(),
       dims           = "A1",
@@ -3717,7 +3717,7 @@ wbWorkbook <- R6::R6Class(
     #' @param dims row and column as spreadsheet dimension, e.g. "A1"
     #' @param comment a comment to apply to the worksheet
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_comment = function(
         sheet   = current_sheet(),
         dims    = "A1",
@@ -3747,7 +3747,7 @@ wbWorkbook <- R6::R6Class(
     #' @param sheet sheet
     #' @param dims row and column as spreadsheet dimension, e.g. "A1"
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     remove_comment = function(
       sheet      = current_sheet(),
       dims       = "A1",
@@ -3930,7 +3930,7 @@ wbWorkbook <- R6::R6Class(
     #' @param type type
     #' @param params Additional parameters
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_conditional_formatting = function(
         sheet  = current_sheet(),
         dims   = NULL,
@@ -4409,7 +4409,7 @@ wbWorkbook <- R6::R6Class(
     #' @param units units
     #' @param dpi dpi
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_plot = function(
       sheet      = current_sheet(),
       dims       = "A1",
@@ -4497,7 +4497,7 @@ wbWorkbook <- R6::R6Class(
     #' @param xml xml
     #' @param col_offset,row_offset offsets for column and row
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_drawing = function(
       sheet      = current_sheet(),
       dims       = "A1",
@@ -4667,7 +4667,7 @@ wbWorkbook <- R6::R6Class(
     #' @param xml xml
     #' @param col_offset,row_offset positioning parameters
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_chart_xml = function(
       sheet      = current_sheet(),
       dims       = NULL,
@@ -4737,7 +4737,7 @@ wbWorkbook <- R6::R6Class(
     #' @param graph mschart graph
     #' @param col_offset,row_offset offsets for column and row
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_mschart = function(
       sheet      = current_sheet(),
       dims       = NULL,
@@ -5096,7 +5096,7 @@ wbWorkbook <- R6::R6Class(
     #'   `"formatRows"`, `"insertColumns"`, `"insertRows"`,
     #'   `"insertHyperlinks"`, `"deleteColumns"`, `"deleteRows"`, `"sort"`,
     #'   `"autoFilter"`, `"pivotTables"`, `"objects"`, `"scenarios"`
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     protect_worksheet = function(
         sheet = current_sheet(),
         protect    = TRUE,
@@ -5446,7 +5446,7 @@ wbWorkbook <- R6::R6Class(
 
     #' @description get tables
     #' @param sheet sheet
-    #' @returns The sheet tables.  `character()` if empty
+    #' @return The sheet tables.  `character()` if empty
     get_tables = function(sheet = current_sheet()) {
       if (length(sheet) != 1) {
         stop("sheet argument must be length 1")
@@ -5468,7 +5468,7 @@ wbWorkbook <- R6::R6Class(
     #' @param sheet sheet
     #' @param table table
     #' @param remove_data removes the data as well
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     remove_tables = function(sheet = current_sheet(), table, remove_data = TRUE) {
       if (length(table) != 1) {
         stop("table argument must be length 1")
@@ -5517,7 +5517,7 @@ wbWorkbook <- R6::R6Class(
     #' @param sheet sheet
     #' @param rows rows
     #' @param cols cols
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_filter = function(sheet = current_sheet(), rows, cols) {
       sheet <- private$get_sheet_index(sheet)
 
@@ -5539,7 +5539,7 @@ wbWorkbook <- R6::R6Class(
 
     #' @description remove filters
     #' @param sheet sheet
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     remove_filter = function(sheet = current_sheet()) {
       for (s in private$get_sheet_index(sheet)) {
         self$worksheets[[s]]$autoFilter <- character()
@@ -5552,7 +5552,7 @@ wbWorkbook <- R6::R6Class(
     #' @param sheet sheet
     #' @param show show
     #' @param print print
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     grid_lines = function(sheet = current_sheet(), show = FALSE, print = show) {
       sheet <- private$get_sheet_index(sheet)
 
@@ -5593,7 +5593,7 @@ wbWorkbook <- R6::R6Class(
     #' @param workbook_parameter workbookParameter
     #' @param xml xml
     #' @param ... additional arguments
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_named_region = function(
       sheet = current_sheet(),
       dims = "A1",
@@ -5696,7 +5696,7 @@ wbWorkbook <- R6::R6Class(
     #' @description remove a named region
     #' @param sheet sheet
     #' @param name name
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     remove_named_region = function(sheet = current_sheet(), name = NULL) {
       # get all nown defined names
       dn <- wb_get_named_regions(self)
@@ -5750,7 +5750,7 @@ wbWorkbook <- R6::R6Class(
     ## sheet visibility ----
 
     #' @description Get sheet visibility
-    #' @returns Returns sheet visibility
+    #' @return Returns sheet visibility
     get_sheet_visibility = function() {
       state <- rep("visible", length(self$workbook$sheets))
       state[grepl("hidden", self$workbook$sheets)] <- "hidden"
@@ -5761,7 +5761,7 @@ wbWorkbook <- R6::R6Class(
     #' @description Set sheet visibility
     #' @param value value
     #' @param sheet sheet
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     set_sheet_visibility = function(sheet = current_sheet(), value) {
       if (length(value) != length(sheet)) {
         stop("`value` and `sheet` must be the same length")
@@ -5806,7 +5806,7 @@ wbWorkbook <- R6::R6Class(
     #' @param sheet sheet
     #' @param row row
     #' @param col col
-    #' @returns The `wbWorkbook` object
+    #' @return The `wbWorkbook` object
     add_page_break = function(sheet = current_sheet(), row = NULL, col = NULL) {
       sheet <- private$get_sheet_index(sheet)
       self$worksheets[[sheet]]$add_page_break(row = row, col = col)
@@ -6605,7 +6605,7 @@ wbWorkbook <- R6::R6Class(
     #' @description get sheet style
     #' @param sheet sheet
     #' @param dims dims
-    #' @returns a character vector of cell styles
+    #' @return a character vector of cell styles
     get_cell_style = function(sheet = current_sheet(), dims) {
 
       if (length(dims) == 1 && grepl(":", dims))

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1,10 +1,11 @@
 
 
 # R6 class ----------------------------------------------------------------
-
+# Lines 7 and 8 are needed until r-lib/roxygen2#1504 is fixed
 #' R6 class for a Workbook
 #'
-#' A Workbook
+#' @description
+#' R6 class for a Workbook
 #'
 #' @export
 wbWorkbook <- R6::R6Class(

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5,7 +5,7 @@
 #' R6 class for a Workbook
 #'
 #' @description
-#' R6 class for a Workbook
+#' A workbook
 #'
 #' @export
 wbWorkbook <- R6::R6Class(

--- a/man/wbChartSheet.Rd
+++ b/man/wbChartSheet.Rd
@@ -7,11 +7,6 @@
 A character vector of xml
 }
 \description{
-R6 class for a Workbook Chart Sheet
-
-R6 class for a Workbook Chart Sheet
-}
-\details{
 A chart sheet
 }
 \section{Public fields}{

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -4,7 +4,7 @@
 \alias{wbWorkbook}
 \title{R6 class for a Workbook}
 \description{
-R6 class for a Workbook
+A workbook
 }
 \examples{
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -62,16 +62,6 @@ a character vector of cell styles
 }
 \description{
 R6 class for a Workbook
-
-R6 class for a Workbook
-}
-\details{
-A Workbook
-
-\code{fun} can be either of AVERAGE, COUNT, COUNTA, MAX, MIN, PRODUCT, STDEV,
-STDEVP, SUM, VAR, VARP
-
-minor helper wrapping xl_open which does the entire same thing
 }
 \examples{
 
@@ -751,6 +741,11 @@ add pivot table
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Details}{
+\code{fun} can be either of AVERAGE, COUNT, COUNTA, MAX, MIN, PRODUCT, STDEV,
+STDEVP, SUM, VAR, VARP
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_formula"></a>}}
@@ -970,6 +965,10 @@ the value returned from \code{\link[base:interactive]{base::interactive()}}}
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Details}{
+minor helper wrapping xl_open which does the entire same thing
+}
+
 \subsection{Returns}{
 The \code{wbWorkbook}, invisibly
 }

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -3,63 +3,6 @@
 \name{wbWorkbook}
 \alias{wbWorkbook}
 \title{R6 class for a Workbook}
-\value{
-The integer position of the sheet
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-A \code{named} \code{character} vector of sheet names in their order.  The
-names represent the original value of the worksheet prior to any
-character substitutions.
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The sheet tables.  \code{character()} if empty
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-Returns sheet visibility
-
-The \code{wbWorkbook} object
-
-The \code{wbWorkbook} object
-
-a character vector of cell styles
-}
 \description{
 R6 class for a Workbook
 }
@@ -422,6 +365,9 @@ validate sheet
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The integer position of the sheet
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_chartsheet"></a>}}
@@ -698,6 +644,9 @@ add a data table
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_pivot_table"></a>}}
@@ -746,6 +695,9 @@ add pivot table
 STDEVP, SUM, VAR, VARP
 }
 
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_formula"></a>}}
@@ -792,6 +744,9 @@ add formula
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_style"></a>}}
@@ -810,6 +765,9 @@ add style
 \item{\code{style_name}}{style_name}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -1203,6 +1161,11 @@ Get sheet names
 \if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$get_sheet_names()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+A \code{named} \code{character} vector of sheet names in their order.  The
+names represent the original value of the worksheet prior to any
+character substitutions.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-set_sheet_names"></a>}}
@@ -1351,6 +1314,9 @@ ungroup cols
 \item{\code{cols}}{= cols}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -1537,6 +1503,9 @@ Adds data validation
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-merge_cells"></a>}}
@@ -1645,6 +1614,9 @@ Add comment
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-remove_comment"></a>}}
@@ -1665,6 +1637,9 @@ Remove comment
 \item{\code{...}}{additional arguments}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -1740,6 +1715,9 @@ Add conditional formatting
 \item{\code{...}}{additional arguments}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -1832,6 +1810,9 @@ Add plot. A wrapper for add_image()
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_drawing"></a>}}
@@ -1863,6 +1844,9 @@ Add xml drawing
 \item{\code{...}}{additional arguments}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -1899,6 +1883,9 @@ Add xml chart
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-add_mschart"></a>}}
@@ -1930,6 +1917,9 @@ Add mschart chart to the workbook
 \item{\code{...}}{additional arguments}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2062,6 +2052,9 @@ or more of the following: \code{"selectLockedCells"},
 \code{"autoFilter"}, \code{"pivotTables"}, \code{"objects"}, \code{"scenarios"}}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2269,6 +2262,9 @@ get tables
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The sheet tables.  \code{character()} if empty
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-remove_tables"></a>}}
@@ -2289,6 +2285,9 @@ remove tables
 \item{\code{remove_data}}{removes the data as well}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2311,6 +2310,9 @@ add filters
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-remove_filter"></a>}}
@@ -2327,6 +2329,9 @@ remove filters
 \item{\code{sheet}}{sheet}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2348,6 +2353,9 @@ grid lines
 \item{\code{print}}{print}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2422,6 +2430,9 @@ add a named region
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Returns}{
+The \code{wbWorkbook} object
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-remove_named_region"></a>}}
@@ -2440,6 +2451,9 @@ remove a named region
 \item{\code{name}}{name}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2471,6 +2485,9 @@ Get sheet visibility
 \if{html}{\out{<div class="r">}}\preformatted{wbWorkbook$get_sheet_visibility()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+Returns sheet visibility
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-wbWorkbook-set_sheet_visibility"></a>}}
@@ -2489,6 +2506,9 @@ Set sheet visibility
 \item{\code{value}}{value}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2510,6 +2530,9 @@ Add a page break
 \item{\code{col}}{col}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The \code{wbWorkbook} object
 }
 }
 \if{html}{\out{<hr>}}
@@ -2931,6 +2954,9 @@ get sheet style
 \item{\code{dims}}{dims}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+a character vector of cell styles
 }
 }
 \if{html}{\out{<hr>}}


### PR DESCRIPTION
Addresses #681.
The reason why the documentation did not render properly for `wbWorkbook` is because of issues in roxygen2. namely r-lib/roxygen2#1148 and r-lib/roxygen2#1504

The documentation for `wbWorkbook` and `wbChartSheet looks much better after this PR. 

I looked at how processx documents its `process` R6 Class.
https://github.com/r-lib/processx/blob/main/man/process.Rd and https://github.com/r-lib/processx/blob/main/R/process.R for the record.

Edit: the changes in the R files could be reverted once the roxygen2 fixes are made.

The `wbWorkbook` docs could be even cleaner if some documentation of fields was removed ? i.e. see methods first? Also could add links to vignettes on how to use it, although, it is mentioned in many places, how to use the R6 methods, `wb$add` etc. (for amother PR or issue if relevant)