### PR TITLE
[pt] another attemt to fix item sorting

### DIFF
--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -673,19 +673,36 @@ get_items <- function(data, x, item_order, slicer = FALSE, choose = NULL) {
   dat <- distinct(data[[x]])
 
   # check length, otherwise a certain spreadsheet software simply dies
-  if (!is.null(item_order) && (length(item_order) != length(dat))) {
-    msg <- sprintf(
-      "Length of sort order for '%s' does not match required length. Is %s, needs %s.\nCheck `openxlsx2:::distinct()` for the correct length. Resetting.",
-      names(data[x]), length(item_order), length(dat)
-    )
-    warning(msg)
-    item_order <- NULL
-  }
+  if (!is.null(item_order)) {
 
-  if (is.null(item_order)) {
+    if (length(item_order) > length(dat)) {
+      msg <- sprintf(
+        "Length of sort order for '%s' does not match required length. Is %s, needs %s.\nCheck `openxlsx2:::distinct()` for the correct length. Resetting.",
+        names(data[x]), length(item_order), length(dat)
+      )
+      warning(msg)
+      item_order <- NULL
+    }
+
+    if (is.character(item_order)) {
+      # add remaining items
+      if (length(item_order) < length(dat)) {
+        item_order <- c(item_order, dat[!dat %in% item_order])
+      }
+
+      item_order <- match(item_order, dat)
+
+    } else {
+      # add remaining items
+      if (length(item_order) < length(dat)) {
+        vals <- seq_along(dat)
+        item_order <- c(item_order, vals[!vals %in% item_order])
+      }
+    }
+
+  } else {
+    # item_order == NULL
     item_order <- order(dat)
-  } else if (is.character(item_order)) {
-    item_order <- match(dat, item_order)
   }
 
   if (!is.null(choose)) {

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -918,9 +918,9 @@ expect_silent(
 expect_warning(
   wb_add_pivot_table(wb, df, dims = "A3",
                      filter = "am", rows = "cyl", cols = "gear", data = "disp",
-                     params = list(sort_item = list(gear = c(1)))
+                     params = list(sort_item = list(gear = seq_len(4)))
   ),
-  "Length of sort order for 'gear' does not match required length. Is 1, needs 3."
+  "Length of sort order for 'gear' does not match required length. Is 4, needs 3."
 )
 
 })


### PR DESCRIPTION
Apparently #842 was not yet sufficient. second part of #909

``` r
library(openxlsx2)
dd <- data.frame(Foo = sample(0:1, 26, TRUE), foo2 = letters, bar = TRUE)
wb <- wb_workbook()$add_worksheet()$add_data(x = dd)
pt <- wb_data(wb)

# so how am I supposed to order this?
wb$
  add_pivot_table(pt, rows = "foo2", data = "bar",
                  pivot_table = "pt1",
                  params = list(
                    sort_item = list(foo2 = c("b", "e", "d"))
                  ))$
  add_slicer(pt, slicer = "foo2", pivot_table = "pt1", dims = "A10",
             params = list(
               choose = c(foo2 = 'x %in% c("b", "e", "d")')
             ))

if (interactive()) wb$open()
```