### PR TITLE
[write] disable hyperlink check for matrix otherwise vapply runs on e…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `wb_add_ignore_error()` now returns a `wbWorkbook`
 
+* Deactivate the `is_hyperlink` check for non-dataframe objects in `wb_add_data()`. Internally, `vapply()` is applied to the input object, which is applied column-wise for a data frame and cell-wise for a matrix. This speeds up the writing of larger matrices considerably. [876](https://github.com/JanMarvin/openxlsx2/pull/876)
+
 
 ***************************************************************************
 

--- a/R/write.R
+++ b/R/write.R
@@ -759,7 +759,7 @@ write_data_table <- function(
   if (applyCellStyle) {
     if (is.null(dim(x))) {
       is_hyperlink <- inherits(x, "hyperlink")
-    } else {
+    } else if (is.data.frame(x)) { # dont check on a matrix
       is_hyperlink <- vapply(x, inherits, what = "hyperlink", FALSE)
     }
 


### PR DESCRIPTION
…very cell instead of every column

Especially with large matrices this should be much faster:

```R
library(openxlsx2)

mm <- matrix(1, 1e4, 1000)

beg <- Sys.time()

wb <- wb_workbook()$add_worksheet()$add_data(x = mm)
```