### PR TITLE
[properties] get/set keywords and comments

### DIFF
--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -11,7 +11,7 @@
 #' "Savon", "Slice", "Vapor Trail", "View", "Wisp", "Wood Type"
 #'
 #' @param creator Creator of the workbook (your name). Defaults to login username or `options("openxlsx2.creator")` if set.
-#' @param title,subject,category Workbook property, a string.
+#' @param title,subject,category,keywords,comments Workbook property, a string.
 #' @param datetime_created The time of the workbook is created
 #' @param theme Optional theme identified by string or number.
 #'   See **Details** for options.
@@ -39,6 +39,8 @@ wb_workbook <- function(
   category         = NULL,
   datetime_created = Sys.time(),
   theme            = NULL,
+  keywords         = NULL,
+  comments         = NULL,
   ...
 ) {
   wbWorkbook$new(
@@ -48,6 +50,8 @@ wb_workbook <- function(
     category         = category,
     datetime_created = datetime_created,
     theme            = theme,
+    keywords         = keywords,
+    comments         = comments,
     ...              = ...
   )
 }
@@ -2225,7 +2229,7 @@ wb_get_properties <- function(wb) {
 
 #' @rdname properties
 #' @export
-wb_set_properties <- function(wb, creators = NULL, title = NULL, subject = NULL, category = NULL, date_time_created = Sys.time(), modifiers = NULL) {
+wb_set_properties <- function(wb, creators = NULL, title = NULL, subject = NULL, category = NULL, date_time_created = Sys.time(), modifiers = NULL, keywords = NULL, comments = NULL) {
   assert_workbook(wb)
   wb$clone()$set_properties(
     creators          = creators,
@@ -2233,7 +2237,9 @@ wb_set_properties <- function(wb, creators = NULL, title = NULL, subject = NULL,
     subject           = subject,
     category          = category,
     date_time_created = date_time_created,
-    modifiers         = modifiers
+    modifiers         = modifiers,
+    keywords          = keywords,
+    comments          = comments
   )
 }
 

--- a/man/properties.Rd
+++ b/man/properties.Rd
@@ -15,7 +15,9 @@ wb_set_properties(
   subject = NULL,
   category = NULL,
   date_time_created = Sys.time(),
-  modifiers = NULL
+  modifiers = NULL,
+  keywords = NULL,
+  comments = NULL
 )
 }
 \arguments{
@@ -23,7 +25,7 @@ wb_set_properties(
 
 \item{creators}{A character string indicating who has created the workbook}
 
-\item{title, subject, category}{Workbook property, a string.}
+\item{title, subject, category, keywords, comments}{Workbook property, a string.}
 
 \item{date_time_created}{datetime created}
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -277,6 +277,8 @@ Creates a new \code{wbWorkbook} object
   category = NULL,
   datetime_created = Sys.time(),
   theme = NULL,
+  keywords = NULL,
+  comments = NULL,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -286,11 +288,7 @@ Creates a new \code{wbWorkbook} object
 \describe{
 \item{\code{creator}}{character vector of creators.  Duplicated are ignored.}
 
-\item{\code{title}}{title}
-
-\item{\code{subject}}{subject}
-
-\item{\code{category}}{category}
+\item{\code{title, subject, category, keywords, comments}}{workbook properties}
 
 \item{\code{datetime_created}}{The datetime (as \code{POSIXt}) the workbook is
 created.  Defaults to the current \code{Sys.time()} when the workbook object
@@ -2095,14 +2093,16 @@ Set a property of a workbook
   subject = NULL,
   category = NULL,
   date_time_created = Sys.time(),
-  modifiers = NULL
+  modifiers = NULL,
+  keywords = NULL,
+  comments = NULL
 )}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{creators, title, subject, category, date_time_created, modifiers}}{A workbook property to set}
+\item{\code{creators, title, subject, category, date_time_created, modifiers, keywords, comments}}{A workbook property to set}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wb_workbook.Rd
+++ b/man/wb_workbook.Rd
@@ -11,13 +11,15 @@ wb_workbook(
   category = NULL,
   datetime_created = Sys.time(),
   theme = NULL,
+  keywords = NULL,
+  comments = NULL,
   ...
 )
 }
 \arguments{
 \item{creator}{Creator of the workbook (your name). Defaults to login username or \code{options("openxlsx2.creator")} if set.}
 
-\item{title, subject, category}{Workbook property, a string.}
+\item{title, subject, category, keywords, comments}{Workbook property, a string.}
 
 \item{datetime_created}{The time of the workbook is created}
 

--- a/tests/testthat/test-class-workbook-wrappers.R
+++ b/tests/testthat/test-class-workbook-wrappers.R
@@ -131,7 +131,7 @@ test_that("wb_set_creators() is a wrapper", {
 # wb_remove_creators() ---------------------------------------------------------
 
 test_that("wb_remove_creators() is a wrapper", {
-  wb <- wb_workbook(creators = "myself")
+  wb <- wb_workbook(creator = "myself")
   expect_wrapper("remove_creators", wb = wb, params = list(creators = "myself"))
 })
 
@@ -180,7 +180,7 @@ test_that("wb_set_bookview() is a wrapper", {
 # wb_set_header_footer() ------------------------------------------------------
 
 test_that("wb_set_header_footer() is a wrapper", {
-  wb <- wb_workbook(creators = "myself")$add_worksheet("a")
+  wb <- wb_workbook(creator = "myself")$add_worksheet("a")
   expect_wrapper("set_header_footer", wb = wb, params = list(sheet = "a"))
 })
 

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -399,12 +399,36 @@ test_that("sheetView is not switched", {
 })
 
 test_that("Loading a workbook with property preserves it.", {
-  wb <- wb_workbook(title = "x")$add_worksheet()
+  wb <- wb_workbook(title = "x", creator = "y", subject = "z", category = "aa", keywords = "ab", comments = "ac")$add_worksheet()
   tmp <- temp_xlsx()
   wb$save(file = tmp)
 
   wb2 <- wb_load(tmp)
-  expect_equal(wb2$get_properties()[["dc:title"]], "x")
+  exp <- c(
+    `dc:title` = "x", `dc:subject` = "z", `dc:creator` = "y", `cp:keywords` = "ab",
+    `dc:description` = "ac",
+    `cp:lastModifiedBy` = "y", `cp:category` = "aa"
+  )
+  sel <- names(exp) # ignore creation date
+  got <- wb2$get_properties()
+  expect_equal(exp, got[sel])
+
   wb2$set_properties(title = "xyz")
   expect_equal(wb2$get_properties()[["dc:title"]], "xyz")
+
+  wb2$set_properties(subject = "aaa")
+  expect_equal(wb2$get_properties()[["dc:subject"]], "aaa")
+
+  wb2$set_properties(creator = "bbb")
+  expect_equal(wb2$get_properties()[["dc:creator"]], "bbb")
+
+  wb2$set_properties(keywords = "ccc")
+  expect_equal(wb2$get_properties()[["cp:keywords"]], "ccc")
+
+  wb2$set_properties(comments = "ddd")
+  expect_equal(wb2$get_properties()[["dc:description"]], "ddd")
+
+  wb2$set_properties(category = "eee")
+  expect_equal(wb2$get_properties()[["cp:category"]], "eee")
+
 })


### PR DESCRIPTION
This also adds more tests and cleans up the previous changes to properties

File properties fields Manager and Company are part of `wb$app`:
```r
wb$app[c("Company", "Manager")]
#> $Company
#> [1] "<Company>COMPANY</Company>"
#> 
#> $Manager
#> [1] "<Manager>MANAGER</Manager>"
```
We could add these to our set/get properties, but I don't use file properties at all and will not prepare a pull request for this.