### PR TITLE
[write] add total_row option to wb_add_data_table()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * It's now possible to pass array formula vectors to `wb_add_formula()`.
 
+* `wb_add_data_table()` gained a new `total_row` argument. This allows to add a total row to spreadsheets including text and spreadsheet formulas.
+
 ## Fixes
 
 * Export `wb_add_ignore_error()`. [955](https://github.com/JanMarvin/openxlsx2/pull/955)

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -260,10 +260,31 @@ wb_add_data <- function(
 #' @param last_column logical. If `TRUE`, the last column is bold.
 #' @param banded_rows logical. If `TRUE`, rows are color banded.
 #' @param banded_cols logical. If `TRUE`, the columns are color banded.
+#' @param total_row logical. With the default `FALSE` no total row is added.
 #' @param ... additional arguments
+#'
+#' @details # Modify total row argument
+#' It is possible to further tweak the total row. In addition to the default
+#' `FALSE` possible values are `TRUE` (the xlsx file will create column sums
+#' each variable).
+#'
+#' In addition it is possible to tweak this further using a character string
+#' with one of the following functions for each variable: `"average"`,
+#' `"count"`, `"countNums"`, `"max"`, `"min"`, `"stdDev"`, `"sum"`, `"var"`.
+#' It is possible to leave the cell empty `"none"` or to create a text input
+#' using a named character with name `text` like: `c(text = "Total")`.
+#' It's also possible to pass other spreadsheet software functions if they
+#' return a single value and hence `"SUM"` would work too.
 #'
 #' @family worksheet content functions
 #' @family workbook wrappers
+#' @examples
+#' wb <- wb_workbook()$add_worksheet()$
+#'   add_data_table(
+#'     x = as.data.frame(USPersonalExpenditure),
+#'     row_names = TRUE,
+#'     total_row = c(text = "Total", "none", "sum", "sum", "sum", "SUM")
+#'   )
 #' @export
 wb_add_data_table <- function(
     wb,
@@ -286,6 +307,7 @@ wb_add_data_table <- function(
     remove_cell_style = FALSE,
     na.strings        = na_strings(),
     inline_strings    = TRUE,
+    total_row        = FALSE,
     ...
 ) {
   assert_workbook(wb)
@@ -309,6 +331,7 @@ wb_add_data_table <- function(
     remove_cell_style = remove_cell_style,
     na.strings        = na.strings,
     inline_strings    = inline_strings,
+    total_row        = total_row,
     ...               = ...
   )
 }
@@ -530,7 +553,7 @@ wb_add_slicer <- function(
 #' cells (see the `MMULT()` example below). For this type of formula, the
 #' output range must be known a priori and passed to `dims`, otherwise only the
 #' value of the first cell will be returned. This type of formula, whose result
-#' extends over several cells, is only possible with scalar values. If a vector
+#' extends over several cells, is only possible with single strings. If a vector
 #' is passed, it is only possible to return individual cells.
 #'
 #' @param wb A Workbook object containing a worksheet.

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -6,12 +6,12 @@
 #' columns of `x` with class `Date` or `POSIXt` are automatically
 #' styled as dates and datetimes respectively.
 #'
-#' @param x An object or a list of objects that can be handled by [wb_add_data()] to write to file
-#' @param file An xlsx file name
+#' @param x An object or a list of objects that can be handled by [wb_add_data()] to write to file.
+#' @param file An optional xlsx file name. If no file is passed, the object is not written to disk and only a workbook object is returned.
 #' @param as_table If `TRUE`, will write as a data table, instead of data.
 #' @inheritDotParams wb_workbook creator
 #' @inheritDotParams wb_add_worksheet sheet grid_lines tab_color zoom
-#' @inheritDotParams wb_add_data_table start_col start_row col_names row_names na.strings
+#' @inheritDotParams wb_add_data_table start_col start_row col_names row_names na.strings total_row
 #' @inheritDotParams wb_add_data start_col start_row col_names row_names na.strings
 #' @inheritDotParams wb_freeze_pane first_active_row first_active_col first_row first_col
 #' @inheritDotParams wb_set_col_widths widths
@@ -49,7 +49,7 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   arguments <- c(ls(), "creator",  "sheet_name", "grid_lines",
     "tab_color", "tab_colour",
     "zoom", "header", "footer", "even_header", "even_footer", "first_header",
-    "first_footer", "start_col", "start_row",
+    "first_footer", "start_col", "start_row", "total_row",
     "col.names", "row.names", "col_names", "row_names", "table_style",
     "table_name", "with_filter", "first_active_row", "first_active_col",
     "first_row", "first_col", "col_widths", "na.strings",
@@ -259,6 +259,11 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
     tableStyle <- params$table_style
   }
 
+  totalRow <- FALSE
+  if ("total_row" %in% names(params)) {
+    totalRow <- params$total_row
+  }
+
   na.strings <-
     if ("na.strings" %in% names(params)) {
       params$na.strings
@@ -356,7 +361,8 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
         table_style = tableStyle[[i]],
         table_name  = NULL,
         with_filter = withFilter[[i]],
-        na.strings  = na.strings
+        na.strings  = na.strings,
+        total_row   = totalRow
       )
     } else {
       # TODO add_data()?
@@ -440,6 +446,8 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
     }
   }
 
-  wb_save(wb, file = file, overwrite = overwrite)
+  if (!missing(file))
+    wb_save(wb, file = file, overwrite = overwrite)
+
   invisible(wb)
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -195,6 +195,7 @@ posixt
 pre
 printTitleCols
 printTitleRows
+priori
 pugi
 pugixml
 queryTables
@@ -239,6 +240,7 @@ tableStyle
 tablename
 textLength
 th
+totalLabel
 totalRow
 totalsRowCount
 twoCell

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -579,6 +579,7 @@ add a data table
   remove_cell_style = FALSE,
   na.strings = na_strings(),
   inline_strings = TRUE,
+  total_row = FALSE,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -624,6 +625,8 @@ add a data table
 \code{na_strings()} uses the special \verb{#N/A} value within the workbook.}
 
 \item{\code{inline_strings}}{write characters as inline strings}
+
+\item{\code{total_row}}{write total rows to table}
 
 \item{\code{...}}{additional arguments}
 }
@@ -972,8 +975,9 @@ Build table
   showColNames,
   tableStyle,
   tableName,
-  withFilter,
+  withFilter = TRUE,
   totalsRowCount = 0,
+  totalLabel = FALSE,
   showFirstColumn = 0,
   showLastColumn = 0,
   showRowStripes = 1,
@@ -999,6 +1003,8 @@ Build table
 \item{\code{withFilter}}{withFilter}
 
 \item{\code{totalsRowCount}}{totalsRowCount}
+
+\item{\code{totalLabel}}{totalLabel}
 
 \item{\code{showFirstColumn}}{showFirstColumn}
 

--- a/man/wb_add_data_table.Rd
+++ b/man/wb_add_data_table.Rd
@@ -25,6 +25,7 @@ wb_add_data_table(
   remove_cell_style = FALSE,
   na.strings = na_strings(),
   inline_strings = TRUE,
+  total_row = FALSE,
   ...
 )
 }
@@ -77,6 +78,8 @@ columns to a character vector e.g.
 
 \item{inline_strings}{write characters as inline strings}
 
+\item{total_row}{logical. With the default \code{FALSE} no total row is added.}
+
 \item{...}{additional arguments}
 }
 \description{
@@ -111,6 +114,28 @@ Functions \code{\link[=wb_add_data]{wb_add_data()}} and \code{\link[=wb_add_data
 distinction is that the latter creates a table in the worksheet that can be
 used for different kind of formulas and can be sorted independently, though
 is less flexible than basic cell regions.
+}
+\section{Modify total row argument}{
+It is possible to further tweak the total row. In addition to the default
+\code{FALSE} possible values are \code{TRUE} (the xlsx file will create column sums
+each variable).
+
+In addition it is possible to tweak this further using a character string
+with one of the following functions for each variable: \code{"average"},
+\code{"count"}, \code{"countNums"}, \code{"max"}, \code{"min"}, \code{"stdDev"}, \code{"sum"}, \code{"var"}.
+It is possible to leave the cell empty \code{"none"} or to create a text input
+using a named character with name \code{text} like: \code{c(text = "Total")}.
+It's also possible to pass other spreadsheet software functions if they
+return a single value and hence \code{"SUM"} would work too.
+}
+
+\examples{
+wb <- wb_workbook()$add_worksheet()$
+  add_data_table(
+    x = as.data.frame(USPersonalExpenditure),
+    row_names = TRUE,
+    total_row = c(text = "Total", "none", "sum", "sum", "sum", "SUM")
+  )
 }
 \seealso{
 Other worksheet content functions: 

--- a/man/wb_add_formula.Rd
+++ b/man/wb_add_formula.Rd
@@ -67,7 +67,7 @@ take \code{dims} as a reference. For some formulas, the result will span multipl
 cells (see the \code{MMULT()} example below). For this type of formula, the
 output range must be known a priori and passed to \code{dims}, otherwise only the
 value of the first cell will be returned. This type of formula, whose result
-extends over several cells, is only possible with scalar values. If a vector
+extends over several cells, is only possible with single strings. If a vector
 is passed, it is only possible to return individual cells.
 }
 \examples{

--- a/man/write_datatable.Rd
+++ b/man/write_datatable.Rd
@@ -25,6 +25,7 @@ write_datatable(
   remove_cell_style = FALSE,
   na.strings = na_strings(),
   inline_strings = TRUE,
+  total_row = FALSE,
   ...
 )
 }
@@ -76,6 +77,8 @@ columns to a character vector e.g.
 \code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
+
+\item{total_row}{logical. With the default \code{FALSE} no total row is added.}
 
 \item{...}{additional arguments}
 }

--- a/man/write_xlsx.Rd
+++ b/man/write_xlsx.Rd
@@ -7,9 +7,9 @@
 write_xlsx(x, file, as_table = FALSE, ...)
 }
 \arguments{
-\item{x}{An object or a list of objects that can be handled by \code{\link[=wb_add_data]{wb_add_data()}} to write to file}
+\item{x}{An object or a list of objects that can be handled by \code{\link[=wb_add_data]{wb_add_data()}} to write to file.}
 
-\item{file}{An xlsx file name}
+\item{file}{An optional xlsx file name. If no file is passed, the object is not written to disk and only a workbook object is returned.}
 
 \item{as_table}{If \code{TRUE}, will write as a data table, instead of data.}
 
@@ -24,6 +24,7 @@ hidden.}
 \code{grDevices::colors()}) or a valid hex color beginning with "#".}
     \item{\code{zoom}}{The sheet zoom level, a numeric between 10 and 400 as a
 percentage. (A zoom value smaller than 10 will default to 10.)}
+    \item{\code{total_row}}{logical. With the default \code{FALSE} no total row is added.}
     \item{\code{start_col}}{A vector specifying the starting column to write \code{x} to.}
     \item{\code{start_row}}{A vector specifying the starting row to write \code{x} to.}
     \item{\code{col_names}}{If \code{TRUE}, column names of \code{x} are written.}


### PR DESCRIPTION
Inspired by https://github.com/ycphs/openxlsx/issues/464

``` r
library(openxlsx2)

wb <- wb_workbook()$add_worksheet()$
  add_data_table(
    x = as.data.frame(USPersonalExpenditure), 
    row_names = TRUE,
    total_row = c(text = "Total", "none", "sum", "sum", "sum", "SUM")
  )

if (interactive()) wb$open()
```
<img width="345" alt="Screenshot 2024-02-28 at 21 56 13" src="https://github.com/JanMarvin/openxlsx2/assets/1645626/7213677a-42ed-4799-83e7-5586b447b4c7">

