### PR TITLE
Document options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,7 +68,7 @@ They will continue to work for some time, but changing to newer functions is rec
 
 * `wb_comment()` is a new helper function to help create `wbComment` objects
   It is very similar to `create_comment()`, with the following differences:
-  * `author` looks at `options("openxlsx2.creator")`; (`create_comment()` only used `sys.getenv("USERNAME")`)
+  * `author` looks at `options("openxlsx2.creator")`; (`create_comment()` only used `sys.getenv("USERNAME")` / `Sys.getenv("USER")`)
   * `visible` defaults to `FALSE` to account for modern spreadsheet software behavior. (`create_comment()`, it is `TRUE`).
   * `width` and `height` must now be of length 1. (In `create_comment()`, the first element is taken, other are ignored.)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,7 +68,7 @@ They will continue to work for some time, but changing to newer functions is rec
 
 * `wb_comment()` is a new helper function to help create `wbComment` objects
   It is very similar to `create_comment()`, with the following differences:
-  * `author` looks at `options("openxlsx2.creator")`; (`create_comment()` only used `sys.getenv("user")`)
+  * `author` looks at `options("openxlsx2.creator")`; (`create_comment()` only used `sys.getenv("USERNAME")`)
   * `visible` defaults to `FALSE` to account for modern spreadsheet software behavior. (`create_comment()`, it is `TRUE`).
   * `width` and `height` must now be of length 1. (In `create_comment()`, the first element is taken, other are ignored.)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 * Improve copying cells in transpose mode and with hyperlinks. [850](https://github.com/JanMarvin/openxlsx2/pull/850)
 
+* Options `openxlsx2.maxWidth` and `openxlsx2.minWidth` are now respected as documented when setting column widths with `wb_set_col_widths()`. [847](https://github.com/JanMarvin/openxlsx2/issues/847)
 
 ***************************************************************************
 

--- a/R/class-comment.R
+++ b/R/class-comment.R
@@ -118,7 +118,7 @@ wb_comment <- function(text = NULL,
                        width = 2,
                        height = 4) {
   # Code copied from the wbWorkbook
-  author <- author %||% Sys.getenv("USERNAME")
+  author <- author %||% Sys.getenv("USERNAME", unset = Sys.getenv("USER"))
   text <- text %||% ""
   assert_class(author, "character")
   assert_class(text, "character")

--- a/R/class-comment.R
+++ b/R/class-comment.R
@@ -118,7 +118,7 @@ wb_comment <- function(text = NULL,
                        width = 2,
                        height = 4) {
   # Code copied from the wbWorkbook
-  author <- author %||% Sys.getenv("USERNAME")
+  author <- author %||% Sys.getenv("USERNAME") %||% Sys.getenv("USER")
   text <- text %||% ""
   assert_class(author, "character")
   assert_class(text, "character")

--- a/R/class-comment.R
+++ b/R/class-comment.R
@@ -118,7 +118,7 @@ wb_comment <- function(text = NULL,
                        width = 2,
                        height = 4) {
   # Code copied from the wbWorkbook
-  author <- author %||% Sys.getenv("USERNAME") %||% Sys.getenv("USER")
+  author <- author %||% Sys.getenv("USERNAME")
   text <- text %||% ""
   assert_class(author, "character")
   assert_class(text, "character")

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -190,8 +190,9 @@ wbWorkbook <- R6::R6Class(
       self$Content_Types <- genBaseContent_Type()
 
       creator <- creator %||%
-        getOption("openxlsx2.creator", default = Sys.getenv("USERNAME"))
-        # USERNAME should be present for all OS (Windows, Mac, Linux)
+        getOption("openxlsx2.creator",
+                  default = Sys.getenv("USERNAME", unset = Sys.getenv("USER")))
+        # USERNAME is present for (Windows, Linux) "USER" is present for Mac
 
       datetime_created <- getOption("openxlsx2.datetimeCreated", datetime_created)
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -190,12 +190,12 @@ wbWorkbook <- R6::R6Class(
       self$Content_Types <- genBaseContent_Type()
 
       creator <- creator %||%
-        getOption("openxlsx2.creator") %||%
+        getOption("openxlsx2.creator", default = Sys.getenv("USERNAME")) %||%
         # USERNAME may only be present for windows
-        Sys.getenv("USERNAME", Sys.getenv("USER"))
+        Sys.getenv("USER")
 
-      datetime_created <- getOption("openxlsx2.datetimeCreated") %||%
-        datetime_created
+      datetime_created <- getOption("openxlsx2.datetimeCreated", datetime_created)
+
 
       assert_class(creator,          "character")
       assert_class(title,            "character", or_null = TRUE)
@@ -4269,7 +4269,7 @@ wbWorkbook <- R6::R6Class(
         done <- as_xml_attr(resolve)
         if (reply) done <- NULL
 
-        ts <- getOption("openxlsx2.datetimeCreated") %||% Sys.time()
+        ts <- getOption("openxlsx2.datetimeCreated", default = Sys.time())
 
         tc <- xml_node_create(
           "threadedComment",
@@ -5587,8 +5587,9 @@ wbWorkbook <- R6::R6Class(
       company          = NULL
     ) {
 
-      datetime_created <- getOption("openxlsx2.datetimeCreated") %||%
-        datetime_created
+      datetime_created <-
+        getOption("openxlsx2.datetimeCreated", datetime_created)
+
 
       core_dctitle <- "dc:title"
       core_subject <- "dc:subject"

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -190,9 +190,8 @@ wbWorkbook <- R6::R6Class(
       self$Content_Types <- genBaseContent_Type()
 
       creator <- creator %||%
-        getOption("openxlsx2.creator", default = Sys.getenv("USERNAME")) %||%
-        # USERNAME may only be present for windows
-        Sys.getenv("USER")
+        getOption("openxlsx2.creator", default = Sys.getenv("USERNAME"))
+        # USERNAME should be present for all OS (Windows, Mac, Linux)
 
       datetime_created <- getOption("openxlsx2.datetimeCreated", datetime_created)
 

--- a/R/conditional_formatting.R
+++ b/R/conditional_formatting.R
@@ -114,8 +114,8 @@ cf_create_databar <- function(extLst, formula, params, sqref, values) {
   newExtLst <- gen_databar_extlst(
     guid      = guid,
     sqref     = sqref,
-    posColor = posColor,
-    negColor = negColor,
+    posColor  = posColor,
+    negColor  = negColor,
     values    = values,
     border    = border,
     gradient  = gradient

--- a/R/converters.R
+++ b/R/converters.R
@@ -108,8 +108,14 @@ calc_col_width <- function(base_font, col_width) {
   # to the expected widths
   widths <- trunc((as.numeric(col_width) * mdw + 5) / mdw * 256) / 256
   widths <- round(widths, 3)
-  if (any(sel <- widths > getOption("openxlsx2.maxWidth"))) {
-    widths[sel] <- getOption("openxlsx2.maxWidth")
+
+  if (any(sel <- widths > getOption("openxlsx2.maxWidth", 250))) {
+    widths[sel] <- getOption("openxlsx2.maxWidth", 250)
   }
+
+  if (any(sel <- widths <= getOption("openxlsx2.minWidth", 0))) {
+    widths[sel] <- getOption("openxlsx2.minWidth", 1)
+  }
+
   widths
 }

--- a/R/openxlsx2-package.R
+++ b/R/openxlsx2-package.R
@@ -70,6 +70,8 @@
 #' * `options("openxlsx2.borderStyle" = "thin")`
 #' * `options("openxlsx2.dateFormat" = "mm/dd/yyyy")`
 #' * `options("openxlsx2.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")`
+#' * `options("openxlsx2.maxWidth" = NULL)` (Maximum width allowed in Excel is 250)
+#' * `options("openxlsx2.minWidth" = NULL)`
 #' * `options("openxlsx2.numFmt" = NULL)`
 #' * `options("openxlsx2.paperSize" = 9)` corresponds to a A4 paper size
 #' * `options("openxlsx2.orientation" = "portrait")` page orientation
@@ -81,7 +83,10 @@
 #'   `wbWorkbook` object with [wb_workbook()] or new comments with [wb_add_comment()]
 #' * `options("openxlsx2.thread_id")` the default person id when adding a threaded comment
 #'   to a cell with [wb_add_thread()]
-#'
+#' * `options("openxlsx2.accountingFormat" = 4)`
+#' * `options("openxlsx2.commaFormat" = 3)`
+#' * `options("openxlsx2.percentageFormat" = 10)`
+#' * `options("openxlsx2.scientificFormat" = 48)`
 #' @name openxlsx2_options
 NULL
 # matches enum celltype

--- a/R/write.R
+++ b/R/write.R
@@ -501,7 +501,7 @@ write_data2 <- function(
       }
     }
     if (any(dc == openxlsx2_celltype[["short_date"]])) { # Date
-      numfmt_dt <- getOption("openxlsx2.dateFormat") %||% 14
+      numfmt_dt <- getOption("openxlsx2.dateFormat", 14)
 
       dim_sel <- get_data_class_dims("short_date")
       # message("short_date: ", dim_sel)
@@ -513,7 +513,7 @@ write_data2 <- function(
       )
     }
     if (any(dc == openxlsx2_celltype[["long_date"]])) {
-      numfmt_posix <- getOption("openxlsx2.datetimeFormat") %||% 22
+      numfmt_posix <- getOption("openxlsx2.datetimeFormat", default = 22)
 
       dim_sel <- get_data_class_dims("long_date")
       # message("long_date: ", dim_sel)
@@ -525,7 +525,7 @@ write_data2 <- function(
       )
     }
     if (any(dc == openxlsx2_celltype[["hms_time"]])) {
-      numfmt_hms <- getOption("openxlsx2.hmsFormat") %||% 21
+      numfmt_hms <- getOption("openxlsx2.hmsFormat", default = 21)
 
       dim_sel <- get_data_class_dims("hms_time")
       # message("hms: ", dim_sel)
@@ -537,7 +537,7 @@ write_data2 <- function(
       )
     }
     if (any(dc == openxlsx2_celltype[["accounting"]])) { # accounting
-      numfmt_accounting <- getOption("openxlsx2.accountingFormat") %||% 4
+      numfmt_accounting <- getOption("openxlsx2.accountingFormat", default = 4)
 
       dim_sel <- get_data_class_dims("accounting")
       # message("accounting: ", dim_sel)
@@ -548,7 +548,7 @@ write_data2 <- function(
       )
     }
     if (any(dc == openxlsx2_celltype[["percentage"]])) { # percentage
-      numfmt_percentage <- getOption("openxlsx2.percentageFormat") %||% 10
+      numfmt_percentage <- getOption("openxlsx2.percentageFormat", default = 10)
 
       dim_sel <- get_data_class_dims("percentage")
       # message("percentage: ", dim_sel)
@@ -560,7 +560,7 @@ write_data2 <- function(
       )
     }
     if (any(dc == openxlsx2_celltype[["scientific"]])) {
-      numfmt_scientific <- getOption("openxlsx2.scientificFormat") %||% 48
+      numfmt_scientific <- getOption("openxlsx2.scientificFormat", default = 48)
 
       dim_sel <- get_data_class_dims("scientific")
       # message("scientific: ", dim_sel)
@@ -572,7 +572,7 @@ write_data2 <- function(
       )
     }
     if (any(dc == openxlsx2_celltype[["comma"]])) {
-      numfmt_comma <- getOption("openxlsx2.commaFormat") %||% 3
+      numfmt_comma <- getOption("openxlsx2.commaFormat", default = 3)
 
       dim_sel <- get_data_class_dims("comma")
       # message("comma: ", dim_sel)

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -89,9 +89,9 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   }
 
   creator <- creator %||%
-    getOption("openxlsx2.creator") %||%
+    getOption("openxlsx2.creator", default = Sys.getenv("USERNAME")) %||%
     # USERNAME may only be present for windows
-    Sys.getenv("USERNAME", Sys.getenv("USER"))
+    Sys.getenv("USER")
 
   #---add_worksheet---#
   ## sheetName

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -89,9 +89,8 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   }
 
   creator <- creator %||%
-    getOption("openxlsx2.creator", default = Sys.getenv("USERNAME")) %||%
-    # USERNAME may only be present for windows
-    Sys.getenv("USER")
+    getOption("openxlsx2.creator", default = Sys.getenv("USERNAME"))
+    # USERNAME should be present for Windows, Mac and Linux
 
   #---add_worksheet---#
   ## sheetName

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -89,8 +89,9 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   }
 
   creator <- creator %||%
-    getOption("openxlsx2.creator", default = Sys.getenv("USERNAME"))
-    # USERNAME should be present for Windows, Mac and Linux
+    getOption("openxlsx2.creator",
+              default = Sys.getenv("USERNAME", unset = Sys.getenv("USER")))
+    # USERNAME should be present for Windows and Linux (USER on Mac)
 
   #---add_worksheet---#
   ## sheetName

--- a/man/openxlsx2_options.Rd
+++ b/man/openxlsx2_options.Rd
@@ -13,6 +13,8 @@ Typically, this is done in the \code{.Rprofile} startup file
 \item \code{options("openxlsx2.borderStyle" = "thin")}
 \item \code{options("openxlsx2.dateFormat" = "mm/dd/yyyy")}
 \item \code{options("openxlsx2.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")}
+\item \code{options("openxlsx2.maxWidth" = NULL)} (Maximum width allowed in Excel is 250)
+\item \code{options("openxlsx2.minWidth" = NULL)}
 \item \code{options("openxlsx2.numFmt" = NULL)}
 \item \code{options("openxlsx2.paperSize" = 9)} corresponds to a A4 paper size
 \item \code{options("openxlsx2.orientation" = "portrait")} page orientation
@@ -24,5 +26,9 @@ warning if using some functions deprecated recently in openxlsx2
 \code{wbWorkbook} object with \code{\link[=wb_workbook]{wb_workbook()}} or new comments with \code{\link[=wb_add_comment]{wb_add_comment()}}
 \item \code{options("openxlsx2.thread_id")} the default person id when adding a threaded comment
 to a cell with \code{\link[=wb_add_thread]{wb_add_thread()}}
+\item \code{options("openxlsx2.accountingFormat" = 4)}
+\item \code{options("openxlsx2.commaFormat" = 3)}
+\item \code{options("openxlsx2.percentageFormat" = 10)}
+\item \code{options("openxlsx2.scientificFormat" = 48)}
 }
 }


### PR DESCRIPTION
Follow-up to #848., where support for `maxWidth` and `minWidth` was added.

Related to #20 