### PR TITLE
[option] openxlsx2.nastrings option as discussed in #964

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -783,6 +783,10 @@ write_data_table <- function(
     return(wb)
   }
 
+  # overwrite na.strings with whatever is in the option
+  na.strings <- getOption("openxlsx2.nastrings") %||% na.strings
+
+
   if (data_table && nrow(x) < 1) {
     warning("Found data table with zero rows, adding one.",
             " Modify na with na.strings")

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -15,3 +15,20 @@ test_that("sheet.default_name", {
   expect_equal(exp, got)
 
 })
+
+test_that("nastrings option works", {
+
+  op <- options("openxlsx2.nastrings" = fmt_txt("N/A", italic = TRUE, color = wb_color("gray")))
+  on.exit(options(op), add = TRUE)
+
+  ## create a data set with missings
+  dd <- mtcars
+  dd[dd < 3] <- NA
+
+  wb <- write_xlsx(x = dd)
+
+  exp <- "<is><r><rPr><i/><color rgb=\"FFBEBEBE\"/></rPr><t>N/A</t></r></is>"
+  got <- wb$worksheets[[1]]$sheet_data$cc[17, "is"]
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
The only thing that is not possible, writing `na.strings = NULL`, because this will fall through. Writing `na.strings = NULL` suppresses writing anything, but you could write `na.strings = ""`. Does this work for you @olivroy?