### PR TITLE
[tests] improve testfile_path() to download files 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ Encoding: UTF-8
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
-Config/testthat/parallel: false
+Config/testthat/parallel: true
 Config/testthat/start-first: aaa

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1001,9 +1001,13 @@ testfile_path <- function(x, replace = FALSE) {
 
   fl <- testthat::test_path("testfiles", x)
 
+  if (Sys.getenv("openxlsx2_testthat_fullrun") == "") {
+    if (isTRUE(as.logical(Sys.getenv("CI", "false")))) # on_ci()
+      return(testthat::skip("Skip on CI"))
+  }
+
   # try to download
   if (!file.exists(fl) || replace) {
-    # relies on libcurl and was optional in R < 4.2.0 on Windows
     out <- paste0(test_path, "/", x)
     url <- paste0("https://github.com/JanMarvin/openxlsx-data/raw/main/", x)
     try({

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -989,72 +989,28 @@ expected_shared_strings <- function() {
 }
 
 
-#' initiates testfiles in local testthat folder
-download_testfiles <- function() {
-
-  fls <- c(
-    "charts.xlsx",
-    "cloneEmptyWorksheetExample.xlsx",
-    "cloneWorksheetExample.xlsx",
-    "ColorTabs3.xlsx",
-    "connection.xlsx",
-    "eurosymbol.xlsx",
-    "fichier_complementaire_ccam_descriptive_a_usage_pmsi_2021_v2.xlsx",
-    "form_control.xlsx",
-    "formula.xlsx",
-    "gh_issue_416.xlsm",
-    "gh_issue_504.xlsx",
-    "hyperlink.xlsb",
-    "inline_str.xlsx",
-    "inlineStr.xlsx",
-    "loadExample.xlsx",
-    "loadPivotTables.xlsx",
-    "loadThreadComment.xlsx",
-    "macro2.xlsm",
-    "mtcars_chart.xlsx",
-    "namedRegions.xlsx",
-    "namedRegions2.xlsx",
-    "nhs-core-standards-for-eprr-v6.1.xlsb",
-    "openxlsx2_example.xlsb",
-    "overwrite_formula.xlsx",
-    "oxlsx2_sheet.xlsx",
-    "pivot_notes.xlsx",
-    "readTest.xlsx",
-    "Single_hyperlink.xlsx",
-    "tableStyles.xlsx",
-    "umlauts.xlsx",
-    "unemployment-nrw202208.xlsx",
-    "update_test.xlsx",
-    "vml_numbering.xlsx"
-  )
+#' provides testfile path for testthat
+#' @param x a file assumed in testfiles folder
+testfile_path <- function(x, replace = FALSE) {
 
   test_path <- testthat::test_path("testfiles")
 
-  if (dir.exists(test_path))  {
-    if (all(file.exists(testthat::test_path("testfiles", fls)))) {
-      return(TRUE)
-    }
-
-    unlink(test_path, recursive = TRUE)
+  if (!dir.exists(test_path))  {
+    dir.create(test_path)
   }
 
-  dir.create(test_path)
-
-  # relies on libcurl and was optional in R < 4.2.0 on Windows
-  out <- paste0(test_path, "/", fls)
-  url <- paste0("https://github.com/JanMarvin/openxlsx-data/raw/main/", fls)
-  try({
-    download.file(url, destfile = out, quiet = TRUE, method = "libcurl")
-  })
-
-  return(TRUE)
-}
-
-#' provides testfile path for testthat
-#' @param x a file assumed in testfiles folder
-testfile_path <- function(x) {
-  # apparently this runs in a different folder
   fl <- testthat::test_path("testfiles", x)
+
+  # try to download
+  if (!file.exists(fl) || replace) {
+    # relies on libcurl and was optional in R < 4.2.0 on Windows
+    out <- paste0(test_path, "/", x)
+    url <- paste0("https://github.com/JanMarvin/openxlsx-data/raw/main/", x)
+    try({
+      download.file(url, destfile = out, quiet = TRUE)
+    })
+  }
+
   if (!file.exists(fl)) {
     return(testthat::skip("Testfile does not exist"))
   } else {

--- a/tests/testthat/test-aaa.R
+++ b/tests/testthat/test-aaa.R
@@ -1,9 +1,11 @@
 test_that("testsetup", {
 
-  options("openxlsx2.datetimeCreated" = as.POSIXct("2023-07-20 23:32:14"))
+  options("openxlsx2.datetimeCreated" = as.POSIXct("2023-07-20 23:32:14", tz = "UTC"))
 
-  if (Sys.getenv("openxlsx2_testthat_fullrun") == "") {
-    skip_on_ci()
-  }
+  wb <- wb_workbook()
+
+  exp <- "2023-07-20T23:32:14Z"
+  got <- wb$get_properties()[["datetime_created"]]
+  expect_equal(exp, got)
 
 })

--- a/tests/testthat/test-aaa.R
+++ b/tests/testthat/test-aaa.R
@@ -6,6 +6,4 @@ test_that("testsetup", {
     skip_on_ci()
   }
 
-  skip_if_offline()
-  expect_true(download_testfiles())
 })

--- a/tests/testthat/test-class-comment.R
+++ b/tests/testthat/test-class-comment.R
@@ -248,7 +248,8 @@ test_that("threaded comments work", {
     done = c("0", "")
   )
   got <- wb_get_thread(wb)[, -1]
-  expect_equal(exp, got)
+  # somehow the row ordering differs for parallel and non-parallel testthat runs
+  expect_equal(exp[order(got$displayName), ], got, ignore_attr = TRUE)
 
   exp <- "[Threaded comment]\n\nYour spreadsheet software allows you to read this threaded comment; however, any edits to it will get removed if the file is opened in a newer version of a certain spreadsheet software.\n\nComment: wow it works!\nReplie:fascinating"
   got <- wb_get_comment(wb)$comment


### PR DESCRIPTION
Previously all files were downloaded prior to testing. Now the download is triggered by testfile_path(). This allows restoring parallel tests.