### PR TITLE
[load] better error message for zip compressed input files. closes #896

### DIFF
--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -114,6 +114,12 @@ wb_load <- function(
   ## Not used
   # .relsXML          <- grep_xml("_rels/.rels$")
   ContentTypesXML   <- grep_xml("\\[Content_Types\\].xml$")
+
+  if (length(ContentTypesXML) == 0 && !debug) {
+    msg <- paste("File does not appear to be xlsx, xlsm or xlsb: ", file)
+    stop(msg)
+  }
+
   appXML            <- grep_xml("app.xml$")
   coreXML           <- grep_xml("core.xml$")
   customXML         <- grep_xml("custom.xml$")

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -442,10 +442,21 @@ test_that("Loading a workbook with property preserves it.", {
 })
 
 test_that("failing to unzip works as expected", {
+
+  # try to read from single file
   tmp <- temp_xlsx()
   writeLines("", tmp)
   expect_error(wb <- wb_load(tmp), "Unable to open and load file")
 
+  # working
   wb_workbook()$add_worksheet()$save(tmp)
   expect_silent(wb <- wb_load(tmp))
+
+  # zip file
+  tmp <- temp_xlsx()
+  writeLines("", tmp)
+  tmp_zip <- tempfile(fileext = ".zip")
+  zip::zip(zipfile = tmp_zip, files = basename(tmp), root = dirname(tmp))
+  expect_error(wb <- wb_load(tmp_zip), "File does not appear to be xlsx, xlsm or xlsb")
+
 })


### PR DESCRIPTION
 that are not openxml files