### PR TITLE
[wb_load] minimal workbook

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -8050,6 +8050,8 @@ wbWorkbook <- R6::R6Class(
 
 # helpers -----------------------------------------------------------------
 
+is_wbWorkbook <- function(x) inherits(x, c("wbWorkbook",   "R6"))
+
 lcr <- function(var) {
   # quick function for specifying error message
   paste(var, "must have length 3 where elements correspond to positions: left, center, right.")

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -723,9 +723,14 @@ wb_load <- function(
 
   import_sheets <- seq_len(nrow(sheets))
   if (!missing(sheet)) {
-    import_sheets <- wb_validate_sheet(wb, sheet)
+    if (is.null(sheet)) {
+      import_sheets <- NULL
+    } else {
+      import_sheets <- wb_validate_sheet(wb, sheet)
+    }
+
     sheet <- import_sheets
-    if (is.na(sheet)) {
+    if (!is.null(sheet) && is.na(sheet)) {
       stop("No such sheet in the workbook. Workbook contains:\n",
            paste(names(wb$get_sheet_names(escape = TRUE)), collapse = "\n"))
     }


### PR DESCRIPTION
This PR provides the safe part from #780
*  `is_wbWorkbook()` and 
*  allows to set `sheet = NULL` in `wb_load()`

This is helpful to load a workbook without any sheet information. Think of it like this, you want only the sheet names in a hundred MB size xlsx file. Obviously you should be able to load all the sheets, but you shouldn't have to. The worksheet information is in `workbook.xml` so you do not need anything else. With this PR you can do the following:

```R
# load only the bar minimum from a workbook
wb_load(x, sheet = NULL, data_only = TRUE)
```

Ideally this should be used in a few functions to restore a few `openxlsx` workflows like this - as suggested in our README
> Furthermore, there are several ways to read certain information of an openxml spreadsheet without having opened it in a spreadsheet software before, e.g. to get the contained sheet names or tables.

Both of these should work interchangeable
``` r
library(openxlsx2)
example_file <- system.file("extdata", "openxlsx2_example.xlsx", package = "openxlsx2")
wb_load(example_file, sheet = NULL, data_only = TRUE)$get_sheet_names()
#>   Sheet1   Sheet2 
#> "Sheet1" "Sheet2"
wb_get_sheet_names(example_file)
#> Error: wb must be class wbWorkbook or R6
```