### PR TITLE
[write] dims impact the direction vectors are written

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,11 @@
 
 * Export `wb_add_ignore_error()`. [955](https://github.com/JanMarvin/openxlsx2/pull/955)
 
+## Breaking changes
+
+* The direction vectors are written is now controlled via `dims`. Previously it was required to transpose a vector to write it horizontally: `wb_add_data(x = t(letters), col_names = FALSE)`. Now the direction is defined by `dims`. The default is still to write vectors vertically, but for a horizontal vector it is possible to write `wb_add_data(x = letters, dims = "A1:Z1")`. This change impacts vectors, hyperlinks and formulas and basically everything that is not a two dimensional `x` object.
+This is only breaking, if previous code made use of the transposed trick above and already defined a correct `dims`. Since the `wb_add_data()` function is agnostic of the direction of `x`, this `wb_add_data(x = t(letters), dims = "A1:Z1", col_names = FALSE)` would write the `letters` into cells `A1:A26`, because of a round trip through transpose.
+
 
 ***************************************************************************
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,12 @@
 * The direction vectors are written is now controlled via `dims`. Previously it was required to transpose a vector to write it horizontally: `wb_add_data(x = t(letters), col_names = FALSE)`. Now the direction is defined by `dims`. The default is still to write vectors vertically, but for a horizontal vector it is possible to write `wb_add_data(x = letters, dims = "A1:Z1")`. This change impacts vectors, hyperlinks and formulas and basically everything that is not a two dimensional `x` object.
 This is only breaking, if previous code made use of the transposed trick above and already defined a correct `dims`. Since the `wb_add_data()` function is agnostic of the direction of `x`, this `wb_add_data(x = t(letters), dims = "A1:Z1", col_names = FALSE)` would write the `letters` into cells `A1:A26`, because of a round trip through transpose.
 
+```r
+# before (workaround needed)
+wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = t(c(4, 5, 8)), col_names = FALSE)
+# now (listens to dims)
+ wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = c(4, 5, 8))
+```
 
 ***************************************************************************
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@ This is only breaking, if previous code made use of the transposed trick above a
 # before (workaround needed)
 wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = t(c(4, 5, 8)), col_names = FALSE)
 # now (listens to dims)
- wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = c(4, 5, 8))
+wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = c(4, 5, 8))
 ```
 
 ***************************************************************************

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -575,7 +575,7 @@ wb_add_slicer <- function(
 #' @export
 #' @examples
 #' wb <- wb_workbook()$add_worksheet()
-#' wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = t(c(4, 5, 8)), col_names = FALSE)
+#' wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = c(4, 5, 8))
 #'
 #' # calculate the sum of elements.
 #' wb$add_formula(dims = "D1", x = "SUM(A1:C1)")

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -1108,6 +1108,14 @@ write_sheetpr <- function(df) {
   )
 }
 
+# helper construct dim comparison from rowcol_to_dims(as_integer = TRUE) object
+min_and_max <- function(x) {
+  c(
+    (max(x[[2]]) + 1L) - min(x[[2]]), # row
+    (max(x[[1]]) + 1L) - min(x[[1]])  # col
+  )
+}
+
 #' helper function to detect if x fits into dims
 #'
 #' This function will throw a warning depending on the experimental option: `openxlsx2.warn_if_dims_dont_fit`
@@ -1123,11 +1131,11 @@ fits_in_dims <- function(x, dims, startCol, startRow) {
   }
 
   if (length(dims) == 1 && is.character(dims)) {
-    dims <- dims_to_rowcol(dims)
+    dims <- dims_to_rowcol(dims, as_integer = TRUE)
   }
 
   dim_x <- dim(x)
-  dim_d <- vapply(dims, length, NA_integer_)[2:1]
+  dim_d <- min_and_max(dims)
 
   opt <- getOption("openxlsx2.warn_if_dims_dont_fit", default = FALSE)
 
@@ -1147,7 +1155,7 @@ fits_in_dims <- function(x, dims, startCol, startRow) {
   if (fits) {
 
     # why oh why wasn't dims_to_rowcol()/rowcol_to_dims() created as a matching pair
-    dims <- rowcol_to_dims(row = as.integer(dims[[2]]), col = col2int(dims[[1]]))
+    dims <- rowcol_to_dims(row = dims[[2]], col = dims[[1]])
 
   } else {
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -223,6 +223,7 @@ showLastColumn
 showRowStripes
 showSheetTabs
 showVerticalScroll
+signalling
 slantDashDot
 slicerCaches
 sparkline

--- a/man/wb_add_formula.Rd
+++ b/man/wb_add_formula.Rd
@@ -72,7 +72,7 @@ is passed, it is only possible to return individual cells.
 }
 \examples{
 wb <- wb_workbook()$add_worksheet()
-wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = t(c(4, 5, 8)), col_names = FALSE)
+wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = c(4, 5, 8))
 
 # calculate the sum of elements.
 wb$add_formula(dims = "D1", x = "SUM(A1:C1)")

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -386,6 +386,10 @@ void wide_to_long(
 
       R_xlen_t pos = (j * m) + i;
 
+      std::string ref_str = Rcpp::String(ref[i]);
+      if (ref_str.compare("0") == 0)
+      ref_str = col + row;
+
       // factors can be numeric or string or both
       if (vtyp == factor) string_nums = true;
 
@@ -439,13 +443,13 @@ void wide_to_long(
       case array_formula:
         cell.f     = vals;
         cell.f_t   = "array";
-        cell.f_ref = ref[j];
+        cell.f_ref = ref_str;
         break;
       case cm_formula:
         cell.c_cm  = c_cm;
         cell.f     = vals;
         cell.f_t   = "array";
-        cell.f_ref = ref[j];
+        cell.f_ref = ref_str;
         break;
       }
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -909,3 +909,53 @@ test_that("writing vectors direction with dims works", {
   expect_equal(exp, got)
 
 })
+
+test_that("dims size warnings work", {
+
+  op <- options("openxlsx2.warn_if_dims_dont_fit" = TRUE)
+  on.exit(options(op), add = TRUE)
+
+  wb <- wb_workbook()$add_worksheet()
+
+  # default no dims
+  expect_warning(
+    wb$add_data(x = head(mtcars)),
+    "dimension of `x` exceeds all `dims`"
+  )
+
+  # with explicit default dims
+  expect_warning(
+    wb$add_data(dims = "A1", x = head(mtcars)),
+    "dimension of `x` exceeds all `dims`"
+  )
+
+  # wb_add_data(dims = wb_dims(x = obj), x = obj) should always be silent
+  expect_silent(wb$add_data(dims = wb_dims(x = head(mtcars)), x = head(mtcars)))
+
+  # correct size should always be silent
+  expect_silent(wb$add_data(dims = "A1:K7", x = head(mtcars)))
+
+  # To wide
+  expect_warning(
+    wb$add_data(dims = "A1:K1", x = head(mtcars)),
+    "dimension of `x` exceeds rows of `dims`"
+  )
+
+  # To short
+  expect_warning(
+    wb$add_data(dims = "A1:J7", x = head(mtcars)),
+    "dimension of `x` exceeds cols of `dims`"
+  )
+
+  # ending in the correct cell isn't enough
+  expect_warning(
+    wb$add_data(dims = "B2:K7", x = head(mtcars)),
+    "dimension of `x` exceeds all `dims`"
+  )
+
+  # currently write_xlsx() uses the default dims
+  expect_warning(
+    wb <- write_xlsx(x = head(mtcars))
+  )
+
+})

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -206,10 +206,10 @@ test_that("update cell(s)", {
 
   exp <- structure(
     list(c(7, NA, NA, NA, NA, 7),
-         c("y", "z", "TRUE", "FALSE", "TRUE", NA),
+         c(NA, NA, TRUE, FALSE, TRUE, NA),
          c(2, NA, 2.5, NA, NA, NA),
          c(7, 2, 3, NA, 5, NA)),
-    names = c(NA, "x", "Var2", "Var3"),
+    names = c(NA, "x", "y", "z"),
     row.names = 4:9,
     class = "data.frame")
 
@@ -875,5 +875,37 @@ test_that("writing total row works", {
   )
   got <- wb_to_df(wb, dims = wb_dims(rows = 6, cols = "A:F"), col_names = FALSE, show_formula = TRUE)
   expect_equal(exp, got, ignore_attr = TRUE)
+
+})
+
+test_that("writing vectors direction with dims works", {
+
+  # write vectors column or rowwise
+  wb <- wb_workbook()$add_worksheet()$
+    add_data(x = 1:2, dims = "A1:B1")$
+    add_data(x = t(1:2), dims = "D1:D2", col_names = FALSE)$
+    add_data(x = 1:2, dims = "A3:A4")$
+    add_data(x = t(1:2), dims = "D3:E3", col_names = FALSE)
+
+  exp <- c("A1", "B1", "D1", "E1", "A3", "D3", "A4", "D4")
+  got <- wb$worksheets[[1]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
+  ## sum, sum as array and sum as cm
+  wb <- wb_workbook()$
+    add_worksheet()$
+    add_data(x = head(cars))$
+    add_formula(x = c("SUM(A2:A7)", "SUM(B2:B7)"), dims = "A9:B9")$
+    add_formula(x = c("{SUM(A2:A7)}", "{SUM(B2:B7)}"), dims = "A10:B10")
+
+  expect_warning(
+    wb$add_formula(x = c("{SUM(A2:A7)}", "{SUM(B2:B7)}"), dims = "A11:B11", cm = TRUE),
+    "modifications with cm formulas are experimental. use at own risk"
+  )
+
+  exp <- c("A1", "B1", "A2", "B2", "A3", "B3", "A4", "B4", "A5", "B5",
+           "A6", "B6", "A7", "B7", "A9", "B9", "A10", "B10", "A11", "B11")
+  got <- wb$worksheets[[1]]$sheet_data$cc$r
+  expect_equal(exp, got)
 
 })


### PR DESCRIPTION
This introduces a change in behavior when writing vectors. Previously, we simply ignored whichever direction `dims` requested. We just selected the top left corner and started writing from there. This PR changes that. We now use the direction that `dims` suggests:

* `A1` (the default) or `A1:A2` - vertical
* `A1:B1` - horizontal

and we transpose the vector so that it can be written horizontally. This affects vectors, formulas (#972) and hyperlinks.

The break occurs if a user has previously transposed a vector manually and also specified the direction via `dims`. In this case, the data is transposed twice and the output looks different with the pull request, see the first example.

``` r
library(openxlsx2)

