### PR TITLE
[pivot tables] use standardize_case_names() and as_xml_attr()

### DIFF
--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -758,6 +758,31 @@ create_pivot_table <- function(
   }
 
   pivotField <- NULL
+  arguments <- c(
+    "apply_alignment_formats", "apply_border_formats", "apply_font_formats",
+    "apply_number_formats", "apply_pattern_formats", "apply_width_height_formats",
+    "apply_width_height_formats", "asterisk_totals", "auto_format_id",
+    "chart_format", "col_grand_totals", "col_header_caption", "compact",
+    "compact", "compact_data", "custom_list_sort", "data_caption",
+    "data_on_rows", "data_position", "disable_field_list", "edit_data",
+    "enable_drill", "enable_field_properties", "enable_wizard", "error_caption",
+    "field_list_sort_ascending", "field_print_titles", "grand_total_caption",
+    "grid_drop_zones", "immersive", "indent", "item_print_titles",
+    "mdx_subqueries", "merge_item", "missing_caption", "multiple_field_filters",
+    "name", "no_style", "numfmt", "outline", "outline_data", "page_over_then_down",
+    "page_style", "page_wrap", "preserve_formatting", "print_drill",
+    "published", "row_grand_totals", "row_header_caption", "show_calc_mbrs",
+    "show_col_headers", "show_col_stripes", "show_data_as", "show_data_drop_down",
+    "show_data_tips", "show_drill", "show_drop_zones", "show_empty_col",
+    "show_empty_row", "show_error", "show_headers", "show_items",
+    "show_last_column", "show_member_property_tips", "show_missing",
+    "show_multiple_label", "show_row_headers", "show_row_stripes",
+    "sort_col", "sort_item", "sort_row", "subtotal_hidden_items",
+    "table_style", "tag", "use_auto_formatting", "vacated_style",
+    "visual_totals"
+  )
+  params <- standardize_case_names(params, arguments = arguments, return = TRUE)
+
 
   compact <- ""
   if (!is.null(params$compact))
