### PR TITLE
[tests] cleanup options

### DIFF
--- a/tests/testthat/test-class-comment.R
+++ b/tests/testthat/test-class-comment.R
@@ -131,8 +131,10 @@ test_that("wb_add_comment", {
 
 test_that("wb_add_comment() works without supplying a wbComment object.", {
   # Do not alter the workspace
-  opt <- getOption("openxlsx2.creator")
-  options("openxlsx2.creator" = "user")
+
+  op <- options("openxlsx2.creator" = "user")
+  on.exit(options(op), add = TRUE)
+
   # Using the new default values of wb_comment() (options("openxlsx2.creators))
   wb <- wb_workbook()$add_worksheet()$add_comment(comment = "this is a comment", dims = "A1")
 
@@ -147,7 +149,6 @@ test_that("wb_add_comment() works without supplying a wbComment object.", {
   wb3 <- wb_workbook()$add_worksheet()$add_comment(comment = "this is a comment")
   expect_equal(wb$comments, wb3$comments)
 
-  options("openxlsx2.creator" = opt)
 })
 
 

--- a/tests/testthat/test-class-workbook-wrappers.R
+++ b/tests/testthat/test-class-workbook-wrappers.R
@@ -205,7 +205,8 @@ test_that("wb_add_image() is a wrapper", {
 test_that("wb_add_plot() is a wrapper", {
 
   # workaround: this filename is inserted to the wrapper function
-  options("openxlsx2.temp_png" = tempfile(pattern = "figureImage", fileext = ".png"))
+  op <- options("openxlsx2.temp_png" = tempfile(pattern = "figureImage", fileext = ".png"))
+  on.exit(options(op), add = TRUE)
 
   # create a device we can dev.copy() from
   grDevices::pdf(NULL) # do not create "Rplots.pdf"
@@ -388,8 +389,10 @@ test_that("wb_add_comment() is a wrapper", {
     wb = wb,
     params = list(comment = c1, dims = "A1")
   )
-  opt <- getOption("openxlsx2.creator")
-  options("openxlsx2.creator" = "user")
+
+  op <- options("openxlsx2.creator" = "user")
+  on.exit(options(op), add = TRUE)
+
   wb <- wb_workbook()$add_worksheet()
 
   expect_wrapper(
@@ -397,7 +400,7 @@ test_that("wb_add_comment() is a wrapper", {
     wb = wb,
     params = list(comment = "a new comment", dims = "A1")
   )
-  options("openxlsx2.creator" = opt)
+
 })
 
 # wb_remove_comment() -----------------------------------------------------

--- a/tests/testthat/test-class-worksheet.R
+++ b/tests/testthat/test-class-worksheet.R
@@ -68,7 +68,8 @@ test_that("set_sheetview", {
 
   exp <- "<sheetViews><sheetView rightToLeft=\"1\" showGridLines=\"1\" showRowColHeaders=\"1\" tabSelected=\"1\" workbookViewId=\"0\" zoomScale=\"100\"/></sheetViews>"
 
-  options("openxlsx2.rightToLeft" = TRUE)
+  op <- options("openxlsx2.rightToLeft" = TRUE)
+  on.exit(options(op), add = TRUE)
   wb <- wb_workbook()$add_worksheet()
 
   got <- wb$worksheets[[1]]$sheetViews

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -345,7 +345,9 @@ test_that("loading slicers works", {
   expect_equal(exp[-8], got)
 
 
-  options("openxlsx2.disableFullCalcOnLoad" = TRUE)
+  op <- options("openxlsx2.disableFullCalcOnLoad" = TRUE)
+  on.exit(options(op), add = TRUE)
+
   wb <- wb_load(file = fl, calc_chain = TRUE)
 
   exp <- "<calcPr calcId=\"152511\"/>"

--- a/tests/testthat/test-named_regions.R
+++ b/tests/testthat/test-named_regions.R
@@ -462,7 +462,8 @@ test_that("wb_named_regions() is not too noisy in its deprecation. (#764)", {
   expect_error(expect_warning(wb_get_named_regions(temp_file, x = 1)))
 
   opt_deprecation <- getOption("openxlsx2.soon_deprecated")
-  options("openxlsx2.soon_deprecated" = FALSE)
+  op <- options("openxlsx2.soon_deprecated" = FALSE)
+  on.exit(options(op), add = TRUE)
   wb <- wb_workbook()$add_worksheet()
   temp_file <- temp_xlsx()
   wb$save(temp_file)
@@ -473,7 +474,6 @@ test_that("wb_named_regions() is not too noisy in its deprecation. (#764)", {
   expect_warning(wb_get_named_regions(temp_file))
   expect_warning(expect_warning(wb_get_named_regions(x = temp_file)))
 
-  options("openxlsx2.soon_deprecated" = opt_deprecation)
 })
 
 test_that("named regions work.", {

--- a/tests/testthat/test-standardize.R
+++ b/tests/testthat/test-standardize.R
@@ -21,18 +21,15 @@ test_that("standardize works", {
 
 test_that("deprecation warning works", {
 
-  opt_deprecation <- getOption("openxlsx2.soon_deprecated")
-
   xlsxFile <- system.file("extdata", "openxlsx2_example.xlsx", package = "openxlsx2")
   wb1 <- wb_load(xlsxFile)
 
-  options("openxlsx2.soon_deprecated" = TRUE)
+  op <- options("openxlsx2.soon_deprecated" = TRUE)
+  on.exit(options(op), add = TRUE)
 
   expect_warning(
     wb_to_df(wb1, colNames = TRUE),
     "Found camelCase arguments in code. These will be deprecated in the next major release. Consider using: col_names"
   )
-  # Do not alter the global state.
-  options("openxlsx2.soon_deprecated" = opt_deprecation)
 
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -347,7 +347,8 @@ test_that("string formating", {
 
 test_that("outdec = \",\" works", {
 
-  options(OutDec = ",")
+  op <- options(OutDec = ",")
+  on.exit(options(op), add = TRUE)
 
   exp <- "[1] 1,1"
   got <- capture.output(print(1.1))

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -311,7 +311,8 @@ test_that("writeData() forces evaluation of x (#264)", {
 test_that("write character numerics with a correct cell style", {
 
   ## current default
-  options("openxlsx2.string_nums" = 0)
+  op <- options("openxlsx2.string_nums" = 0)
+  on.exit(options(op), add = TRUE)
 
   wb <- wb_workbook() %>%
     wb_add_worksheet() %>%
@@ -595,8 +596,11 @@ test_that("writing in specific encoding works", {
   loc <- Sys.getlocale("LC_CTYPE")
   Sys.setlocale("LC_CTYPE", "")
 
-  options("openxlsx2.force_utf8_encoding" = TRUE)
-  options("openxlsx2.native_encoding" = "CP1251")
+  op <- options(
+    "openxlsx2.force_utf8_encoding" = TRUE,
+    "openxlsx2.native_encoding" = "CP1251"
+  )
+  on.exit(options(op), add = TRUE)
 
   # a cyrillic string: https://github.com/JanMarvin/openxlsx2/issues/640
   enc_str <- as.raw(c(0xd0, 0xb0, 0xd0, 0xb1, 0xd0, 0xb2, 0xd0, 0xb3, 0xd0,

--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -1,5 +1,6 @@
 test_that("Writing Posixct with write_data & write_datatable", {
-  options("openxlsx2.datetimeFormat" = "dd/mm/yy hh:mm")
+  op <- options("openxlsx2.datetimeFormat" = "dd/mm/yy hh:mm")
+  on.exit(options(op), add = TRUE)
 
   tstart <- strptime("30/05/2017 08:30", "%d/%m/%Y %H:%M", tz = "CET")
   TimeDT <- c(0, 5, 10, 15, 30, 60, 120, 180, 240, 480, 720, 1440) * 60 + tstart
@@ -20,12 +21,12 @@ test_that("Writing Posixct with write_data & write_datatable", {
   expect_equal(wd$v[[3]], "42885.3541666667")
   expect_equal(wd$is[[4]], "<is><t>2017-05-30 08:30</t></is>")
 
-  options("openxlsx2.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")
 })
 
 # missing datetime is not yet implemented
 test_that("Writing mixed EDT/EST Posixct with write_data & write_datatable", {
-  options("openxlsx2.datetimeFormat" = "dd/mm/yy hh:mm")
+  op <- options("openxlsx2.datetimeFormat" = "dd/mm/yy hh:mm")
+  on.exit(options(op), add = TRUE)
 
   tstart1 <- as.POSIXct("12/03/2018 08:30", format = "%d/%m/%Y %H:%M")
   tstart2 <- as.POSIXct("10/03/2018 08:30", format = "%d/%m/%Y %H:%M")
@@ -68,5 +69,4 @@ test_that("Writing mixed EDT/EST Posixct with write_data & write_datatable", {
   got <- wb_s2$timetxt
   expect_equal(exp, got)
 
-  options("openxlsx2.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")
 })


### PR DESCRIPTION
I always assumed that the options are only valid for a single testthat chunk, but they are not and therefore some were carried over the entire test run