# write vectors column or row wise
wb <- wb_workbook()$add_worksheet()$
  add_data(x = 1:2, dims = "A1:B1")$
  add_data(x = t(1:2), dims = "D1:D2", col_names = FALSE)$
  add_data(x = 1:2, dims = "A3:A4")$
  add_data(x = t(1:2), dims = "D3:E3", col_names = FALSE)$
  add_fill(dims = "A1:B2", color = wb_color(theme = 4))$
  add_fill(dims = "A3:B4", color = wb_color(theme = 5))$
  add_fill(dims = "D1:E2", color = wb_color(theme = 6))$
  add_fill(dims = "D3:E4", color = wb_color(theme = 7))

if (interactive()) wb$open()


## sum, sum as array and sum as cm
wb <- wb_workbook()$
  add_worksheet()$
  add_data(x = head(cars))$
  add_formula(x = c("SUM(A2:A7)", "SUM(B2:B7)"), dims = "A9:B9")$
  add_formula(x = c("{SUM(A2:A7)}", "{SUM(B2:B7)}"), dims = "A10:B10")$
  add_formula(x = c("{SUM(A2:A7)}", "{SUM(B2:B7)}"), dims = "A11:B11", cm = TRUE)
#> Warning in write_data2(wb = wb, sheet = sheet, data = x, name = name, colNames
#> = colNames, : modifications with cm formulas are experimental. use at own risk

if (interactive()) wb$open()


## example from wb_add_formula()
wb <- wb_workbook()$add_worksheet()
wb$add_data(dims = wb_dims(rows = 1, cols = 1:3), x = c(4, 5, 8))

# calculate the sum of elements.
wb$add_formula(dims = "D1", x = "SUM(A1:C1)")

# array formula with result spanning over multiple cells
mm <- matrix(1:4, 2, 2)

wb$add_worksheet()$
  add_data(x = mm, dims = "A1:B2", col_names = FALSE)$
  add_data(x = mm, dims = "A4:B5", col_names = FALSE)$
  add_formula(x = "MMULT(A1:B2, A4:B5)", dims = "A7:B8", array = TRUE)

if (interactive()) wb$open()
```

Could you take a look, @olivroy, if you are following the intent of this PR? Unfortunately, when I wrote `write_data()`, `write_data2()` and `write_data_table()`, I didn't force a conversion to a data frame and kept building on the confused `openxlsx` logic, so the code looks terrible and is spread across three functions that should be rewritten in a single clean function.


