### PR TITLE
[Styles] restore currency style. fixes #878

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,11 @@
 
 ## Fixes
 
-* `wb_add_ignore_error()` now returns a `wbWorkbook`
+* `wb_add_ignore_error()` now returns a `wbWorkbook`. [865](https://github.com/JanMarvin/openxlsx2/pull/865)
 
 * Deactivate the `is_hyperlink` check for non-dataframe objects in `wb_add_data()`. Internally, `vapply()` is applied to the input object, which is applied column-wise for a data frame and cell-wise for a matrix. This speeds up the writing of larger matrices considerably. [876](https://github.com/JanMarvin/openxlsx2/pull/876)
+
+* Column style `currency` is now correctly applied to numeric vectors. Previously it was not handled. This applies the built in spreadsheet style for currency presumably linked to the spreadsheet software locale. [879](https://github.com/JanMarvin/openxlsx2/pull/879)
 
 
 ***************************************************************************

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -36,6 +36,10 @@ long_to_wide <- function(z, tt, zz) {
     invisible(.Call(`_openxlsx2_long_to_wide`, z, tt, zz))
 }
 
+is_charnum <- function(x) {
+    .Call(`_openxlsx2_is_charnum`, x)
+}
+
 wide_to_long <- function(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm) {
     invisible(.Call(`_openxlsx2_wide_to_long`, z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm))
 }

--- a/R/openxlsx2-package.R
+++ b/R/openxlsx2-package.R
@@ -84,6 +84,7 @@
 #' * `options("openxlsx2.thread_id")` the default person id when adding a threaded comment
 #'   to a cell with [wb_add_thread()]
 #' * `options("openxlsx2.accountingFormat" = 4)`
+#' * `options("openxlsx2.currencyFormat" = 4)`
 #' * `options("openxlsx2.commaFormat" = 3)`
 #' * `options("openxlsx2.percentageFormat" = 10)`
 #' * `options("openxlsx2.scientificFormat" = 48)`
@@ -108,7 +109,8 @@ openxlsx2_celltype <- c(
   factor         = 12,
   string_nums    = 13,
   cm_formula     = 14,
-  hms_time       = 15
+  hms_time       = 15,
+  currency       = 16
 )
 
 #' Deprecated functions in package *openxlsx2*

--- a/R/write.R
+++ b/R/write.R
@@ -536,6 +536,19 @@ write_data2 <- function(
         numfmt = numfmt_hms
       )
     }
+    if (any(dc == openxlsx2_celltype[["currency"]])) { # currency
+      numfmt_currency <- getOption("openxlsx2.currencyFormat", default = 44)
+      ## For vignette: Builtin style for USD
+      #"_-[$$-409]* #,##0.00_ ;_-[$$-409]* \\-#,##0.00\\ ;_-[$$-409]* &quot;-&quot;??_ ;_-@_ "
+
+      dim_sel <- get_data_class_dims("currency")
+      # message("currency: ", dim_sel)
+
+      wb$add_numfmt(
+        dim = dim_sel,
+        numfmt = numfmt_currency
+      )
+    }
     if (any(dc == openxlsx2_celltype[["accounting"]])) { # accounting
       numfmt_accounting <- getOption("openxlsx2.accountingFormat", default = 4)
 

--- a/man/openxlsx2_options.Rd
+++ b/man/openxlsx2_options.Rd
@@ -27,6 +27,7 @@ warning if using some functions deprecated recently in openxlsx2
 \item \code{options("openxlsx2.thread_id")} the default person id when adding a threaded comment
 to a cell with \code{\link[=wb_add_thread]{wb_add_thread()}}
 \item \code{options("openxlsx2.accountingFormat" = 4)}
+\item \code{options("openxlsx2.currencyFormat" = 4)}
 \item \code{options("openxlsx2.commaFormat" = 3)}
 \item \code{options("openxlsx2.percentageFormat" = 10)}
 \item \code{options("openxlsx2.scientificFormat" = 48)}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -102,6 +102,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// is_charnum
+Rcpp::LogicalVector is_charnum(Rcpp::CharacterVector x);
+RcppExport SEXP _openxlsx2_is_charnum(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(is_charnum(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 // wide_to_long
 void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, int32_t string_nums, bool na_null, bool na_missing, std::string na_strings, bool inline_strings, std::string c_cm);
 RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP, SEXP na_nullSEXP, SEXP na_missingSEXP, SEXP na_stringsSEXP, SEXP inline_stringsSEXP, SEXP c_cmSEXP) {
@@ -942,6 +953,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_copy", (DL_FUNC) &_openxlsx2_copy, 1},
     {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 3},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
+    {"_openxlsx2_is_charnum", (DL_FUNC) &_openxlsx2_is_charnum, 1},
     {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 13},
     {"_openxlsx2_create_char_dataframe", (DL_FUNC) &_openxlsx2_create_char_dataframe, 2},
     {"_openxlsx2_col_to_df", (DL_FUNC) &_openxlsx2_col_to_df, 1},

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -45,9 +45,9 @@ SEXP openxlsx2_type(SEXP x) {
     // logical
     case LGLSXP:
       if (Rf_isNull(Rclass)) {
-        type[i] = 3; // logical
+        type[i] = logical; // logical
       } else {
-        type[i] = 12; // probably some custom class
+        type[i] = factor; // probably some custom class
       };
       break;
 
@@ -55,15 +55,15 @@ SEXP openxlsx2_type(SEXP x) {
     case CPLXSXP:
     case STRSXP:
       if (Rf_inherits(z, "formula")) {
-        type[i] = 5;
+        type[i] = formula;
       } else if (Rf_inherits(z, "hyperlink")) {
-        type[i] = 10;
+        type[i] = hyperlink;
       } else if (Rf_inherits(z, "array_formula")) {
-        type[i] = 11;
+        type[i] = array_formula;
       } else if (Rf_inherits(z, "cm_formula")) {
-        type[i] = 14;
+        type[i] = cm_formula;
       } else {
-        type[i] = 4;
+        type[i] = character;
       }
       break;
 
@@ -73,28 +73,28 @@ SEXP openxlsx2_type(SEXP x) {
     case INTSXP:
     case REALSXP: {
       if (Rf_inherits(z, "Date")) {
-      type[i] = 0;
+      type[i] = short_date;
     } else if (Rf_inherits(z, "POSIXct")) {
-      type[i] = 1;
+      type[i] = long_date;
     } else if (Rf_inherits(z, "accounting")) {
-      type[i] = 6;
+      type[i] = accounting;
     } else if (Rf_inherits(z, "percentage")) {
-      type[i] = 7;
+      type[i] = percentage;
     } else if (Rf_inherits(z, "scientific")) {
-      type[i] = 8;
+      type[i] = scientific;
     } else if (Rf_inherits(z, "comma")) {
-      type[i] = 9;
+      type[i] = comma;
     } else if (Rf_inherits(z, "factor") || !Rf_isNull(Rf_getAttrib(z, Rf_install("labels")))) {
-      type[i] = 12;
+      type[i] = factor;
     } else if (Rf_inherits(z, "hms")) {
-      type[i] = 15;
+      type[i] = hms_time;
     } else if (Rf_inherits(z, "currency")) {
-      type[i] = 16;
+      type[i] = currency;
     } else {
       if (Rf_isNull(Rclass)) {
-        type[i] = 2; // numeric and integer
+        type[i] = numeric; // numeric and integer
       } else {
-        type[i] = 12; // probably some custom class
+        type[i] = factor; // probably some custom class
       }
     }
     break;
@@ -103,7 +103,7 @@ SEXP openxlsx2_type(SEXP x) {
 
     // whatever is not covered from above
     default: {
-      type[i] = 4;
+      type[i] = character;
       break;
     }
 

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -88,6 +88,8 @@ SEXP openxlsx2_type(SEXP x) {
       type[i] = 12;
     } else if (Rf_inherits(z, "hms")) {
       type[i] = 15;
+    } else if (Rf_inherits(z, "currency")) {
+      type[i] = 16;
     } else {
       if (Rf_isNull(Rclass)) {
         type[i] = 2; // numeric and integer
@@ -293,6 +295,7 @@ void long_to_wide(Rcpp::DataFrame z, Rcpp::DataFrame tt, Rcpp::DataFrame zz) {
     }
   }
 }
+
 // similar to is.numeric(x)
 // returns true if string can be written as numeric and is not Inf
 // @param x a string input
@@ -308,6 +311,17 @@ bool is_double(std::string x) {
   }
 
   return 0;
+}
+
+// function to apply on vector
+// @param x a character vector as input
+// [[Rcpp::export]]
+Rcpp::LogicalVector is_charnum(Rcpp::CharacterVector x) {
+  Rcpp::LogicalVector out(x.size());
+  for (size_t i = 0; i < x.size(); ++i) {
+    out[i] = is_double(Rcpp::as<std::string>(x[i]));
+  }
+  return out;
 }
 
 // similar to dcast converts cc dataframe to z dataframe
@@ -374,6 +388,7 @@ void wide_to_long(
       switch(vtyp)
       {
 
+      case currency:
       case short_date:
       case long_date:
       case accounting:

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -58,7 +58,8 @@ enum celltype {
   factor         = 12,
   string_num     = 13,
   cm_formula     = 14,
-  hms_time       = 15
+  hms_time       = 15,
+  currency       = 16
 };
 
 // check for 1.0.8.0

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -17,7 +17,7 @@ test_that("openxlsx2_types", {
     "Date" = Sys.Date() - 0:19,
     "T" = TRUE, "F" = FALSE,
     "Time" = Sys.time() - 0:19 * 60 * 60,
-    "Cash" = paste("$", 1:20), "Cash2" = 31:50,
+    "Cash" = 1:20, "Cash2" = 31:50,
     "hLink" = "https://CRAN.R-project.org/",
     "Percentage" = seq(0, 1, length.out = 20),
     "TinyNumbers" = runif(20) / 1E9, stringsAsFactors = FALSE
@@ -36,18 +36,23 @@ test_that("openxlsx2_types", {
     T = openxlsx2_celltype[["logical"]],
     F = openxlsx2_celltype[["logical"]],
     Time = openxlsx2_celltype[["long_date"]],
-    Cash = openxlsx2_celltype[["character"]],
+    Cash = openxlsx2_celltype[["currency"]],
     Cash2 = openxlsx2_celltype[["accounting"]],
     hLink = openxlsx2_celltype[["hyperlink"]],
     Percentage = openxlsx2_celltype[["percentage"]],
     TinyNumbers = openxlsx2_celltype[["scientific"]]
   )
 
+  expect_equal(exp, got)
 
+  wb <- wb_workbook()$add_worksheet()$add_data(x = df)
+  xf <- rbindlist(xml_attr(wb$styles_mgr$styles$cellXfs, "xf"))
+
+  exp <- c("0", "0", "14", "22", "44", "4", "10", "48")
+  got <- xf$numFmtId
   expect_equal(exp, got)
 
 })
-
 
 test_that("wb_page_setup example", {
 
@@ -233,6 +238,15 @@ test_that("basename2() works", {
 
   exp <- "filenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilenamefilename.txt"
   got <- basename2(long_path)
+  expect_equal(exp, got)
+
+})
+
+test_that("is_double works", {
+
+  x <- c("0.1", "a")
+  exp <- c(TRUE, FALSE)
+  got <- is_charnum(x)
   expect_equal(exp, got)
 
 })

--- a/vignettes/openxlsx2_style_manual.Rmd
+++ b/vignettes/openxlsx2_style_manual.Rmd
@@ -176,7 +176,7 @@ df <- data.frame(
   "T" = TRUE,
   "F" = FALSE,
   "Time" = Sys.time() - 0:19 * 60 * 60,
-  "Cash" = paste("$", 1:20), "Cash2" = 31:50,
+  "Cash" = 1:20, "Cash2" = 31:50,
   "hLink" = "https://CRAN.R-project.org/",
   "Percentage" = seq(0, 1, length.out = 20),
   "TinyNumbers" = runif(20) / 1E9, stringsAsFactors = FALSE
@@ -210,7 +210,7 @@ df <- data.frame(
   "Date" = Sys.Date() - 0:19,
   "T" = TRUE, "F" = FALSE,
   "Time" = Sys.time() - 0:19 * 60 * 60,
-  "Cash" = paste("$", 1:20), "Cash2" = 31:50,
+  "Cash" = 1:20, "Cash2" = 31:50,
   "hLink" = "https://CRAN.R-project.org/",
   "Percentage" = seq(0, 1, length.out = 20),
   "TinyNumbers" = runif(20) / 1E9, stringsAsFactors = FALSE,


### PR DESCRIPTION
This is set by default to the local currency of the spreadsheet software. For other cases, a predefined numeric style should be used. Have not seen a local variable to apply defining the currency used.

Adds the internal helper `is_charnum()` to check if a string can be safely converted to a numeric value.

``` r
df <- data.frame(
  "dollar" = paste("$", 1:20),
  "euro" = 1:20
)
class(df$dollar) <- c("currency", class(df$dollar))
class(df$euro) <- c("currency", class(df$euro))

str(df)
#> 'data.frame':    20 obs. of  2 variables:
#>  $ dollar: 'currency' chr  "$ 1" "$ 2" "$ 3" "$ 4" ...
#>  $ euro  : 'currency' int  1 2 3 4 5 6 7 8 9 10 ...

library(openxlsx2)
wb <- wb_workbook()$
  add_worksheet()$
  add_data(x = df, start_row = 4, row_names = FALSE)$
  add_worksheet()$
  add_data_table(x = df, start_row = 4, row_names = FALSE)

if (interactive()) wb$open()
```
Fortunately the old behavior with characters remains.

<img width="141" alt="Screenshot 2023-12-31 at 01 02 10" src="https://github.com/JanMarvin/openxlsx2/assets/1645626/288c75e8-4265-447e-9af0-51df3ae486b6">

For other currency formats MS365 uses the following with varying positions:
```R
#> # GBP
#> [1] "_-[$£-809]* #,##0.00_-;\\-[$£-809]* #,##0.00_-;_-[$£-809]* &quot;-&quot;??_-;_-@_-"   
#> # EUR
#> [2] "_-[$$-409]* #,##0.00_ ;_-[$$-409]* \\-#,##0.00\\ ;_-[$$-409]* &quot;-&quot;??_ ;_-@_ "
#> # USD
#> [3] "_-[$€-2]\\ * #,##0.00_-;\\-[$€-2]\\ * #,##0.00_-;_-[$€-2]\\ * &quot;-&quot;??_-;_-@_-"
#> # YEN
#> [4] "_ [$¥-804]* #,##0.00_ ;_ [$¥-804]* \\-#,##0.00_ ;_ [$¥-804]* &quot;-&quot;??_ ;_ @_ " 
```

