### PR TITLE
[pivot_table] add sort_item param option

### DIFF
--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -851,3 +851,26 @@ test_that("numfmt in pivot tables works", {
   expect_equal(exp, got)
 
 })
+
+test_that("sort_item with pivot tables works", {
+
+wb <- wb_workbook() %>% wb_add_worksheet() %>% wb_add_data(x = mtcars)
+
+df <- wb_data(wb, sheet = 1)
+
+expect_silent(
+  wb_add_pivot_table(wb, df, dims = "A3",
+                     filter = "am", rows = "cyl", cols = "gear", data = "disp",
+                     params = list(sort_item = list(gear = c(3, 2, 1)))
+  )
+)
+
+expect_warning(
+  wb_add_pivot_table(wb, df, dims = "A3",
+                     filter = "am", rows = "cyl", cols = "gear", data = "disp",
+                     params = list(sort_item = list(gear = c(1)))
+  ),
+  "Length of sort order for 'gear' does not match required length. Is 1, needs 3."
+)
+
+})


### PR DESCRIPTION
Forgot to push this

```R
library(openxlsx2)

wb <- wb_workbook() %>% wb_add_worksheet() %>% wb_add_data(x = mtcars)

df <- wb_data(wb, sheet = 1)

wb <- wb %>%
  wb_add_pivot_table(df, dims = "A3",
                     filter = "am", rows = "cyl", cols = "gear", data = "disp",
                     params = list(sort_item = list(gear = c(3, 2, 1)))
  )
```