### PR TITLE
[remove_worksheet] update activeTab. closes #792

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -3357,24 +3357,6 @@ wbWorkbook <- R6::R6Class(
         self$tables$tab_act[sel] <- 0
       }
 
-      # ## drawing will always be the first relationship
-      # if (nSheets > 1) {
-      #   for (i in seq_len(nSheets - 1L)) {
-      #     # did this get updated from length of 3 to 2?
-      #     #self$worksheets_rels[[i]][1:2] <- genBaseSheetRels(i)
-      #     rel <- rbindlist(xml_attr(self$worksheets_rels[[i]], "Relationship"))
-      #     if (nrow(rel) && ncol(rel)) {
-      #       if (any(basename(rel$Type) == "drawing")) {
-      #         rel$Target[basename(rel$Type) == "drawing"] <- sprintf("../drawings/drawing%s.xml", i)
-      #       }
-      #       if (is.null(rel$TargetMode)) rel$TargetMode <- ""
-      #       self$worksheets_rels[[i]] <- df_to_xml("Relationship", rel[c("Id", "Type", "Target", "TargetMode")])
-      #     }
-      #   }
-      # } else {
-      #   self$worksheets_rels <- list()
-      # }
-
       ## remove sheet
       sn <- apply_reg_match0(self$workbook$sheets, pat = '(?<= name=")[^"]+')
       self$workbook$sheets <- self$workbook$sheets[!sn %in% sheet_names]

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -3388,6 +3388,13 @@ wbWorkbook <- R6::R6Class(
             self$workbook$sheets,
             fixed = TRUE
           )
+          # these are zero indexed
+          self$workbook$bookViews <- gsub(
+            stri_join("activeTab=\"", i - 1L, "\""),
+            stri_join("activeTab=\"", i - 2L, "\""),
+            self$workbook$bookViews,
+            fixed = TRUE
+          )
         }
       } else {
         self$workbook$sheets <- NULL

--- a/tests/testthat/test-remove_worksheets.R
+++ b/tests/testthat/test-remove_worksheets.R
@@ -132,3 +132,21 @@ test_that("removing leading chartsheets works", {
   unlink(tmp_dir, recursive = TRUE)
 
 })
+
+test_that("bookViews activeTab attribute is updated", {
+
+  wb <- wb_workbook()$
+    add_worksheet()$
+    add_worksheet()
+
+  wb$set_active_sheet(2)
+  exp <- "<bookViews><workbookView activeTab=\"1\"/></bookViews>"
+  got <- wb$workbook$bookViews
+  expect_equal(exp, got)
+
+  wb$remove_worksheet(1)
+  exp <- "<bookViews><workbookView activeTab=\"0\"/></bookViews>"
+  got <- wb$workbook$bookViews
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Could you please double check with your files that it works as expected @chowmun63?
```R 
# the id of the PR, should be 793 or something
remotes::install_github("JanMarvin/openxlsx2#793)
```

The issue was that the last tab was active, but removed and the activeTab id was never updated. Therefore Excel complained.