### PR TITLE
[read, write] add standardize_dot_names(): na.strings -> na_strings

### DIFF
--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -111,7 +111,7 @@ wb_save <- function(wb, file = NULL, overwrite = TRUE, path = NULL) {
 #'   columns to a character vector e.g. `sapply(x$list_column, paste, collapse = sep)`.
 #' @param apply_cell_style Should we write cell styles to the workbook
 #' @param remove_cell_style keep the cell style?
-#' @param na.strings Value used for replacing `NA` values from `x`. Default
+#' @param na_strings Value used for replacing `NA` values from `x`. Default
 #'   [na_strings()] uses the special `#N/A` value within the workbook.
 #' @param inline_strings write characters as inline strings
 #' @param ... additional arguments
@@ -195,11 +195,18 @@ wb_add_data <- function(
     sep               = ", ",
     apply_cell_style  = TRUE,
     remove_cell_style = FALSE,
-    na.strings        = na_strings(),
+    na_strings        = na_strings(),
     inline_strings    = TRUE,
     ...
 ) {
   assert_workbook(wb)
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
+
   wb$clone(deep = TRUE)$add_data(
     sheet             = sheet,
     x                 = x,
@@ -214,7 +221,7 @@ wb_add_data <- function(
     sep               = sep,
     apply_cell_style  = apply_cell_style,
     remove_cell_style = remove_cell_style,
-    na.strings        = na.strings,
+    na_strings        = na_strings,
     inline_strings    = inline_strings,
     ...               = ...
   )
@@ -272,11 +279,18 @@ wb_add_data_table <- function(
     banded_cols       = FALSE,
     apply_cell_style  = TRUE,
     remove_cell_style = FALSE,
-    na.strings        = na_strings(),
+    na_strings        = na_strings(),
     inline_strings    = TRUE,
     ...
 ) {
   assert_workbook(wb)
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
+
   wb$clone()$add_data_table(
     sheet             = sheet,
     x                 = x,
@@ -295,7 +309,7 @@ wb_add_data_table <- function(
     banded_cols       = banded_cols,
     apply_cell_style  = apply_cell_style,
     remove_cell_style = remove_cell_style,
-    na.strings        = na.strings,
+    na_strings        = na_strings,
     inline_strings    = inline_strings,
     ...               = ...
   )

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1221,7 +1221,7 @@ wbWorkbook <- R6::R6Class(
     #' @param sep sep
     #' @param apply_cell_style applyCellStyle
     #' @param remove_cell_style if writing into existing cells, should the cell style be removed?
-    #' @param na.strings Value used for replacing `NA` values from `x`. Default
+    #' @param na_strings Value used for replacing `NA` values from `x`. Default
     #'   `na_strings()` uses the special `#N/A` value within the workbook.
     #' @param inline_strings write characters as inline strings
     #' @param return The `wbWorkbook` object
@@ -1239,12 +1239,18 @@ wbWorkbook <- R6::R6Class(
         sep               = ", ",
         apply_cell_style  = TRUE,
         remove_cell_style = FALSE,
-        na.strings        = na_strings(),
+        na_strings        = na_strings(),
         inline_strings    = TRUE,
         ...
       ) {
 
       standardize(...)
+
+      if (missing(na_strings)) {
+        default <- substitute(na_strings)
+        rm(na_strings)
+        na_strings <- eval(default)
+      }
 
       write_data(
         wb                = self,
@@ -1261,7 +1267,7 @@ wbWorkbook <- R6::R6Class(
         sep               = sep,
         apply_cell_style  = apply_cell_style,
         remove_cell_style = remove_cell_style,
-        na.strings        = na.strings,
+        na_strings        = na_strings,
         inline_strings    = inline_strings
       )
       invisible(self)
@@ -1283,7 +1289,7 @@ wbWorkbook <- R6::R6Class(
     #' @param banded_cols bandedCols
     #' @param apply_cell_style applyCellStyle
     #' @param remove_cell_style if writing into existing cells, should the cell style be removed?
-    #' @param na.strings Value used for replacing `NA` values from `x`. Default
+    #' @param na_strings Value used for replacing `NA` values from `x`. Default
     #'   `na_strings()` uses the special `#N/A` value within the workbook.
     #' @param inline_strings write characters as inline strings
     #' @param ... additional arguments
@@ -1306,12 +1312,18 @@ wbWorkbook <- R6::R6Class(
         banded_cols       = FALSE,
         apply_cell_style  = TRUE,
         remove_cell_style = FALSE,
-        na.strings        = na_strings(),
+        na_strings        = na_strings(),
         inline_strings    = TRUE,
         ...
     ) {
 
       standardize(...)
+
+      if (missing(na_strings)) {
+        default <- substitute(na_strings)
+        rm(na_strings)
+        na_strings <- eval(default)
+      }
 
       write_datatable(
         wb              = self,
@@ -1332,7 +1344,7 @@ wbWorkbook <- R6::R6Class(
         bandedCols      = banded_cols,
         applyCellStyle  = apply_cell_style,
         removeCellStyle = remove_cell_style,
-        na.strings      = na.strings,
+        na_strings      = na_strings,
         inline_strings  = inline_strings
       )
       invisible(self)
@@ -1884,8 +1896,8 @@ wbWorkbook <- R6::R6Class(
     #' @param cols A numeric vector specifying which columns in the Excel file to read. If NULL, all columns are read.
     #' @param named_region Character string with a named_region (defined name or table). If no sheet is selected, the first appearance will be selected.
     #' @param types A named numeric indicating, the type of the data. 0: character, 1: numeric, 2: date, 3: posixt, 4:logical. Names must match the returned data
-    #' @param na.strings A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.
-    #' @param na.numbers A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.
+    #' @param na_strings A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.
+    #' @param na_numbers A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.
     #' @param fill_merged_cells If TRUE, the value in a merged cell is given to all cells within the merge.
     #' @param keep_attributes If TRUE additional attributes are returned. (These are used internally to define a cell type.)
     #' @return a data frame
@@ -1902,8 +1914,8 @@ wbWorkbook <- R6::R6Class(
       rows              = NULL,
       cols              = NULL,
       detect_dates      = TRUE,
-      na.strings        = "#N/A",
-      na.numbers        = NA,
+      na_strings        = "#N/A",
+      na_numbers        = NA,
       fill_merged_cells = FALSE,
       dims,
       show_formula      = FALSE,
@@ -1934,8 +1946,8 @@ wbWorkbook <- R6::R6Class(
         rows              = rows,
         cols              = cols,
         detect_dates      = detect_dates,
-        na.strings        = na.strings,
-        na.numbers        = na.numbers,
+        na_strings        = na_strings,
+        na_numbers        = na_numbers,
         fill_merged_cells = fill_merged_cells,
         dims              = dims,
         show_formula      = show_formula,
@@ -8453,7 +8465,7 @@ wbWorkbook <- R6::R6Class(
         self$add_data(
           sheet = sheet,
           x = dims_to_dataframe(dims),
-          na.strings = NULL,
+          na_strings = NULL,
           colNames = FALSE,
           dims = dims
         )

--- a/R/read.R
+++ b/R/read.R
@@ -52,9 +52,9 @@
 #'   If no sheet is selected, the first appearance will be selected. See [wb_get_named_regions()]
 #' @param types A named numeric indicating, the type of the data.
 #'   Names must match the returned data. See **Details** for more.
-#' @param na.strings A character vector of strings which are to be interpreted as `NA`.
+#' @param na_strings A character vector of strings which are to be interpreted as `NA`.
 #'   Blank cells will be returned as `NA`.
-#' @param na.numbers A numeric vector of digits which are to be interpreted as `NA`.
+#' @param na_numbers A numeric vector of digits which are to be interpreted as `NA`.
 #'   Blank cells will be returned as `NA`.
 #' @param fill_merged_cells If `TRUE`, the value in a merged cell is given to all cells within the merge.
 #' @param keep_attributes If `TRUE` additional attributes are returned.
@@ -107,7 +107,7 @@
 #' wb_to_df(wb1, start_row = 5, col_names = FALSE)
 #'
 #' # na string
-#' wb_to_df(wb1, na.strings = "a")
+#' wb_to_df(wb1, na_strings = "a")
 #'
 #' ###########################################################################
 #' # Named regions
@@ -140,8 +140,8 @@ wb_to_df <- function(
     rows              = NULL,
     cols              = NULL,
     detect_dates      = TRUE,
-    na.strings        = "#N/A",
-    na.numbers        = NA,
+    na_strings        = "#N/A",
+    na_numbers        = NA,
     fill_merged_cells = FALSE,
     dims,
     show_formula      = FALSE,
@@ -154,7 +154,7 @@ wb_to_df <- function(
 
 
   xlsx_file <- list(...)$xlsx_file
-  standardize_case_names(...)
+  standardize(...)
 
   if (!is.null(xlsx_file)) {
     .Deprecated(old = "xlsx_file", new = "file", package = "openxlsx2")
@@ -357,8 +357,8 @@ wb_to_df <- function(
 
   has_na_string <- FALSE
   # convert missings
-  if (!all(is.na(na.strings))) {
-    sel <- cc$val %in% na.strings
+  if (!all(is.na(na_strings))) {
+    sel <- cc$val %in% na_strings
     if (any(sel)) {
       cc$val[sel] <- NA_character_
       cc$typ[sel] <- "na_string"
@@ -369,9 +369,9 @@ wb_to_df <- function(
   has_na_number <- FALSE
   # convert missings.
   # at this stage we only have characters.
-  na.numbers <- as.character(na.numbers)
-  if (!all(is.na(na.numbers))) {
-    sel <- cc$v %in% na.numbers
+  na_numbers <- as.character(na_numbers)
+  if (!all(is.na(na_numbers))) {
+    sel <- cc$v %in% na_numbers
     if (any(sel)) {
       cc$val[sel] <- NA_character_
       cc$typ[sel] <- "na_number"
@@ -468,7 +468,7 @@ wb_to_df <- function(
             file            = wb,
             sheet           = sheet,
             dims            = filler,
-            na.strings      = na.strings,
+            na_strings      = na_strings,
             convert         = FALSE,
             col_names       = FALSE,
             detect_dates    = detect_dates,
@@ -627,8 +627,8 @@ read_xlsx <- function(
   cols              = NULL,
   detect_dates      = TRUE,
   named_region,
-  na.strings        = "#N/A",
-  na.numbers        = NA,
+  na_strings        = "#N/A",
+  na_numbers        = NA,
   fill_merged_cells = FALSE,
   ...
 ) {
@@ -654,8 +654,8 @@ read_xlsx <- function(
     cols              = cols,
     detect_dates      = detect_dates,
     named_region      = named_region,
-    na.strings        = na.strings,
-    na.numbers        = na.numbers,
+    na_strings        = na_strings,
+    na_numbers        = na_numbers,
     fill_merged_cells = fill_merged_cells,
     ...
   )
@@ -677,8 +677,8 @@ wb_read <- function(
   cols            = NULL,
   detect_dates    = TRUE,
   named_region,
-  na.strings      = "NA",
-  na.numbers      = NA,
+  na_strings      = "NA",
+  na_numbers      = NA,
   ...
 ) {
 
@@ -703,8 +703,8 @@ wb_read <- function(
     cols            = cols,
     detect_dates    = detect_dates,
     named_region    = named_region,
-    na.strings      = na.strings,
-    na.numbers      = na.numbers,
+    na_strings      = na_strings,
+    na_numbers      = na_numbers,
     ...
   )
 

--- a/R/standardize.R
+++ b/R/standardize.R
@@ -90,7 +90,40 @@ standardize_case_names <- function(..., return = FALSE, arguments = NULL) {
 
 }
 
-#' takes camelCase and colour returns camel_case and color
+#' takes na.strings and returns na_strings
+#' @param ... ...
+#' @returns void. assigns an object in the parent frame
+#' @noRd
+standardize_dot_names <- function(..., return = FALSE) {
+
+  # since R 4.1.0: ...names()
+  args <- list(...)
+  if (return) {
+    args <- args[[1]]
+  }
+  got <- names(args)
+  got_dots <- which(grepl(".", tolower(got)))
+
+  if (length(got_dots)) {
+    for (got_dot in got_dots) {
+      dot_ <- got[got_dot]
+      name_dot <- stringi::stri_replace_all_fixed(dot_, ".", "_")
+
+      if (return) {
+        names(args)[got_dot] <- name_dot
+      } else {
+        # since R 3.5.0: ...elt(got_col)
+        value_dot <- args[[got_dot]]
+        assign(name_dot, value_dot, parent.frame())
+      }
+    }
+  }
+
+  if (return) args
+
+}
+
+#' takes camelCase, colour, and na.strings. returns camel_case, color, and na_strings
 #' @param ... ...
 #' @returns void. assigns an object in the parent frame
 #' @noRd
@@ -102,6 +135,7 @@ standardize <- function(..., arguments) {
   }
 
   rtns <- standardize_color_names(nms, return = TRUE)
+  rtns <- standardize_dot_names(rtns, return = TRUE)
   rtns <- standardize_case_names(rtns, return = TRUE, arguments = arguments)
 
   nms <- names(rtns)

--- a/R/write.R
+++ b/R/write.R
@@ -9,7 +9,7 @@
 #' @param cells_needed the cells needed
 #' @param colNames has colNames (only in update_cell)
 #' @param removeCellStyle remove the cell style (only in update_cell)
-#' @param na.strings Value used for replacing `NA` values from `x`. Default
+#' @param na_strings Value used for replacing `NA` values from `x`. Default
 #'   `na_strings()` uses the special `#N/A` value within the workbook.#' @keywords internal
 #' @noRd
 inner_update <- function(
@@ -20,8 +20,14 @@ inner_update <- function(
     cells_needed,
     colNames = FALSE,
     removeCellStyle = FALSE,
-    na.strings = na_strings()
+    na_strings = na_strings()
 ) {
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
 
   # 1) pull sheet to modify from workbook; 2) modify it; 3) push it back
   cc  <- wb$worksheets[[sheet_id]]$sheet_data$cc
@@ -82,8 +88,8 @@ inner_update <- function(
     wb$worksheets[[sheet_id]]$dimension <- paste0("<dimension ref=\"", min_cell, ":", max_cell, "\"/>")
   }
 
-  if (is_na_strings(na.strings)) {
-    na.strings <- NULL
+  if (is_na_strings(na_strings)) {
+    na_strings <- NULL
   }
 
   if (removeCellStyle) {
@@ -144,15 +150,15 @@ initialize_cell <- function(wb, sheet, new_cells) {
 #' @param cell the cell you want to update in Excel connotation e.g. "A1"
 #' @param colNames if TRUE colNames are passed down
 #' @param removeCellStyle keep the cell style?
-#' @param na.strings optional na.strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
+#' @param na_strings optional na_strings argument. if missing #N/A is used. If NULL no cell value is written, if character or numeric this is written (even if NA is part of numeric data)
 #'
 #' @keywords internal
 #' @noRd
 update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
-                        removeCellStyle = FALSE, na.strings) {
+                        removeCellStyle = FALSE, na_strings) {
 
-  if (missing(na.strings))
-    na.strings <- substitute()
+  if (missing(na_strings))
+    na_strings <- substitute()
 
   sheet_id <- wb$validate_sheet(sheet)
 
@@ -161,7 +167,7 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
 
   cells_needed <- unname(unlist(dims))
 
-  inner_update(wb, sheet_id, x, rows, cells_needed, colNames, removeCellStyle, na.strings)
+  inner_update(wb, sheet_id, x, rows, cells_needed, colNames, removeCellStyle, na_strings)
 }
 
 #' dummy function to write data
@@ -175,7 +181,7 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
 #' @param startCol col to place it
 #' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle keep the cell style?
-#' @param na.strings Value used for replacing `NA` values from `x`. Default
+#' @param na_strings Value used for replacing `NA` values from `x`. Default
 #'   `na_strings()` uses the special `#N/A` value within the workbook.
 #' @param data_table logical. if `TRUE` and `rowNames = TRUE`, do not write the cell containing  `"_rowNames_"`
 #' @param inline_strings write characters as inline strings
@@ -210,10 +216,16 @@ write_data2 <- function(
     startCol = 1,
     applyCellStyle = TRUE,
     removeCellStyle = FALSE,
-    na.strings = na_strings(),
+    na_strings = na_strings(),
     data_table = FALSE,
     inline_strings = TRUE
 ) {
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
 
   is_data_frame <- FALSE
   #### prepare the correct data formats for openxml
@@ -390,11 +402,11 @@ write_data2 <- function(
   na_missing <- FALSE
   na_null    <- FALSE
 
-  if (is_na_strings(na.strings)) {
-    na.strings <- ""
+  if (is_na_strings(na_strings)) {
+    na_strings <- ""
     na_missing <- TRUE
-  } else if (is.null(na.strings)) {
-    na.strings <- ""
+  } else if (is.null(na_strings)) {
+    na_strings <- ""
     na_null    <- TRUE
   }
 
@@ -409,7 +421,7 @@ write_data2 <- function(
     string_nums    = string_nums,
     na_null        = na_null,
     na_missing     = na_missing,
-    na_strings     = na.strings,
+    na_strings     = na_strings,
     inline_strings = inline_strings,
     c_cm           = c_cm
   )
@@ -438,7 +450,7 @@ write_data2 <- function(
       cell = dims,
       colNames = colNames,
       removeCellStyle = removeCellStyle,
-      na.strings = na.strings
+      na_strings = na_strings
     )
   }
 
@@ -695,7 +707,7 @@ write_data2 <- function(
 #' @param name If not NULL, a named region is defined.
 #' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
-#' @param na.strings Value used for replacing `NA` values from `x`. Default
+#' @param na_strings Value used for replacing `NA` values from `x`. Default
 #'   `na_strings()` uses the special `#N/A` value within the workbook.
 #' @param inline_strings optional write strings as inline strings
 #' @noRd
@@ -722,9 +734,15 @@ write_data_table <- function(
     applyCellStyle  = TRUE,
     removeCellStyle = FALSE,
     data_table      = FALSE,
-    na.strings      = na_strings(),
+    na_strings      = na_strings(),
     inline_strings  = TRUE
 ) {
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
 
   ## Input validating
   assert_workbook(wb)
@@ -757,7 +775,7 @@ write_data_table <- function(
 
   if (data_table && nrow(x) < 1) {
     warning("Found data table with zero rows, adding one.",
-            " Modify na with na.strings")
+            " Modify na with na_strings")
     x[1, ] <- NA
   }
 
@@ -902,7 +920,7 @@ write_data_table <- function(
     startCol = startCol,
     applyCellStyle = applyCellStyle,
     removeCellStyle = removeCellStyle,
-    na.strings = na.strings,
+    na_strings = na_strings,
     data_table = data_table,
     inline_strings = inline_strings
   )
@@ -994,12 +1012,18 @@ write_data <- function(
     name              = NULL,
     apply_cell_style  = TRUE,
     remove_cell_style = FALSE,
-    na.strings        = na_strings(),
+    na_strings        = na_strings(),
     inline_strings    = TRUE,
     ...
 ) {
 
   standardize_case_names(...)
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
 
   write_data_table(
     wb              = wb,
@@ -1023,7 +1047,7 @@ write_data <- function(
     applyCellStyle  = apply_cell_style,
     removeCellStyle = remove_cell_style,
     data_table      = FALSE,
-    na.strings      = na.strings,
+    na_strings      = na_strings,
     inline_strings  = inline_strings
   )
 }
@@ -1163,12 +1187,18 @@ write_datatable <- function(
     banded_cols       = FALSE,
     apply_cell_style  = TRUE,
     remove_cell_style = FALSE,
-    na.strings        = na_strings(),
+    na_strings        = na_strings(),
     inline_strings    = TRUE,
     ...
 ) {
 
   standardize_case_names(...)
+
+  if (missing(na_strings)) {
+    default <- substitute(na_strings)
+    rm(na_strings)
+    na_strings <- eval(default)
+  }
 
   write_data_table(
     wb              = wb,
@@ -1192,7 +1222,7 @@ write_datatable <- function(
     data_table      = TRUE,
     applyCellStyle  = apply_cell_style,
     removeCellStyle = remove_cell_style,
-    na.strings      = na.strings,
+    na_strings      = na_strings,
     inline_strings  = inline_strings
   )
 }

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -11,8 +11,8 @@
 #' @param as_table If `TRUE`, will write as a data table, instead of data.
 #' @inheritDotParams wb_workbook creator
 #' @inheritDotParams wb_add_worksheet sheet grid_lines tab_color zoom
-#' @inheritDotParams wb_add_data_table start_col start_row col_names row_names na.strings
-#' @inheritDotParams wb_add_data start_col start_row col_names row_names na.strings
+#' @inheritDotParams wb_add_data_table start_col start_row col_names row_names na_strings
+#' @inheritDotParams wb_add_data start_col start_row col_names row_names na_strings
 #' @inheritDotParams wb_freeze_pane first_active_row first_active_col first_row first_col
 #' @inheritDotParams wb_set_col_widths widths
 #' @inheritDotParams wb_save overwrite
@@ -52,7 +52,7 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
     "first_footer", "start_col", "start_row",
     "col.names", "row.names", "col_names", "row_names", "table_style",
     "table_name", "with_filter", "first_active_row", "first_active_col",
-    "first_row", "first_col", "col_widths", "na.strings",
+    "first_row", "first_col", "col_widths", "na_strings", "na.strings",
     "overwrite", "title", "subject", "category"
   )
 
@@ -110,7 +110,7 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   ## startRow = 1,
   ## colNames = TRUE,
   ## rowNames = FALSE,
-  ## na.strings = NULL
+  ## na_strings = NULL
 
   #----write_datatable---#
   ## startCol = 1
@@ -259,8 +259,10 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
     tableStyle <- params$table_style
   }
 
-  na.strings <-
-    if ("na.strings" %in% names(params)) {
+  na_strings <-
+    if ("na_strings" %in% names(params)) {
+      params$na_strings
+    } else if ("na.strings" %in% names(params)) {
       params$na.strings
     } else {
       na_strings()
@@ -355,7 +357,7 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
         table_style = tableStyle[[i]],
         table_name  = NULL,
         with_filter = withFilter[[i]],
-        na.strings  = na.strings
+        na_strings  = na_strings
       )
     } else {
       write_data(
@@ -366,7 +368,7 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
         start_row  = startRow[[i]],
         col_names  = colNames[[i]],
         row_names  = rowNames[[i]],
-        na.strings = na.strings
+        na_strings = na_strings
       )
     }
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -456,7 +456,7 @@ add data
   sep = ", ",
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
-  na.strings = na_strings(),
+  na_strings = na_strings(),
   inline_strings = TRUE,
   ...
 )}\if{html}{\out{</div>}}
@@ -491,7 +491,7 @@ add data
 
 \item{\code{remove_cell_style}}{if writing into existing cells, should the cell style be removed?}
 
-\item{\code{na.strings}}{Value used for replacing \code{NA} values from \code{x}. Default
+\item{\code{na_strings}}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{na_strings()} uses the special \verb{#N/A} value within the workbook.}
 
 \item{\code{inline_strings}}{write characters as inline strings}
@@ -527,7 +527,7 @@ add a data table
   banded_cols = FALSE,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
-  na.strings = na_strings(),
+  na_strings = na_strings(),
   inline_strings = TRUE,
   ...
 )}\if{html}{\out{</div>}}
@@ -570,7 +570,7 @@ add a data table
 
 \item{\code{remove_cell_style}}{if writing into existing cells, should the cell style be removed?}
 
-\item{\code{na.strings}}{Value used for replacing \code{NA} values from \code{x}. Default
+\item{\code{na_strings}}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{na_strings()} uses the special \verb{#N/A} value within the workbook.}
 
 \item{\code{inline_strings}}{write characters as inline strings}
@@ -767,8 +767,8 @@ to_df
   rows = NULL,
   cols = NULL,
   detect_dates = TRUE,
-  na.strings = "#N/A",
-  na.numbers = NA,
+  na_strings = "#N/A",
+  na_numbers = NA,
   fill_merged_cells = FALSE,
   dims,
   show_formula = FALSE,
@@ -807,9 +807,9 @@ to_df
 
 \item{\code{detect_dates}}{If TRUE, attempt to recognize dates and perform conversion.}
 
-\item{\code{na.strings}}{A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.}
+\item{\code{na_strings}}{A character vector of strings which are to be interpreted as NA. Blank cells will be returned as NA.}
 
-\item{\code{na.numbers}}{A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.}
+\item{\code{na_numbers}}{A numeric vector of digits which are to be interpreted as NA. Blank cells will be returned as NA.}
 
 \item{\code{fill_merged_cells}}{If TRUE, the value in a merged cell is given to all cells within the merge.}
 

--- a/man/wb_add_data.Rd
+++ b/man/wb_add_data.Rd
@@ -19,7 +19,7 @@ wb_add_data(
   sep = ", ",
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
-  na.strings = na_strings(),
+  na_strings = na_strings(),
   inline_strings = TRUE,
   ...
 )
@@ -55,7 +55,7 @@ columns to a character vector e.g. \code{sapply(x$list_column, paste, collapse =
 
 \item{remove_cell_style}{keep the cell style?}
 
-\item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
+\item{na_strings}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}

--- a/man/wb_add_data_table.Rd
+++ b/man/wb_add_data_table.Rd
@@ -23,7 +23,7 @@ wb_add_data_table(
   banded_cols = FALSE,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
-  na.strings = na_strings(),
+  na_strings = na_strings(),
   inline_strings = TRUE,
   ...
 )
@@ -72,7 +72,7 @@ columns to a character vector e.g.
 
 \item{remove_cell_style}{keep the cell style?}
 
-\item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
+\item{na_strings}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}

--- a/man/wb_to_df.Rd
+++ b/man/wb_to_df.Rd
@@ -20,8 +20,8 @@ wb_to_df(
   rows = NULL,
   cols = NULL,
   detect_dates = TRUE,
-  na.strings = "#N/A",
-  na.numbers = NA,
+  na_strings = "#N/A",
+  na_numbers = NA,
   fill_merged_cells = FALSE,
   dims,
   show_formula = FALSE,
@@ -45,8 +45,8 @@ read_xlsx(
   cols = NULL,
   detect_dates = TRUE,
   named_region,
-  na.strings = "#N/A",
-  na.numbers = NA,
+  na_strings = "#N/A",
+  na_numbers = NA,
   fill_merged_cells = FALSE,
   ...
 )
@@ -64,8 +64,8 @@ wb_read(
   cols = NULL,
   detect_dates = TRUE,
   named_region,
-  na.strings = "NA",
-  na.numbers = NA,
+  na_strings = "NA",
+  na_numbers = NA,
   ...
 )
 }
@@ -98,10 +98,10 @@ If \code{NULL}, all columns are read.}
 
 \item{detect_dates}{If \code{TRUE}, attempt to recognize dates and perform conversion.}
 
-\item{na.strings}{A character vector of strings which are to be interpreted as \code{NA}.
+\item{na_strings}{A character vector of strings which are to be interpreted as \code{NA}.
 Blank cells will be returned as \code{NA}.}
 
-\item{na.numbers}{A numeric vector of digits which are to be interpreted as \code{NA}.
+\item{na_numbers}{A numeric vector of digits which are to be interpreted as \code{NA}.
 Blank cells will be returned as \code{NA}.}
 
 \item{fill_merged_cells}{If \code{TRUE}, the value in a merged cell is given to all cells within the merge.}
@@ -199,7 +199,7 @@ wb_to_df(wb1, cols = c(2, 5), types = c("Var1" = 0, "Var3" = 1))
 wb_to_df(wb1, start_row = 5, col_names = FALSE)
 
 # na string
-wb_to_df(wb1, na.strings = "a")
+wb_to_df(wb1, na_strings = "a")
 
 ###########################################################################
 # Named regions

--- a/man/write_data.Rd
+++ b/man/write_data.Rd
@@ -19,7 +19,7 @@ write_data(
   name = NULL,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
-  na.strings = na_strings(),
+  na_strings = na_strings(),
   inline_strings = TRUE,
   ...
 )
@@ -55,7 +55,7 @@ columns to a character vector e.g. \code{sapply(x$list_column, paste, collapse =
 
 \item{remove_cell_style}{keep the cell style?}
 
-\item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
+\item{na_strings}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}

--- a/man/write_datatable.Rd
+++ b/man/write_datatable.Rd
@@ -23,7 +23,7 @@ write_datatable(
   banded_cols = FALSE,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
-  na.strings = na_strings(),
+  na_strings = na_strings(),
   inline_strings = TRUE,
   ...
 )
@@ -72,7 +72,7 @@ columns to a character vector e.g.
 
 \item{remove_cell_style}{keep the cell style?}
 
-\item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
+\item{na_strings}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}

--- a/man/write_xlsx.Rd
+++ b/man/write_xlsx.Rd
@@ -28,7 +28,7 @@ percentage. (A zoom value smaller than 10 will default to 10.)}
     \item{\code{start_row}}{A vector specifying the starting row to write \code{x} to.}
     \item{\code{col_names}}{If \code{TRUE}, column names of \code{x} are written.}
     \item{\code{row_names}}{If \code{TRUE}, the row names of \code{x} are written.}
-    \item{\code{na.strings}}{Value used for replacing \code{NA} values from \code{x}. Default
+    \item{\code{na_strings}}{Value used for replacing \code{NA} values from \code{x}. Default
 \code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
     \item{\code{first_active_row}}{Top row of active region}
     \item{\code{first_active_col}}{Furthest left column of active region}

--- a/vignettes/openxlsx2.Rmd
+++ b/vignettes/openxlsx2.Rmd
@@ -138,7 +138,7 @@ wb_to_df(file, start_row = 5, col_names = FALSE)
 There is the "#N/A" string, but often the user will be faced with custom missing values and other values we are not interested. Such strings can be passed as character vector via `na.strings`
 ```{r}
 # na strings
-wb_to_df(file, na.strings = "")
+wb_to_df(file, na_strings = "")
 ```
 
 ### Importing as workbook


### PR DESCRIPTION
Not sure I will merge this. We run into a nasty issue I wasn't aware of before:

Basically, we have `foo(na_strings = na_strings())` and R does not like this. Therefore we have to hack our way around this, as seen [here](https://stat.ethz.ch/pipermail/r-package-devel/2022q3/008298.html), but obviously it looks bad.

Therefore I'd favor post phoning this for some 2.x release, where we might replace `na_strings()` with a new name.

``` r
na_strings <- function() {
  NA
}

test1 <- function(na_strings = na_strings()) {
  print(na_strings)
}

test2 <- function(na_strings = na_strings()) {
  if (missing(na_strings)) {
    default <- substitute(na_strings)
    rm(na_strings)
    na_strings <- eval(default)
  }
  print(na_strings)
}

try(test1())
#> Error in print(na_strings) : 
#>   promise already under evaluation: recursive default argument reference or earlier problems?
test2()
#> [1] NA
```