### PR TITLE
assert_workbook() can now be used to load an empty workbook to return…

### DIFF
--- a/R/asserts.R
+++ b/R/asserts.R
@@ -34,8 +34,11 @@ assert_comment     <- function(x) assert_class(x, c("wbComment",    "R6"), all =
 assert_color       <- function(x) assert_class(x, c("wbColour"),           all = TRUE)
 assert_hyperlink   <- function(x) assert_class(x, c("wbHyperlink",  "R6"), all = TRUE)
 assert_sheet_data  <- function(x) assert_class(x, c("wbSheetData",  "R6"), all = TRUE)
-assert_workbook    <- function(x) assert_class(x, c("wbWorkbook",   "R6"), all = TRUE)
 assert_worksheet   <- function(x) assert_class(x, c("wbWorksheet",  "R6"), all = TRUE)
+assert_workbook    <- function(x) {
+  if (!is_wbWorkbook(x)) x <- wb_load(x, sheet = NULL, data_only = TRUE)
+  x
+}
 
 match_oneof <- function(x, y, or_null = FALSE, several = FALSE, envir = parent.frame()) {
   sx <- as.character(substitute(x, envir))

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -2288,7 +2288,7 @@ wb_set_sheet_names <- function(wb, old = NULL, new) {
 #' @param escape Should the xml special characters be escaped?
 #' @export
 wb_get_sheet_names <- function(wb, escape = FALSE) {
-  assert_workbook(wb)
+  wb <- assert_workbook(wb)
   wb$get_sheet_names(escape = escape)
 }
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -8037,3 +8037,5 @@ worksheet_lock_properties <- function() {
     NULL
   )
 }
+
+is_wbWorkbook <- function(x) inherits(x, c("wbWorkbook",   "R6"))

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -640,7 +640,12 @@ wb_load <- function(
 
   import_sheets <- seq_len(nrow(sheets))
   if (!missing(sheet)) {
-    import_sheets <- wb_validate_sheet(wb, sheet)
+    if (is.null(sheet)) {
+      import_sheets <- NULL
+    } else {
+      import_sheets <- wb_validate_sheet(wb, sheet)
+    }
+
     sheet <- import_sheets
     if (is.na(sheet)) {
       stop("No such sheet in the workbook. Workbook contains:\n",

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -50,6 +50,21 @@ test_that("get_date_origin from different sources", {
 })
 
 
+test_that("assert_workbook() is working", {
+  xlsxFile <- testfile_path("readTest.xlsx")
+
+  wb <- wb_load(example_file, sheet = NULL)
+  exp <- wb$get_sheet_names()
+
+  got <- wb_get_sheet_names(wb)
+  expect_equal(exp, got)
+
+  got <- wb_get_sheet_names(example_file)
+  expect_equal(exp, got)
+
+})
+
+
 test_that("read html source without r attribute on cell", {
 
   # sheet without row attribute


### PR DESCRIPTION
… sheet names without loading the sheets