### PR TITLE
Add openxlsx2.na.strings option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `wb_dims()` now accepts `from_dims` to specify a starting cell [960](https://github.com/JanMarvin/openxlsx2/pull/960).
 
+* You can now set `options(openxlsx2.na.strings)` to a value  to have a default value for `na.strings` in `wb_add_data()`, `wb_add_data_table()`, and `write_xlsx()` [968](https://github.com/JanMarvin/openxlsx2/pull/968).
+
 ## Fixes
 
 * Export `wb_add_ignore_error()`. [955](https://github.com/JanMarvin/openxlsx2/pull/955)

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -112,7 +112,8 @@ wb_save <- function(wb, file = NULL, overwrite = TRUE, path = NULL) {
 #' @param apply_cell_style Should we write cell styles to the workbook
 #' @param remove_cell_style keep the cell style?
 #' @param na.strings Value used for replacing `NA` values from `x`. Default
-#'   [na_strings()] uses the special `#N/A` value within the workbook.
+#'   looks if `options(openxlsx2.na.strings)` is set. Otherwise [na_strings()]
+#'   uses the special `#N/A` value within the workbook.
 #' @param inline_strings write characters as inline strings
 #' @param ... additional arguments
 #' @export

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6322,7 +6322,9 @@ wbWorkbook <- R6::R6Class(
       sheet <- private$get_sheet_index(sheet)
 
       if (!table %in% self$tables$tab_name) {
-        stop(sprintf("table '%s' does not exist.", table), call. = FALSE)
+        stop(sprintf("table '%s' does not exist.\n
+                     Call `wb_get_tables()` to get existing table names", table),
+             call. = FALSE)
       }
 
       ## delete table object (by flagging as deleted)

--- a/R/openxlsx2-package.R
+++ b/R/openxlsx2-package.R
@@ -158,7 +158,8 @@
 #' * `options("openxlsx2.scientificFormat" = 48)`
 #' * `options("openxlsx2.string_nums" = TRUE)` numerics in character columns
 #'    will be converted. `"1"` will be written as `1`
-#' * `options("openxlsx2.nastrings" = "#N/A")` consulted by write and add data functions.
+#' * `options("openxlsx2.na.strings" = "#N/A")` consulted by `write_xlsx()`,
+#'   `wb_add_data()` and `wb_add_data_table()`.
 #' @name openxlsx2_options
 NULL
 # matches enum celltype
@@ -198,6 +199,8 @@ openxlsx2_celltype <- c(
 #'
 #' You should be able to modify
 #' * [delete_data()] -> [wb_clean_sheet()]
+#' * [write_data()] -> [wb_add_data()]
+#' * [write_datatable()] -> [wb_add_data_table()]
 #' * [write_comment()] -> [wb_add_comment()]
 #' * [remove_comment()] -> [wb_remove_comment()]
 #' * [write_formula()] -> [wb_add_formula()]

--- a/R/openxlsx2-package.R
+++ b/R/openxlsx2-package.R
@@ -158,6 +158,7 @@
 #' * `options("openxlsx2.scientificFormat" = 48)`
 #' * `options("openxlsx2.string_nums" = TRUE)` numerics in character columns
 #'    will be converted. `"1"` will be written as `1`
+#' * `options("openxlsx2.nastrings" = "#N/A")` consulted by write and add data functions.
 #' @name openxlsx2_options
 NULL
 # matches enum celltype

--- a/R/write.R
+++ b/R/write.R
@@ -10,7 +10,8 @@
 #' @param colNames has colNames (only in update_cell)
 #' @param removeCellStyle remove the cell style (only in update_cell)
 #' @param na.strings Value used for replacing `NA` values from `x`. Default
-#'   `na_strings()` uses the special `#N/A` value within the workbook.#' @keywords internal
+#'   `na_strings()` uses the special `#N/A` value within the workbook.
+#' @keywords internal
 #' @noRd
 inner_update <- function(
     wb,
@@ -176,7 +177,8 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
 #' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle keep the cell style?
 #' @param na.strings Value used for replacing `NA` values from `x`. Default
-#'   `na_strings()` uses the special `#N/A` value within the workbook.
+#'   looks if `options(openxlsx2.na.strings)` is set. Otherwise [na_strings()]
+#'   uses the special `#N/A` value within the workbook.
 #' @param data_table logical. if `TRUE` and `rowNames = TRUE`, do not write the cell containing  `"_rowNames_"`
 #' @param inline_strings write characters as inline strings
 #' @details
@@ -723,7 +725,8 @@ write_data2 <- function(
 #' @param applyCellStyle apply styles when writing on the sheet
 #' @param removeCellStyle if writing into existing cells, should the cell style be removed?
 #' @param na.strings Value used for replacing `NA` values from `x`. Default
-#'   `na_strings()` uses the special `#N/A` value within the workbook.
+#'   looks if `options(openxlsx2.na.strings)` is set. Otherwise [na_strings()]
+#'   uses the special `#N/A` value within the workbook.
 #' @param inline_strings optional write strings as inline strings
 #' @param total_row optional write total rows
 #' @noRd
@@ -785,8 +788,8 @@ write_data_table <- function(
   # overwrite na.strings if nothing was provided
   # with whatever is in the option if not set to default
   if (identical(as.character(na.strings), "na_string") &&
-      !is.null(getOption("openxlsx2.nastrings"))) {
-    na.strings <- getOption("openxlsx2.nastrings")
+      !is.null(getOption("openxlsx2.na.strings"))) {
+    na.strings <- getOption("openxlsx2.na.strings")
   }
 
   if (data_table && nrow(x) < 1) {

--- a/R/write.R
+++ b/R/write.R
@@ -782,6 +782,12 @@ write_data_table <- function(
   if (is.null(x)) {
     return(wb)
   }
+  # overwrite na.strings if nothing was provided
+  # with whatever is in the option if not set to default
+  if (identical(as.character(na.strings), "na_string") &&
+      !is.null(getOption("openxlsx2.nastrings"))) {
+    na.strings <- getOption("openxlsx2.nastrings")
+  }
 
   if (data_table && nrow(x) < 1) {
     warning("Found data table with zero rows, adding one.",

--- a/R/write.R
+++ b/R/write.R
@@ -787,8 +787,8 @@ write_data_table <- function(
   }
   # overwrite na.strings if nothing was provided
   # with whatever is in the option if not set to default
-  if (identical(as.character(na.strings), "na_string") &&
-      !is.null(getOption("openxlsx2.na.strings"))) {
+  if (is_na_strings(na.strings) && !is.null(getOption("openxlsx2.na.strings"))) {
+
     na.strings <- getOption("openxlsx2.na.strings")
   }
 

--- a/R/write.R
+++ b/R/write.R
@@ -788,7 +788,6 @@ write_data_table <- function(
   # overwrite na.strings if nothing was provided
   # with whatever is in the option if not set to default
   if (is_na_strings(na.strings) && !is.null(getOption("openxlsx2.na.strings"))) {
-
     na.strings <- getOption("openxlsx2.na.strings")
   }
 

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -267,6 +267,8 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   na.strings <-
     if ("na.strings" %in% names(params)) {
       params$na.strings
+    } else if (!is.null(getOption("openxlsx2.nastrings"))) {
+      getOption("openxlsx2.nastrings")
     } else {
       na_strings()
     }

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -267,8 +267,8 @@ write_xlsx <- function(x, file, as_table = FALSE, ...) {
   na.strings <-
     if ("na.strings" %in% names(params)) {
       params$na.strings
-    } else if (!is.null(getOption("openxlsx2.nastrings"))) {
-      getOption("openxlsx2.nastrings")
+    } else if (!is.null(getOption("openxlsx2.na.strings"))) {
+      getOption("openxlsx2.na.strings")
     } else {
       na_strings()
     }

--- a/man/openxlsx2-deprecated.Rd
+++ b/man/openxlsx2-deprecated.Rd
@@ -17,6 +17,8 @@ to use them in scripts. They originate from openxlsx, but do not fit openxlsx2's
 You should be able to modify
 \itemize{
 \item \code{\link[=delete_data]{delete_data()}} -> \code{\link[=wb_clean_sheet]{wb_clean_sheet()}}
+\item \code{\link[=write_data]{write_data()}} -> \code{\link[=wb_add_data]{wb_add_data()}}
+\item \code{\link[=write_datatable]{write_datatable()}} -> \code{\link[=wb_add_data_table]{wb_add_data_table()}}
 \item \code{\link[=write_comment]{write_comment()}} -> \code{\link[=wb_add_comment]{wb_add_comment()}}
 \item \code{\link[=remove_comment]{remove_comment()}} -> \code{\link[=wb_remove_comment]{wb_remove_comment()}}
 \item \code{\link[=write_formula]{write_formula()}} -> \code{\link[=wb_add_formula]{wb_add_formula()}}

--- a/man/openxlsx2_options.Rd
+++ b/man/openxlsx2_options.Rd
@@ -33,6 +33,7 @@ to a cell with \code{\link[=wb_add_thread]{wb_add_thread()}}
 \item \code{options("openxlsx2.scientificFormat" = 48)}
 \item \code{options("openxlsx2.string_nums" = TRUE)} numerics in character columns
 will be converted. \code{"1"} will be written as \code{1}
-\item \code{options("openxlsx2.nastrings" = "#N/A")} consulted by write and add data functions.
+\item \code{options("openxlsx2.na.strings" = "#N/A")} consulted by \code{write_xlsx()},
+\code{wb_add_data()} and \code{wb_add_data_table()}.
 }
 }

--- a/man/openxlsx2_options.Rd
+++ b/man/openxlsx2_options.Rd
@@ -33,5 +33,6 @@ to a cell with \code{\link[=wb_add_thread]{wb_add_thread()}}
 \item \code{options("openxlsx2.scientificFormat" = 48)}
 \item \code{options("openxlsx2.string_nums" = TRUE)} numerics in character columns
 will be converted. \code{"1"} will be written as \code{1}
+\item \code{options("openxlsx2.nastrings" = "#N/A")} consulted by write and add data functions.
 }
 }

--- a/man/wb_add_data.Rd
+++ b/man/wb_add_data.Rd
@@ -56,7 +56,8 @@ columns to a character vector e.g. \code{sapply(x$list_column, paste, collapse =
 \item{remove_cell_style}{keep the cell style?}
 
 \item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
-\code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
+looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_strings]{na_strings()}}
+uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
 

--- a/man/wb_add_data_table.Rd
+++ b/man/wb_add_data_table.Rd
@@ -74,7 +74,8 @@ columns to a character vector e.g.
 \item{remove_cell_style}{keep the cell style?}
 
 \item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
-\code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
+looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_strings]{na_strings()}}
+uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
 

--- a/man/write_data.Rd
+++ b/man/write_data.Rd
@@ -56,7 +56,8 @@ columns to a character vector e.g. \code{sapply(x$list_column, paste, collapse =
 \item{remove_cell_style}{keep the cell style?}
 
 \item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
-\code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
+looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_strings]{na_strings()}}
+uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
 

--- a/man/write_datatable.Rd
+++ b/man/write_datatable.Rd
@@ -74,7 +74,8 @@ columns to a character vector e.g.
 \item{remove_cell_style}{keep the cell style?}
 
 \item{na.strings}{Value used for replacing \code{NA} values from \code{x}. Default
-\code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
+looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_strings]{na_strings()}}
+uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
 

--- a/man/write_xlsx.Rd
+++ b/man/write_xlsx.Rd
@@ -30,7 +30,8 @@ percentage. (A zoom value smaller than 10 will default to 10.)}
     \item{\code{col_names}}{If \code{TRUE}, column names of \code{x} are written.}
     \item{\code{row_names}}{If \code{TRUE}, the row names of \code{x} are written.}
     \item{\code{na.strings}}{Value used for replacing \code{NA} values from \code{x}. Default
-\code{\link[=na_strings]{na_strings()}} uses the special \verb{#N/A} value within the workbook.}
+looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_strings]{na_strings()}}
+uses the special \verb{#N/A} value within the workbook.}
     \item{\code{first_active_row}}{Top row of active region}
     \item{\code{first_active_col}}{Furthest left column of active region}
     \item{\code{first_row}}{If \code{TRUE}, freezes the first row (equivalent to \code{first_active_row = 2})}

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -18,7 +18,7 @@ test_that("sheet.default_name", {
 
 test_that("nastrings option works", {
 
-  op <- options("openxlsx2.nastrings" = fmt_txt("N/A", italic = TRUE, color = wb_color("gray")))
+  op <- options("openxlsx2.na.strings" = fmt_txt("N/A", italic = TRUE, color = wb_color("gray")))
   on.exit(options(op), add = TRUE)
 
   ## create a data set with missings

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -15,3 +15,30 @@ test_that("sheet.default_name", {
   expect_equal(exp, got)
 
 })
+
+test_that("nastrings option works", {
+
+  op <- options("openxlsx2.nastrings" = fmt_txt("N/A", italic = TRUE, color = wb_color("gray")))
+  on.exit(options(op), add = TRUE)
+
+  ## create a data set with missings
+  dd <- mtcars
+  dd[dd < 3] <- NA
+
+  wb <- write_xlsx(x = dd)
+
+  exp <- "<is><r><rPr><i/><color rgb=\"FFBEBEBE\"/></rPr><t>N/A</t></r></is>"
+  got <- wb$worksheets[[1]]$sheet_data$cc[17, "is"]
+  expect_equal(got, exp)
+
+  wb <- wb_workbook()
+  wb$add_worksheet()
+  wb$add_data(x = dd, na.strings = "", row_names = TRUE)
+  res <- wb$to_df(row_names = TRUE)
+  expect_equal(res, dd)
+
+  wb$add_worksheet()
+  wb$add_data(x = dd, row_names = TRUE)
+  res2 <- wb$to_df(row_names = TRUE, na.strings = "N/A")
+  expect_equal(res2, dd)
+})


### PR DESCRIPTION
I was thinking about something more like this.

I strongly feel about not having an option overriding a parameter passed (other than the default)


If option is set and na.string is  not supplied: use the option
If option is set and na.string is supplied: use na.strings
If option is not set and na.string is not use default.

Amends to #473 and addresses #20 

