### PR TITLE
[wb_add_drawing] read and add "mc:alternateContent"

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4540,9 +4540,10 @@ wbWorkbook <- R6::R6Class(
       xml <- read_xml(xml, pointer = FALSE)
 
       if (!(xml_node_name(xml) == "xdr:wsDr")) {
-        error("xml needs to be a drawing.")
+        stop("xml needs to be a drawing.")
       }
 
+      altc  <- xml_node(xml, "xdr:wsDr", "xdr:absoluteAnchor", "mc:AlternateContent")
       ext   <- xml_node(xml, "xdr:wsDr", "xdr:absoluteAnchor", "xdr:ext")
       pic   <- xml_node(xml, "xdr:wsDr", "xdr:absoluteAnchor", "xdr:pic")
       grpSp <- xml_node(xml, "xdr:wsDr", "xdr:absoluteAnchor", "xdr:grpSp")
@@ -4608,6 +4609,7 @@ wbWorkbook <- R6::R6Class(
           xdr_typ,
           xml_children = c(
             anchor,
+            altc,
             ext,
             pic,
             grpSp,


### PR DESCRIPTION
This fixes a typo and allows adding formulas with [`equatags`](https://github.com/ardata-fr/equatags/tree/main):

```R
eqs <- c(
  "(ax^2 + bx + c = 0)",
  "a \\ne 0",
  "x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}")

fml_xml <- function(x) {
  x <- equatags::transform_mathjax(x, to = "mml")
  x <- read_xml(x, pointer = FALSE)
  out <- sprintf('
<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
 <xdr:absoluteAnchor>
  <xdr:from>
   <xdr:col>1</xdr:col>
   <xdr:colOff>482600</xdr:colOff>
   <xdr:row>1</xdr:row>
   <xdr:rowOff>63500</xdr:rowOff>
  </xdr:from>
  <xdr:to>
   <xdr:col>13</xdr:col>
   <xdr:colOff>685800</xdr:colOff>
   <xdr:row>29</xdr:row>
   <xdr:rowOff>25400</xdr:rowOff>
  </xdr:to>
  <mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
   <mc:Choice xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" Requires="a14">
    <xdr:sp macro="" textlink="">
     <xdr:nvSpPr>
      <xdr:cNvPr id="2" name="TextBox 1">
       <a:extLst>
        <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
         <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{68830EB3-485E-DDCF-FBE6-813F0AC4CE78}" />
        </a:ext>
       </a:extLst>
      </xdr:cNvPr>
      <xdr:cNvSpPr txBox="1" />
     </xdr:nvSpPr>
     <xdr:spPr>
      <a:xfrm>
       <a:off x="1308100" y="266700" />
       <a:ext cx="10109200" cy="5651500" />
      </a:xfrm>
      <a:prstGeom prst="rect">
       <a:avLst />
      </a:prstGeom>
      <a:solidFill>
       <a:schemeClr val="lt1" />
      </a:solidFill>
      <a:ln w="9525" cmpd="sng">
       <a:solidFill>
        <a:schemeClr val="lt1">
         <a:shade val="50000" />
        </a:schemeClr>
       </a:solidFill>
      </a:ln>
     </xdr:spPr>
     <xdr:style>
      <a:lnRef idx="0">
       <a:scrgbClr r="0" g="0" b="0" />
      </a:lnRef>
      <a:fillRef idx="0">
       <a:scrgbClr r="0" g="0" b="0" />
      </a:fillRef>
      <a:effectRef idx="0">
       <a:scrgbClr r="0" g="0" b="0" />
      </a:effectRef>
      <a:fontRef idx="minor">
       <a:schemeClr val="dk1" />
      </a:fontRef>
     </xdr:style>
     <xdr:txBody>
      <a:bodyPr vertOverflow="clip" horzOverflow="clip" wrap="square" rtlCol="0" anchor="t" />
      <a:lstStyle />
      <a:p>
       <a14:m>
        <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
         <m:oMathParaPr>
          <m:jc m:val="centerGroup" />
         </m:oMathParaPr>
         %s
        </m:oMathPara>
       </a14:m>
       <a:endParaRPr lang="en-GB" sz="1100" />
      </a:p>
     </xdr:txBody>
    </xdr:sp>
   </mc:Choice>
  </mc:AlternateContent>
  <xdr:clientData />
 </xdr:absoluteAnchor>
</xdr:wsDr>', x)
  read_xml(out, pointer = FALSE)
}


library(openxlsx2)
wb <- wb_workbook()$add_worksheet()

wb$add_drawing(dims = "A1:B2", xml = fml_xml(eqs[1]))
wb$add_drawing(dims = "A3:B4", xml = fml_xml(eqs[2]))
wb$add_drawing(dims = "A5:D7", xml = fml_xml(eqs[3]))

wb$open()
```