@@ -943,28 +968,28 @@ create_pivot_table <- function(
     table_style <- params$table_style
 
   dataCaption <- "Values"
-  if (!is.null(params$dataCaption))
-    dataCaption <- params$dataCaption
+  if (!is.null(params$data_caption))
+    dataCaption <- params$data_caption
 
   showRowHeaders <- "1"
-  if (!is.null(params$showRowHeaders))
-    showRowHeaders <- params$showRowHeaders
+  if (!is.null(params$show_row_headers))
+    showRowHeaders <- params$show_row_headers
 
   showColHeaders <- "1"
-  if (!is.null(params$showColHeaders))
-    showColHeaders <- params$showColHeaders
+  if (!is.null(params$show_col_headers))
+    showColHeaders <- params$show_col_headers
 
   showRowStripes <- "0"
-  if (!is.null(params$showRowStripes))
-    showRowStripes <- params$showRowStripes
+  if (!is.null(params$show_row_stripes))
+    showRowStripes <- params$show_row_stripes
 
   showColStripes <- "0"
-  if (!is.null(params$showColStripes))
-    showColStripes <- params$showColStripes
+  if (!is.null(params$show_col_stripes))
+    showColStripes <- params$show_col_stripes
 
   showLastColumn <- "1"
-  if (!is.null(params$showLastColumn))
-    showLastColumn <- params$showLastColumn
+  if (!is.null(params$show_last_column))
+    showLastColumn <- params$show_last_column
 
   pivotTableStyleInfo <- xml_node_create(
     "pivotTableStyleInfo",
@@ -978,17 +1003,6 @@ create_pivot_table <- function(
     )
   )
 
-  # extLst <- paste0(
-  #   '<extLst>',
-  #   '<ext xmlns:xpdl="http://schemas.microsoft.com/office/spreadsheetml/2016/pivotdefaultlayout" uri="{747A6164-185A-40DC-8AA5-F01512510D54}">',
-  #   '<xpdl:pivotTableDefinition16/>',
-  #   '</ext>',
-  #   '<ext xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" uri="{725AE2AE-9491-48be-B2B4-4EB974FC3084}">',
-  #   '<x14:pivotCacheDefinition/>',
-  #   '</ext>',
-  #   '</extLst>'
-  # )
-
   if (isTRUE(params$no_style))
     pivotTableStyleInfo <- ""
 
@@ -997,44 +1011,44 @@ create_pivot_table <- function(
     indent <- params$indent
 
   itemPrintTitles <- "1"
-  if (!is.null(params$itemPrintTitles))
-    itemPrintTitles <- params$itemPrintTitles
+  if (!is.null(params$item_print_titles))
+    itemPrintTitles <- params$item_print_titles
 
   multipleFieldFilters <- "0"
-  if (!is.null(params$multipleFieldFilters))
-    multipleFieldFilters <- params$multipleFieldFilters
+  if (!is.null(params$multiple_field_filters))
+    multipleFieldFilters <- params$multiple_field_filters
 
   outlineData <- "1"
-  if (!is.null(params$outlineData))
-    outlineData <- params$outlineData
+  if (!is.null(params$outline_data))
+    outlineData <- params$outline_data
 
   useAutoFormatting <- "1"
-  if (!is.null(params$useAutoFormatting))
-    useAutoFormatting <- params$useAutoFormatting
+  if (!is.null(params$use_auto_formatting))
+    useAutoFormatting <- params$use_auto_formatting
 
   applyAlignmentFormats <- "0"
-  if (!is.null(params$applyAlignmentFormats))
-    applyAlignmentFormats <- params$applyAlignmentFormats
+  if (!is.null(params$apply_alignment_formats))
+    applyAlignmentFormats <- params$apply_alignment_formats
 
   applyNumberFormats <- "0"
-  if (!is.null(params$applyNumberFormats))
-    applyNumberFormats <- params$applyNumberFormats
+  if (!is.null(params$apply_number_formats))
+    applyNumberFormats <- params$apply_number_formats
 
   applyBorderFormats <- "0"
-  if (!is.null(params$applyBorderFormats))
-    applyBorderFormats <- params$applyBorderFormats
+  if (!is.null(params$apply_border_formats))
+    applyBorderFormats <- params$apply_border_formats
 
   applyFontFormats <- "0"
-  if (!is.null(params$applyFontFormats))
-    applyFontFormats <- params$applyFontFormats
+  if (!is.null(params$apply_font_formats))
+    applyFontFormats <- params$apply_font_formats
 
   applyPatternFormats <- "0"
-  if (!is.null(params$applyPatternFormats))
-    applyPatternFormats <- params$applyPatternFormats
+  if (!is.null(params$apply_pattern_formats))
+    applyPatternFormats <- params$apply_pattern_formats
 
   applyWidthHeightFormats <- "1"
-  if (!is.null(params$applyWidthHeightFormats))
-    applyWidthHeightFormats <- params$applyWidthHeightFormats
+  if (!is.null(params$apply_width_height_formats))
+    applyWidthHeightFormats <- params$apply_width_height_formats
 
   pivot_table_name <- sprintf("PivotTable%s", n)
   if (!is.null(params$name))
@@ -1047,74 +1061,74 @@ create_pivot_table <- function(
       `xmlns:mc`              = "http://schemas.openxmlformats.org/markup-compatibility/2006",
       `mc:Ignorable`          = "xr",
       `xmlns:xr`              = "http://schemas.microsoft.com/office/spreadsheetml/2014/revision",
-      name                    = pivot_table_name,
-      cacheId                 = as.character(n),
-      applyNumberFormats      = applyNumberFormats,
-      applyBorderFormats      = applyBorderFormats,
-      applyFontFormats        = applyFontFormats,
-      applyPatternFormats     = applyPatternFormats,
-      applyAlignmentFormats   = applyAlignmentFormats,
-      applyWidthHeightFormats = applyWidthHeightFormats,
-      asteriskTotals          = params$asteriskTotals,
-      autoFormatId            = params$autoFormatId,
-      chartFormat             = params$chartFormat,
-      dataCaption             = dataCaption,
+      name                    = as_xml_attr(pivot_table_name),
+      cacheId                 = as_xml_attr(n),
+      applyNumberFormats      = as_xml_attr(applyNumberFormats),
+      applyBorderFormats      = as_xml_attr(applyBorderFormats),
+      applyFontFormats        = as_xml_attr(applyFontFormats),
+      applyPatternFormats     = as_xml_attr(applyPatternFormats),
+      applyAlignmentFormats   = as_xml_attr(applyAlignmentFormats),
+      applyWidthHeightFormats = as_xml_attr(applyWidthHeightFormats),
+      asteriskTotals          = as_xml_attr(params$asterisk_totals),
+      autoFormatId            = as_xml_attr(params$auto_format_id),
+      chartFormat             = as_xml_attr(params$chart_format),
+      dataCaption             = as_xml_attr(dataCaption),
       updatedVersion          = "8",
       minRefreshableVersion   = "3",
-      useAutoFormatting       = useAutoFormatting,
-      itemPrintTitles         = itemPrintTitles,
+      useAutoFormatting       = as_xml_attr(useAutoFormatting),
+      itemPrintTitles         = as_xml_attr(itemPrintTitles),
       createdVersion          = "8",
-      indent                  = indent,
-      outline                 = outline,
-      outlineData             = outlineData,
-      multipleFieldFilters    = multipleFieldFilters,
-      colGrandTotals          = params$colGrandTotals,
-      colHeaderCaption        = params$colHeaderCaption,
-      compact                 = params$compact,
-      compactData             = params$compactData,
-      customListSort          = params$customListSort,
-      dataOnRows              = params$dataOnRows,
-      dataPosition            = params$dataPosition,
-      disableFieldList        = params$disableFieldList,
-      editData                = params$editData,
-      enableDrill             = params$enableDrill,
-      enableFieldProperties   = params$enableFieldProperties,
-      enableWizard            = params$enableWizard,
-      errorCaption            = params$errorCaption,
-      fieldListSortAscending  = params$fieldListSortAscending,
-      fieldPrintTitles        = params$fieldPrintTitles,
-      grandTotalCaption       = params$grandTotalCaption,
-      gridDropZones           = params$gridDropZones,
-      immersive               = params$immersive,
-      mdxSubqueries           = params$mdxSubqueries,
-      missingCaption          = params$missingCaption,
-      mergeItem               = params$mergeItem,
-      pageOverThenDown        = params$pageOverThenDown,
-      pageStyle               = params$pageStyle,
-      pageWrap                = params$pageWrap,
+      indent                  = as_xml_attr(indent),
+      outline                 = as_xml_attr(outline),
+      outlineData             = as_xml_attr(outlineData),
+      multipleFieldFilters    = as_xml_attr(multipleFieldFilters),
+      colGrandTotals          = as_xml_attr(params$col_grand_totals),
+      colHeaderCaption        = as_xml_attr(params$col_header_caption),
+      compact                 = as_xml_attr(params$compact),
+      compactData             = as_xml_attr(params$compact_data),
+      customListSort          = as_xml_attr(params$custom_list_sort),
+      dataOnRows              = as_xml_attr(params$data_on_rows),
+      dataPosition            = as_xml_attr(params$data_position),
+      disableFieldList        = as_xml_attr(params$disable_field_list),
+      editData                = as_xml_attr(params$edit_data),
+      enableDrill             = as_xml_attr(params$enable_drill),
+      enableFieldProperties   = as_xml_attr(params$enable_field_properties),
+      enableWizard            = as_xml_attr(params$enable_wizard),
+      errorCaption            = as_xml_attr(params$error_caption),
+      fieldListSortAscending  = as_xml_attr(params$field_list_sort_ascending),
+      fieldPrintTitles        = as_xml_attr(params$field_print_titles),
+      grandTotalCaption       = as_xml_attr(params$grand_total_caption),
+      gridDropZones           = as_xml_attr(params$grid_drop_zones),
+      immersive               = as_xml_attr(params$immersive),
+      mdxSubqueries           = as_xml_attr(params$mdx_subqueries),
+      missingCaption          = as_xml_attr(params$missing_caption),
+      mergeItem               = as_xml_attr(params$merge_item),
+      pageOverThenDown        = as_xml_attr(params$page_over_then_down),
+      pageStyle               = as_xml_attr(params$page_style),
+      pageWrap                = as_xml_attr(params$page_wrap),
       # pivotTableStyle
-      preserveFormatting      = params$preserveFormatting,
-      printDrill              = params$printDrill,
-      published               = params$published,
-      rowGrandTotals          = params$rowGrandTotals,
-      rowHeaderCaption        = params$rowHeaderCaption,
-      showCalcMbrs            = params$showCalcMbrs,
-      showDataDropDown        = params$showDataDropDown,
-      showDataTips            = params$showDataTips,
-      showDrill               = params$showDrill,
-      showDropZones           = params$showDropZones,
-      showEmptyCol            = params$showEmptyCol,
-      showEmptyRow            = params$showEmptyRow,
-      showError               = params$showError,
-      showHeaders             = params$showHeaders,
-      showItems               = params$showItems,
-      showMemberPropertyTips  = params$showMemberPropertyTips,
-      showMissing             = params$showMissing,
-      showMultipleLabel       = params$showMultipleLabel,
-      subtotalHiddenItems     = params$subtotalHiddenItems,
-      tag                     = params$tag,
-      vacatedStyle            = params$vacatedStyle,
-      visualTotals            = params$visualTotals
+      preserveFormatting      = as_xml_attr(params$preserve_formatting),
+      printDrill              = as_xml_attr(params$print_drill),
+      published               = as_xml_attr(params$published),
+      rowGrandTotals          = as_xml_attr(params$row_grand_totals),
+      rowHeaderCaption        = as_xml_attr(params$row_header_caption),
+      showCalcMbrs            = as_xml_attr(params$show_calc_mbrs),
+      showDataDropDown        = as_xml_attr(params$show_data_drop_down),
+      showDataTips            = as_xml_attr(params$show_data_tips),
+      showDrill               = as_xml_attr(params$show_drill),
+      showDropZones           = as_xml_attr(params$show_drop_zones),
+      showEmptyCol            = as_xml_attr(params$show_empty_col),
+      showEmptyRow            = as_xml_attr(params$show_empty_row),
+      showError               = as_xml_attr(params$show_error),
+      showHeaders             = as_xml_attr(params$show_headers),
+      showItems               = as_xml_attr(params$show_items),
+      showMemberPropertyTips  = as_xml_attr(params$show_member_property_tips),
+      showMissing             = as_xml_attr(params$show_missing),
+      showMultipleLabel       = as_xml_attr(params$show_multiple_label),
+      subtotalHiddenItems     = as_xml_attr(params$subtotal_hidden_items),
+      tag                     = as_xml_attr(params$tag),
+      vacatedStyle            = as_xml_attr(params$vacated_style),
+      visualTotals            = as_xml_attr(params$visual_totals)
     ),
     # xr:uid="{375073AB-E7CA-C149-922E-A999C47476C1}"
     xml_children =  paste0(

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -775,10 +775,10 @@ test_that("numfmt in pivot tables works", {
                     filter = c("Location", "Status"), data = "Units")$
     add_pivot_table(df, dims = "A3", rows = "Plant",
                     filter = c("Location", "Status"), data = "Units",
-                    param = list(numfmts = c(formatCode = "#,###0"), sort_row = "ascending"))$
+                    param = list(numfmt = c(formatCode = "#,###0"), sort_row = "ascending"))$
     add_pivot_table(df, dims = "A3", rows = "Plant",
                     filter = c("Location", "Status"), data = "Units",
-                    param = list(numfmts = c(numfmt = 10), sort_row = "descending"))
+                    param = list(numfmt = c(numfmt = 10), sort_row = "descending"))
 
   exp <- c(
     "<dataField name=\"Sum of Units\" fld=\"3\" baseField=\"0\" baseItem=\"0\"/>",
@@ -821,7 +821,7 @@ test_that("numfmt in pivot tables works", {
   expect_error(
     wb$add_pivot_table(df, dims = "A3", rows = "cyl", cols = "gear",
                        data = c("vs", "am"),
-                       param = list(numfmts = c(numfmt = 10))),
+                       param = list(numfmt = c(numfmt = 10))),
     "length of numfmt and data does not match"
   )
 


### PR DESCRIPTION
Now the following works
``` r
# adapted example from https://janmarvin.github.io/ox2-book/chapters/openxlsx2_pivot_tables.html
library(openxlsx2)

wb <- wb_workbook() %>% wb_add_worksheet() %>% wb_add_data(x = mtcars, inline_strings = F)

df <- wb_data(wb)

# nested pivot table with two variables for column, row and data and two different functions
# uses an autoformatid (not that I like it, just because I can do it)
wb$add_pivot_table(
  df,
  rows = c("cyl", "mpg"),
  cols = c("vs","gear"),
  data = c("disp", "hp"),
  fun  = c("sum", "average"),
  params = list(
    apply_alignment_formats    = TRUE,
    apply_number_formats       = TRUE,
    apply_border_formats       = TRUE,
    apply_font_formats         = TRUE,
    apply_pattern_formats      = TRUE,
    apply_width_height_formats = TRUE,
    auto_format_id             = 4099,
    data_caption               = "Foo"
  )
)

if (interactive()) wb$open()
```