### PR TITLE
[styles] allow `from` and `to` to be waivers

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6904,7 +6904,9 @@ wbWorkbook <- R6::R6Class(
     #' @param to the worksheet the style is applied to
     clone_sheet_style = function(from = current_sheet(), to) {
 
-      id_org <- private$get_sheet_index(from)
+      # clone is required, otherwise from sets the current sheet and to can
+      # not use current_sheet().
+      id_org <- self$clone()$.__enclos_env__$private$get_sheet_index(from)
       id_new <- private$get_sheet_index(to)
 
       org_style <- self$worksheets[[id_org]]$sheet_data$cc


### PR DESCRIPTION
This allows the following, came across this in the following [SO](https://stackoverflow.com/a/77208548/12340029). The issue at hand is that the first evaluation sets the `current_sheet()` no matter what the actual current sheet is.

I was considering updating the waiver code to add an argument or something similar, but there are not that many functions that take two potential sheets (clone worksheet and the one fixed here)

``` r
library(openxlsx2)

df <- data.frame(
  Date = Sys.Date() - 0:4, 
  Logical = c(TRUE, FALSE, TRUE, TRUE, FALSE),
  Currency = paste("$", -2:2),
  Accounting = -2:2,
  hLink = "https://CRAN.R-project.org/",
  Percentage = seq(-1, 1, length.out = 5), 
  TinyNumber = runif(5)/1e+09,
  stringsAsFactors = FALSE
)

dat_grouped <- df %>% dplyr::group_by(Date)

wb <- wb_workbook()$
  # first worksheet
  add_worksheet("1st")$
  add_data_table(x = dat_grouped, 
                 table_style = "TableStyleLight13")$
  set_col_widths(cols = "A:G", widths = c(10, 10, 10, 10, 25, 10, 10))$
  # second worksheet
  add_worksheet("2nd")$
  add_data_table(x = dat_grouped, 
                 table_style = "TableStyleLight13")$
  clone_sheet_style(from = "1st", to = openxlsx2::current_sheet())
  
if (interactive()) wb$open()
```