### PR TITLE
[pivot tables] add `show_data_as` and `compact`/`outline`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # openxlsx2 (development version)
 
+* Add new params to `wb_add_pivot_table()`. It is now possible to set the `show_data_as` value and set a tabular table design. [833](https://github.com/JanMarvin/openxlsx2/pull/833)
+
 
 ***************************************************************************
 

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -305,6 +305,9 @@ wb_add_data_table <- function(
 #' `fun` can be any of `AVERAGE`, `COUNT`, `COUNTA`, `MAX`, `MIN`,
 #' `PRODUCT`, `STDEV`, `STDEVP`, `SUM`, `VAR`, `VARP`.
 #'
+#' `show_data_as` can be any of `normal`, `difference`, `percent`, `percentDiff`,
+#' `runTotal`, `percentOfRow`, `percentOfCol`, `percentOfTotal`, `index`.
+#'
 #' The sheet will be empty unless it is opened in spreadsheet software.
 #'
 #' @param wb A Workbook object containing a #' worksheet.

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -758,6 +758,15 @@ create_pivot_table <- function(
   }
 
   pivotField <- NULL
+
+  compact <- ""
+  if (!is.null(params$compact))
+    compact <- params$compact
+
+  outline <- ""
+  if (!is.null(params$outline))
+    outline <- params$outline
+
   for (i in seq_along(x)) {
 
     dataField <- NULL
@@ -814,7 +823,10 @@ create_pivot_table <- function(
       else                  sort <- "ascending"
     }
 
-    attrs <- c(axis, dataField, showAll = "0", sortType = sort)
+    attrs <- c(
+      axis, dataField, showAll = "0", sortType = sort,
+      compact = as_xml_attr(compact), outline = as_xml_attr(outline)
+    )
 
     tmp <- xml_node_create(
       "pivotField",
@@ -991,10 +1003,6 @@ create_pivot_table <- function(
   multipleFieldFilters <- "0"
   if (!is.null(params$multipleFieldFilters))
     multipleFieldFilters <- params$multipleFieldFilters
-
-  outline <- "1"
-  if (!is.null(params$outline))
-    outline <- params$outline
 
   outlineData <- "1"
   if (!is.null(params$outlineData))

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -879,6 +879,11 @@ create_pivot_table <- function(
   if (use_data) {
 
     dataField <- NULL
+
+    show_data_as <- rep("", length(data))
+    if (!is.null(params$show_data_as))
+      show_data_as <- params$show_data_as
+
     for (i in seq_along(data)) {
 
       if (missing(fun)) fun <- NULL
@@ -888,12 +893,13 @@ create_pivot_table <- function(
         xml_node_create(
           "dataField",
           xml_attributes = c(
-            name      = sprintf("%s of %s", ifelse(is.null(fun[i]), "Sum", fun[i]), data[i]),
-            fld       = sprintf("%s", data_pos[i] - 1L),
-            subtotal  = fun[i],
-            baseField = "0",
-            baseItem  = "0",
-            numFmtId  = numfmts[i]
+            name       = sprintf("%s of %s", ifelse(is.null(fun[i]), "Sum", fun[i]), data[i]),
+            fld        = sprintf("%s", data_pos[i] - 1L),
+            showDataAs = as_xml_attr(ifelse(is.null(show_data_as[i]), "", show_data_as[i])),
+            subtotal   = fun[i],
+            baseField  = "0",
+            baseItem   = "0",
+            numFmtId   = numfmts[i]
           )
         )
       )

--- a/man/wb_add_pivot_table.Rd
+++ b/man/wb_add_pivot_table.Rd
@@ -52,6 +52,9 @@ to ensure the function works.
 \code{fun} can be any of \code{AVERAGE}, \code{COUNT}, \code{COUNTA}, \code{MAX}, \code{MIN},
 \code{PRODUCT}, \code{STDEV}, \code{STDEVP}, \code{SUM}, \code{VAR}, \code{VARP}.
 
+\code{show_data_as} can be any of \code{normal}, \code{difference}, \code{percent}, \code{percentDiff},
+\code{runTotal}, \code{percentOfRow}, \code{percentOfCol}, \code{percentOfTotal}, \code{index}.
+
 The sheet will be empty unless it is opened in spreadsheet software.
 }
 \examples{


### PR DESCRIPTION
```r
library(openxlsx2)

wb <- wb_workbook() %>% wb_add_worksheet() %>% wb_add_data(x = mtcars)

df <- wb_data(wb, sheet = 1)

wb <- wb %>%
  wb_add_pivot_table(
    df,
    dims = "A3",
    filter = "am",
    rows = "cyl",
    cols = "gear",
    data = "disp",
    params = list(
      show_data_as = c("percentOfRow"),
      numfmts = c(formatCode = "#.##%")
    )
  )

if (interactive()) wb$open()
```