### PR TITLE
[add_image] fix logic to allow adding images after a drawing w/o relships

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5068,7 +5068,7 @@ wbWorkbook <- R6::R6Class(
         imageNo <- 1L
       }
 
-      if (length(self$drawings_rels) >= sheet_drawing) {
+      if (length(self$drawings_rels) >= sheet_drawing && !all(self$drawings_rels[[sheet_drawing]] == "")) {
         next_id <- get_next_id(self$drawings_rels[[sheet_drawing]])
       } else {
         next_id <- "rId1"

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -504,6 +504,10 @@ test_that("add_drawing works", {
 
   expect_length(wb$drawings, 1L)
 
+  img <- system.file("extdata", "einstein.jpg", package = "openxlsx2")
+
+  expect_silent(wb$add_image(file = img))
+
 })
 
 test_that("add_drawing works", {


### PR DESCRIPTION
Fixes a rare case, where one wants to add an image to a workbook that has no drawing relationship yet. Like adding a drawing xml first and an image afterwards. Probably nothing anybody ever tried to do.