### PR TITLE
[WIP] More flexible dims

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,14 @@
 * Helper to read sensitivity labels from files and apply them to workbooks. 
 [983](https://github.com/JanMarvin/openxlsx2/pull/983)
 
+* It is now possible to pass non consecutive dims like `"A1:B1,C2:D2"` to various style helpers like `wb_add_fill()`. In addition it is now possible to write a data set into a predefined dims region using `enforce = TRUE`. This handles either `","` or `";"` as cell separator. [993](https://github.com/JanMarvin/openxlsx2/pull/993)
+
+```r
+# force a dataset into a specific cell dimension
+wb <- wb_workbook()$add_worksheet()
+wb$add_data(dims = "I2:J2;A1:B2;G5:H6", x = matrix(1:8, 4, 2), enforce = TRUE)
+```
+
 ## Fixes
 
 * Allow writing data frames with zero rows. [987](https://github.com/JanMarvin/openxlsx2/pull/987)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -48,8 +48,8 @@ is_charnum <- function(x) {
     .Call(`_openxlsx2_is_charnum`, x)
 }
 
-wide_to_long <- function(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm) {
-    invisible(.Call(`_openxlsx2_wide_to_long`, z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm))
+wide_to_long <- function(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm, dims) {
+    invisible(.Call(`_openxlsx2_wide_to_long`, z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm, dims))
 }
 
 #' @param colnames a vector of the names of the data frame

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -28,8 +28,16 @@ copy <- function(x) {
     .Call(`_openxlsx2_copy`, x)
 }
 
+needed_cells <- function(range) {
+    .Call(`_openxlsx2_needed_cells`, range)
+}
+
 dims_to_df <- function(rows, cols, fill) {
     .Call(`_openxlsx2_dims_to_df`, rows, cols, fill)
+}
+
+dims_to_df2 <- function(rows, cols, filled, fill) {
+    .Call(`_openxlsx2_dims_to_df2`, rows, cols, filled, fill)
 }
 
 long_to_wide <- function(z, tt, zz) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -28,16 +28,16 @@ copy <- function(x) {
     .Call(`_openxlsx2_copy`, x)
 }
 
+validate_dims <- function(input) {
+    .Call(`_openxlsx2_validate_dims`, input)
+}
+
 needed_cells <- function(range) {
     .Call(`_openxlsx2_needed_cells`, range)
 }
 
-dims_to_df <- function(rows, cols, fill) {
-    .Call(`_openxlsx2_dims_to_df`, rows, cols, fill)
-}
-
-dims_to_df2 <- function(rows, cols, filled, fill) {
-    .Call(`_openxlsx2_dims_to_df2`, rows, cols, filled, fill)
+dims_to_df <- function(rows, cols, filled, fill) {
+    .Call(`_openxlsx2_dims_to_df`, rows, cols, filled, fill)
 }
 
 long_to_wide <- function(z, tt, zz) {

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -115,6 +115,7 @@ wb_save <- function(wb, file = NULL, overwrite = TRUE, path = NULL) {
 #'   looks if `options(openxlsx2.na.strings)` is set. Otherwise [na_strings()]
 #'   uses the special `#N/A` value within the workbook.
 #' @param inline_strings write characters as inline strings
+#' @param enforce enforce that selected dims is filled. For this to work, `dims` must match `x`
 #' @param ... additional arguments
 #' @export
 #' @details Formulae written using [wb_add_formula()] to a Workbook object will
@@ -216,6 +217,7 @@ wb_add_data <- function(
     remove_cell_style = FALSE,
     na.strings        = na_strings(),
     inline_strings    = TRUE,
+    enforce           = FALSE,
     ...
 ) {
   assert_workbook(wb)
@@ -235,6 +237,7 @@ wb_add_data <- function(
     remove_cell_style = remove_cell_style,
     na.strings        = na.strings,
     inline_strings    = inline_strings,
+    enforce           = enforce,
     ...               = ...
   )
 }
@@ -332,7 +335,7 @@ wb_add_data_table <- function(
     remove_cell_style = remove_cell_style,
     na.strings        = na.strings,
     inline_strings    = inline_strings,
-    total_row        = total_row,
+    total_row         = total_row,
     ...               = ...
   )
 }
@@ -568,6 +571,7 @@ wb_add_slicer <- function(
 #'   Add this, if you see "@" inserted into your formulas.
 #' @param apply_cell_style Should we write cell styles to the workbook?
 #' @param remove_cell_style Should we keep the cell style?
+#' @param enforce enforce dims
 #' @param ... additional arguments
 #' @return The workbook, invisibly.
 #' @family workbook wrappers
@@ -599,6 +603,7 @@ wb_add_formula <- function(
     cm                = FALSE,
     apply_cell_style  = TRUE,
     remove_cell_style = FALSE,
+    enforce           = FALSE,
     ...
 ) {
   assert_workbook(wb)
@@ -612,6 +617,7 @@ wb_add_formula <- function(
     cm                = cm,
     apply_cell_style  = apply_cell_style,
     remove_cell_style = remove_cell_style,
+    enforce           = enforce,
     ...               = ...
   )
 }

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -1278,6 +1278,7 @@ wbWorkbook <- R6::R6Class(
     #' @param na.strings Value used for replacing `NA` values from `x`. Default
     #'   `na_strings()` uses the special `#N/A` value within the workbook.
     #' @param inline_strings write characters as inline strings
+    #' @param enforce enforce that selected dims is filled. For this to work, `dims` must match `x`
     #' @param return The `wbWorkbook` object
     add_data = function(
         sheet            = current_sheet(),
@@ -1295,6 +1296,7 @@ wbWorkbook <- R6::R6Class(
         remove_cell_style = FALSE,
         na.strings        = na_strings(),
         inline_strings    = TRUE,
+        enforce           = FALSE,
         ...
       ) {
 
@@ -1324,7 +1326,8 @@ wbWorkbook <- R6::R6Class(
         apply_cell_style  = apply_cell_style,
         remove_cell_style = remove_cell_style,
         na.strings        = na.strings,
-        inline_strings    = inline_strings
+        inline_strings    = inline_strings,
+        enforce           = enforce
       )
       invisible(self)
     },
@@ -1885,6 +1888,7 @@ wbWorkbook <- R6::R6Class(
     #' @param cm cm
     #' @param apply_cell_style applyCellStyle
     #' @param remove_cell_style if writing into existing cells, should the cell style be removed?
+    #' @param enforce enforce dims
     #' @return The `wbWorkbook` object
     add_formula = function(
         sheet             = current_sheet(),
@@ -1896,6 +1900,7 @@ wbWorkbook <- R6::R6Class(
         cm                = FALSE,
         apply_cell_style  = TRUE,
         remove_cell_style = FALSE,
+        enforce           = FALSE,
         ...
     ) {
 
@@ -1910,7 +1915,8 @@ wbWorkbook <- R6::R6Class(
         array           = array,
         cm              = cm,
         applyCellStyle  = apply_cell_style,
-        removeCellStyle = remove_cell_style
+        removeCellStyle = remove_cell_style,
+        enforce         = enforce
       )
       invisible(self)
     },

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -9081,8 +9081,6 @@ wbWorkbook <- R6::R6Class(
     ## @keywords internal
     do_cell_init = function(sheet = current_sheet(), dims) {
 
-      if (all(dims == "")) return(invisible(self))
-
       sheet <- private$get_sheet_index(sheet)
 
       if (is.null(self$worksheets[[sheet]]$sheet_data$cc)) {

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -9075,6 +9075,8 @@ wbWorkbook <- R6::R6Class(
     ## @keywords internal
     do_cell_init = function(sheet = current_sheet(), dims) {
 
+      if (all(dims == "")) return(invisible(self))
+
       sheet <- private$get_sheet_index(sheet)
 
       if (is.null(self$worksheets[[sheet]]$sheet_data$cc)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -178,8 +178,10 @@ NULL
 dims_to_rowcol <- function(x, as_integer = FALSE) {
 
   dims <- x
-  if (length(x) == 1 && grepl(";", x))
-    dims <- unlist(strsplit(x, ";"))
+  if (length(x) == 1) {
+    if (grepl(";", x)) dims <- unlist(strsplit(x, ";"))
+    if (grepl(",", x)) dims <- unlist(strsplit(x, ","))
+  }
 
   cols_out <- NULL
   rows_out <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -163,6 +163,7 @@ random_string <- function(n = 1, length = 16, pattern = "[A-Za-z0-9]", keep_seed
 #' @param as_integer If the output should be returned as integer, (defaults to string)
 #' @param row a numeric vector of rows
 #' @param col a numeric or character vector of cols
+#' @param single argument indicating if [rowcol_to_dims()] returns a single cell dimension
 #' @returns
 #'   * A `dims` string for `_to_dim` i.e  "A1:A1"
 #'   * A list of rows and columns for `to_rowcol`

--- a/R/utils.R
+++ b/R/utils.R
@@ -226,7 +226,7 @@ dims_to_rowcol <- function(x, as_integer = FALSE) {
 
 #' @rdname dims_helper
 #' @export
-rowcol_to_dims <- function(row, col) {
+rowcol_to_dims <- function(row, col, single = TRUE) {
 
   # no assert for col. will output character anyways
   # assert_class(row, "numeric") - complains if integer
@@ -240,7 +240,11 @@ rowcol_to_dims <- function(row, col) {
   max_row <- max(row)
 
   # we will always return something like "A1:A1", even for single cells
-  stringi::stri_join(min_col, min_row, ":", max_col, max_row)
+  if (single) {
+    return(stringi::stri_join(min_col, min_row, ":", max_col, max_row))
+  } else {
+    return(paste0(vapply(int2col(col_int), FUN = function(x) stringi::stri_join(x, min_row, ":", x, max_row), ""), collapse = ","))
+  }
 
 }
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -45,10 +45,10 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
   }
 
   dims_to_df(
-    rows = rows_out,
-    cols = cols_out,
+    rows   = rows_out,
+    cols   = cols_out,
     filled = filled,
-    fill = fill
+    fill   = fill
   )
 }
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -11,6 +11,9 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
   if (grepl(";", dims)) {
     dims <- unlist(strsplit(dims, ";"))
   }
+  if (grepl(",", dims)) {
+    dims <- unlist(strsplit(dims, ","))
+  }
 
   rows_out <- NULL
   cols_out <- NULL

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -44,22 +44,12 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
     }
   }
 
-  if (is.null(filled)) {
-    # create data frame from rows/
-    dims_to_df(
-      rows = rows_out,
-      cols = cols_out,
-      fill = fill
-    )
-  } else {
-    # create data frame from rows/
-    dims_to_df2(
-      rows   = rows_out,
-      cols   = cols_out,
-      filled = filled,
-      fill   = fill
-    )
-  }
+  dims_to_df(
+    rows = rows_out,
+    cols = cols_out,
+    filled = filled,
+    fill = fill
+  )
 }
 
 #' Create dimensions from dataframe

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -76,28 +76,26 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
 dataframe_to_dims <- function(df, dim_break = TRUE) {
 
   if (dim_break) {
-    # get continuous sequences of columns and rows in df
-    v <- as.integer(rownames(df))
-    rows <- split(v, cumsum(diff(c(-Inf, v)) != 1))
 
-    v <- col2int(colnames(df))
-    cols <- split(colnames(df), cumsum(diff(c(-Inf, v)) != 1))
+    dims <- dims_to_dataframe(dataframe_to_dims(df, dim_break = FALSE), fill = TRUE)
 
-    # combine columns and rows to construct dims
-    out <- NULL
-    for (col in seq_along(cols)) {
-      for (row in seq_along(rows)) {
-        tmp <- paste0(
-          cols[[col]][[1]], rows[[row]][[1]],
-          ":",
-          rev(cols[[col]])[[1]],  rev(rows[[row]])[[1]]
-        )
-        out <- c(out, tmp)
-      }
-    }
+    mm <- as.matrix(df)
+    mm[mm != "" | is.na(mm)] <- 1
+    mm[mm == ""] <- 0
 
-    return(paste0(out, collapse = ";"))
+    matrix <- matrix(as.numeric(mm), nrow(mm), ncol(mm))
+    dimnames(matrix) <- list(rownames(mm), colnames(mm))
+
+    # remove columns and rows not in df
+    dims <- dims[, colnames(dims) %in% colnames(matrix)]
+    dims <- dims[rownames(dims) %in% rownames(matrix), ]
+
+    out <- dims[matrix == 1]
+
+    return(paste0(out, collapse = ","))
+
   } else {
+
     rows <- as.integer(rownames(df))
     cols <- colnames(df)
 
@@ -108,6 +106,7 @@ dataframe_to_dims <- function(df, dim_break = TRUE) {
     )
 
     return(tmp)
+
   }
 }
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -66,34 +66,48 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
 #'
 #' Use [wb_dims()]
 #' @param df dataframe with spreadsheet columns and rows
+#' @param dim_break split the dims?
 #' @examples
 #'  df <- dims_to_dataframe("A1:D5;F1:F6;D8", fill = TRUE)
 #'  dataframe_to_dims(df)
 #' @keywords internal
 #' @export
-dataframe_to_dims <- function(df) {
+dataframe_to_dims <- function(df, dim_break = TRUE) {
 
-  # get continuous sequences of columns and rows in df
-  v <- as.integer(rownames(df))
-  rows <- split(v, cumsum(diff(c(-Inf, v)) != 1))
+  if (dim_break) {
+    # get continuous sequences of columns and rows in df
+    v <- as.integer(rownames(df))
+    rows <- split(v, cumsum(diff(c(-Inf, v)) != 1))
 
-  v <- col2int(colnames(df))
-  cols <- split(colnames(df), cumsum(diff(c(-Inf, v)) != 1))
+    v <- col2int(colnames(df))
+    cols <- split(colnames(df), cumsum(diff(c(-Inf, v)) != 1))
 
-  # combine columns and rows to construct dims
-  out <- NULL
-  for (col in seq_along(cols)) {
-    for (row in seq_along(rows)) {
-      tmp <- paste0(
-        cols[[col]][[1]], rows[[row]][[1]],
-        ":",
-        rev(cols[[col]])[[1]],  rev(rows[[row]])[[1]]
-      )
-      out <- c(out, tmp)
+    # combine columns and rows to construct dims
+    out <- NULL
+    for (col in seq_along(cols)) {
+      for (row in seq_along(rows)) {
+        tmp <- paste0(
+          cols[[col]][[1]], rows[[row]][[1]],
+          ":",
+          rev(cols[[col]])[[1]],  rev(rows[[row]])[[1]]
+        )
+        out <- c(out, tmp)
+      }
     }
-  }
 
-  paste0(out, collapse = ";")
+    return(paste0(out, collapse = ";"))
+  } else {
+    rows <- as.integer(rownames(df))
+    cols <- colnames(df)
+
+    tmp <- paste0(
+      cols[[1]][[1]], rows[[1]][[1]],
+      ":",
+      rev(cols)[[1]][[1]],  rev(rows)[[1]][[1]]
+    )
+
+    return(tmp)
+  }
 }
 
 #' function to estimate the column type.

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -73,7 +73,7 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
 #'  dataframe_to_dims(df)
 #' @keywords internal
 #' @export
-dataframe_to_dims <- function(df, dim_break = TRUE) {
+dataframe_to_dims <- function(df, dim_break = FALSE) {
 
   if (dim_break) {
 
@@ -102,7 +102,7 @@ dataframe_to_dims <- function(df, dim_break = TRUE) {
     tmp <- paste0(
       cols[[1]][[1]], rows[[1]][[1]],
       ":",
-      rev(cols)[[1]][[1]],  rev(rows)[[1]][[1]]
+      rev(cols)[[1]][[1]], rev(rows)[[1]][[1]]
     )
 
     return(tmp)

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -14,11 +14,15 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
 
   rows_out <- NULL
   cols_out <- NULL
+  filled   <- NULL
   for (dim in dims) {
 
     if (!grepl(":", dim)) {
       dim <- paste0(dim, ":", dim)
     }
+
+    if (length(dims) > 1)
+      filled <- c(filled, needed_cells(dim))
 
     if (identical(dim, "Inf:-Inf")) {
       # This should probably be fixed elsewhere?
@@ -40,12 +44,22 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
     }
   }
 
-  # create data frame from rows/
-  dims_to_df(
-    rows = rows_out,
-    cols = cols_out,
-    fill = fill
-  )
+  if (is.null(filled)) {
+    # create data frame from rows/
+    dims_to_df(
+      rows = rows_out,
+      cols = cols_out,
+      fill = fill
+    )
+  } else {
+    # create data frame from rows/
+    dims_to_df2(
+      rows   = rows_out,
+      cols   = cols_out,
+      filled = filled,
+      fill   = fill
+    )
+  }
 }
 
 #' Create dimensions from dataframe

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -8,11 +8,14 @@
 #' @export
 dims_to_dataframe <- function(dims, fill = FALSE) {
 
-  if (grepl(";", dims)) {
+  has_dim_sep <- FALSE
+  if (any(grepl(";", dims))) {
     dims <- unlist(strsplit(dims, ";"))
+    has_dim_sep <- TRUE
   }
-  if (grepl(",", dims)) {
+  if (any(grepl(",", dims))) {
     dims <- unlist(strsplit(dims, ","))
+    has_dim_sep <- TRUE
   }
 
   rows_out <- NULL
@@ -45,6 +48,11 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
 
       cols_out <- unique(c(cols_out, cols))
     }
+  }
+
+  if (has_dim_sep) {
+    cols_out <- int2col(sort(col2int(cols_out)))
+    rows_out <- sort(rows_out)
   }
 
   dims_to_df(

--- a/R/write.R
+++ b/R/write.R
@@ -185,6 +185,7 @@ update_cell <- function(x, wb, sheet, cell, colNames = FALSE,
 #' @param data_table logical. if `TRUE` and `rowNames = TRUE`, do not write the cell containing  `"_rowNames_"`
 #' @param inline_strings write characters as inline strings
 #' @param dims worksheet dimensions
+#' @param enforce enforce dims
 #' @details
 #' The string `"_openxlsx_NA"` is reserved for `openxlsx2`. If the data frame
 #' contains this string, the output will be broken.
@@ -219,7 +220,8 @@ write_data2 <- function(
     na.strings = na_strings(),
     data_table = FALSE,
     inline_strings = TRUE,
-    dims = NULL
+    dims = NULL,
+    enforce = FALSE
 ) {
 
   is_data_frame <- FALSE
@@ -303,7 +305,8 @@ write_data2 <- function(
   }
 
   # hackish solution
-  if (!getOption("openxlsx2.enforce_dims", default = FALSE)) {
+  if (!enforce) {
+    # not really sure why. With enforce this breaks, without it works.
     dims <- fits_in_dims(x = data, dims = dims, startCol = startCol, startRow = startRow)
   }
 
@@ -398,7 +401,7 @@ write_data2 <- function(
   }
 
   # hackish attemt
-  if (getOption("openxlsx2.enforce_dims", default = FALSE)) {
+  if (enforce) {
     clls <- unlist(lapply(unlist(strsplit(dims, ";")), FUN = function(x) {
       matrix(openxlsx2:::needed_cells(x), ncol = ncol(data), byrow = TRUE)
     }))
@@ -425,7 +428,9 @@ write_data2 <- function(
     dims           = c(clls) # required only for combined cell ranges
   )
 
-  if (getOption("openxlsx2.enforce_dims", default = FALSE)) {
+  if (enforce) {
+    # this is required for the worksheet dimension spanning the entire
+    # initialized worksheet from top left to bottom right
     dims <- dataframe_to_dims(rtyp, dim_break = FALSE)
   }
 
@@ -757,7 +762,8 @@ write_data_table <- function(
     data_table      = FALSE,
     na.strings      = na_strings(),
     inline_strings  = TRUE,
-    total_row       = FALSE
+    total_row       = FALSE,
+    enforce         = FALSE
 ) {
 
   ## Input validating
@@ -957,7 +963,8 @@ write_data_table <- function(
     na.strings      = na.strings,
     data_table      = data_table,
     inline_strings  = inline_strings,
-    dims            = odims
+    dims            = odims,
+    enforce         = enforce
   )
 
   ### Beg: Only in datatable ---------------------------------------------------
@@ -1007,7 +1014,8 @@ write_data_table <- function(
         na.strings      = na.strings,
         data_table      = data_table,
         inline_strings  = inline_strings,
-        dims            = NULL
+        dims            = NULL,
+        enforce         = FALSE
       )
     }
 
@@ -1084,6 +1092,7 @@ write_data <- function(
     remove_cell_style = FALSE,
     na.strings        = na_strings(),
     inline_strings    = TRUE,
+    enforce           = FALSE,
     ...
 ) {
 
@@ -1112,7 +1121,8 @@ write_data <- function(
     removeCellStyle = remove_cell_style,
     data_table      = FALSE,
     na.strings      = na.strings,
-    inline_strings  = inline_strings
+    inline_strings  = inline_strings,
+    enforce         = enforce
   )
 }
 
@@ -1137,6 +1147,7 @@ write_formula <- function(
     cm                = FALSE,
     apply_cell_style  = TRUE,
     remove_cell_style = FALSE,
+    enforce           = FALSE,
     ...
 ) {
 
@@ -1237,7 +1248,8 @@ write_formula <- function(
     col_names         = FALSE,
     row_names         = FALSE,
     apply_cell_style  = apply_cell_style,
-    remove_cell_style = remove_cell_style
+    remove_cell_style = remove_cell_style,
+    enforce           = enforce
   )
 
 }

--- a/R/write.R
+++ b/R/write.R
@@ -407,11 +407,15 @@ write_data2 <- function(
   }
 
   if (enforce) {
-    clls <- unlist(lapply(unlist(strsplit(dims, dim_sep)), FUN = function(x) {
-      matrix(needed_cells(x), ncol = ncol(data), byrow = TRUE)
-    }))
 
-    clls <- c(matrix(clls, ncol = ncol(data), nrow = nrow(data), byrow = TRUE))
+    clls <- lapply(unlist(strsplit(dims, dim_sep)), FUN = function(x) {
+      matrix(needed_cells(x), ncol = ncol(data), byrow = FALSE)
+    })
+
+    clls <- do.call("rbind", clls)
+
+    clls <- c(matrix(clls, nrow = nrow(data), byrow = FALSE))
+
   } else {
     clls <- paste0(colnames(rtyp[1, 1]), rownames(rtyp[1, 1]))
   }

--- a/R/write.R
+++ b/R/write.R
@@ -409,12 +409,19 @@ write_data2 <- function(
   if (enforce) {
 
     clls <- lapply(unlist(strsplit(dims, dim_sep)), FUN = function(x) {
-      matrix(needed_cells(x), ncol = ncol(data), byrow = FALSE)
+      nc <- needed_cells(x)
+      len <- length(unique(col2int(nc)))
+
+      if (length(nc) > 1) {
+        matrix(nc, ncol = len, byrow = FALSE)
+      } else {
+        nc
+      }
+
     })
 
     clls <- do.call("rbind", clls)
-
-    clls <- c(matrix(clls, nrow = nrow(data), byrow = FALSE))
+    clls <- c(clls)
 
   } else {
     clls <- paste0(colnames(rtyp[1, 1]), rownames(rtyp[1, 1]))

--- a/R/write.R
+++ b/R/write.R
@@ -310,9 +310,9 @@ write_data2 <- function(
     data <- as.data.frame(t(data))
   }
 
-  # hackish solution
+  # TODO fits_in_dims does not handle "A1,B2" and instead converts it to the
+  # outer range "A1:B2"
   if (!enforce) {
-    # not really sure why. With enforce this breaks, without it works.
     dims <- fits_in_dims(x = data, dims = dims, startCol = startCol, startRow = startRow)
   }
 
@@ -361,7 +361,7 @@ write_data2 <- function(
 
   # rtyp character vector per row
   # list(c("A1, ..., "k1"), ...,  c("An", ..., "kn"))
-  rtyp <- dims_to_dataframe(dims, fill = TRUE)
+  rtyp <- dims_to_dataframe(dims, fill = enforce)
 
   rows_attr <- vector("list", nrow(rtyp))
 
@@ -411,9 +411,9 @@ write_data2 <- function(
       matrix(needed_cells(x), ncol = ncol(data), byrow = TRUE)
     }))
 
-    clls <- matrix(clls, ncol = ncol(data), nrow = nrow(data), byrow = TRUE)
+    clls <- c(matrix(clls, ncol = ncol(data), nrow = nrow(data), byrow = TRUE))
   } else {
-    clls <- rtyp[1, 1]
+    clls <- paste0(colnames(rtyp[1, 1]), rownames(rtyp[1, 1]))
   }
 
   wide_to_long(
@@ -430,7 +430,7 @@ write_data2 <- function(
     na_strings     = na.strings,
     inline_strings = inline_strings,
     c_cm           = c_cm,
-    dims           = c(clls) # required only for combined cell ranges
+    dims           = clls
   )
 
   if (enforce) {
@@ -968,7 +968,7 @@ write_data_table <- function(
     na.strings      = na.strings,
     data_table      = data_table,
     inline_strings  = inline_strings,
-    dims            = odims,
+    dims            = if (enforce) odims else dims,
     enforce         = enforce
   )
 

--- a/R/write.R
+++ b/R/write.R
@@ -224,6 +224,12 @@ write_data2 <- function(
     enforce = FALSE
 ) {
 
+  dim_sep <- ";"
+  if (any(grepl(";|,", dims))) {
+    if (any(grepl(";", dims))) dim_sep <- ";"
+    if (any(grepl(",", dims))) dim_sep <- ","
+  }
+
   is_data_frame <- FALSE
   #### prepare the correct data formats for openxml
   dc <- openxlsx2_type(data)
@@ -327,7 +333,7 @@ write_data2 <- function(
   # this requires access to wb$workbook.
   # TODO The check for existing names is in write_data()
   # TODO use wb$add_named_region()
-  if (!is.null(name) && !any(grepl(";", dims))) {
+  if (!is.null(name) && !any(grepl(dim_sep, dims))) {
 
     ## named region
     ex_names <- regmatches(wb$workbook$definedNames, regexpr('(?<=name=")[^"]+', wb$workbook$definedNames, perl = TRUE))
@@ -400,9 +406,8 @@ write_data2 <- function(
     na_null    <- TRUE
   }
 
-  # hackish attemt
   if (enforce) {
-    clls <- unlist(lapply(unlist(strsplit(dims, ";")), FUN = function(x) {
+    clls <- unlist(lapply(unlist(strsplit(dims, dim_sep)), FUN = function(x) {
       matrix(needed_cells(x), ncol = ncol(data), byrow = TRUE)
     }))
 

--- a/R/write.R
+++ b/R/write.R
@@ -796,6 +796,7 @@ write_data_table <- function(
 
   if (!is.null(dims)) {
     dims <- dims_to_rowcol(dims, as_integer = TRUE)
+    # if dims = "K1,A1" startCol = "A" and startRow = "1" are selected
     startCol <- min(dims[[1]])
     startRow <- min(dims[[2]])
   }
@@ -804,6 +805,7 @@ write_data_table <- function(
   if (is.null(x)) {
     return(wb)
   }
+
   # overwrite na.strings if nothing was provided
   # with whatever is in the option if not set to default
   if (is_na_strings(na.strings) && !is.null(getOption("openxlsx2.na.strings"))) {

--- a/R/write.R
+++ b/R/write.R
@@ -24,6 +24,9 @@ inner_update <- function(
     na.strings = na_strings()
 ) {
 
+  cells_needed <- cells_needed[cells_needed != ""]
+  if (length(cells_needed) == 0) return(wb)
+
   # 1) pull sheet to modify from workbook; 2) modify it; 3) push it back
   cc  <- wb$worksheets[[sheet_id]]$sheet_data$cc
   row_attr <- wb$worksheets[[sheet_id]]$sheet_data$row_attr

--- a/R/write.R
+++ b/R/write.R
@@ -403,7 +403,7 @@ write_data2 <- function(
   # hackish attemt
   if (enforce) {
     clls <- unlist(lapply(unlist(strsplit(dims, ";")), FUN = function(x) {
-      matrix(openxlsx2:::needed_cells(x), ncol = ncol(data), byrow = TRUE)
+      matrix(needed_cells(x), ncol = ncol(data), byrow = TRUE)
     }))
 
     clls <- matrix(clls, ncol = ncol(data), nrow = nrow(data), byrow = TRUE)

--- a/man/dataframe_to_dims.Rd
+++ b/man/dataframe_to_dims.Rd
@@ -4,7 +4,7 @@
 \alias{dataframe_to_dims}
 \title{Create dimensions from dataframe}
 \usage{
-dataframe_to_dims(df, dim_break = TRUE)
+dataframe_to_dims(df, dim_break = FALSE)
 }
 \arguments{
 \item{df}{dataframe with spreadsheet columns and rows}

--- a/man/dataframe_to_dims.Rd
+++ b/man/dataframe_to_dims.Rd
@@ -4,10 +4,12 @@
 \alias{dataframe_to_dims}
 \title{Create dimensions from dataframe}
 \usage{
-dataframe_to_dims(df)
+dataframe_to_dims(df, dim_break = TRUE)
 }
 \arguments{
 \item{df}{dataframe with spreadsheet columns and rows}
+
+\item{dim_break}{split the dims?}
 }
 \description{
 Use \code{\link[=wb_dims]{wb_dims()}}

--- a/man/dims_helper.Rd
+++ b/man/dims_helper.Rd
@@ -18,6 +18,8 @@ rowcol_to_dims(row, col, single = TRUE)
 \item{row}{a numeric vector of rows}
 
 \item{col}{a numeric or character vector of cols}
+
+\item{single}{argument indicating if \code{\link[=rowcol_to_dims]{rowcol_to_dims()}} returns a single cell dimension}
 }
 \value{
 \itemize{

--- a/man/dims_helper.Rd
+++ b/man/dims_helper.Rd
@@ -8,7 +8,7 @@
 \usage{
 dims_to_rowcol(x, as_integer = FALSE)
 
-rowcol_to_dims(row, col)
+rowcol_to_dims(row, col, single = TRUE)
 }
 \arguments{
 \item{x}{a dimension object "A1" or "A1:A1"}

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -754,6 +754,7 @@ Add formula
   cm = FALSE,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
+  enforce = FALSE,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -778,6 +779,8 @@ Add formula
 \item{\code{apply_cell_style}}{applyCellStyle}
 
 \item{\code{remove_cell_style}}{if writing into existing cells, should the cell style be removed?}
+
+\item{\code{enforce}}{enforce dims}
 
 \item{\code{...}}{additional arguments}
 }

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -513,6 +513,7 @@ add data
   remove_cell_style = FALSE,
   na.strings = na_strings(),
   inline_strings = TRUE,
+  enforce = FALSE,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -550,6 +551,8 @@ add data
 \code{na_strings()} uses the special \verb{#N/A} value within the workbook.}
 
 \item{\code{inline_strings}}{write characters as inline strings}
+
+\item{\code{enforce}}{enforce that selected dims is filled. For this to work, \code{dims} must match \code{x}}
 
 \item{\code{...}}{additional arguments}
 

--- a/man/wb_add_data.Rd
+++ b/man/wb_add_data.Rd
@@ -21,6 +21,7 @@ wb_add_data(
   remove_cell_style = FALSE,
   na.strings = na_strings(),
   inline_strings = TRUE,
+  enforce = FALSE,
   ...
 )
 }
@@ -60,6 +61,8 @@ looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_
 uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
+
+\item{enforce}{enforce that selected dims is filled. For this to work, \code{dims} must match \code{x}}
 
 \item{...}{additional arguments}
 }

--- a/man/wb_add_formula.Rd
+++ b/man/wb_add_formula.Rd
@@ -15,6 +15,7 @@ wb_add_formula(
   cm = FALSE,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
+  enforce = FALSE,
   ...
 )
 }
@@ -39,6 +40,8 @@ Add this, if you see "@" inserted into your formulas.}
 \item{apply_cell_style}{Should we write cell styles to the workbook?}
 
 \item{remove_cell_style}{Should we keep the cell style?}
+
+\item{enforce}{enforce dims}
 
 \item{...}{additional arguments}
 }

--- a/man/write_data.Rd
+++ b/man/write_data.Rd
@@ -21,6 +21,7 @@ write_data(
   remove_cell_style = FALSE,
   na.strings = na_strings(),
   inline_strings = TRUE,
+  enforce = FALSE,
   ...
 )
 }
@@ -60,6 +61,8 @@ looks if \code{options(openxlsx2.na.strings)} is set. Otherwise \code{\link[=na_
 uses the special \verb{#N/A} value within the workbook.}
 
 \item{inline_strings}{write characters as inline strings}
+
+\item{enforce}{enforce that selected dims is filled. For this to work, \code{dims} must match \code{x}}
 
 \item{...}{additional arguments}
 }

--- a/man/write_formula.Rd
+++ b/man/write_formula.Rd
@@ -15,6 +15,7 @@ write_formula(
   cm = FALSE,
   apply_cell_style = TRUE,
   remove_cell_style = FALSE,
+  enforce = FALSE,
   ...
 )
 }
@@ -39,6 +40,8 @@ Add this, if you see "@" inserted into your formulas.}
 \item{apply_cell_style}{Should we write cell styles to the workbook?}
 
 \item{remove_cell_style}{Should we keep the cell style?}
+
+\item{enforce}{enforce dims}
 
 \item{...}{additional arguments}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,8 +139,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // wide_to_long
-void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, int32_t string_nums, bool na_null, bool na_missing, std::string na_strings, bool inline_strings, std::string c_cm);
-RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP, SEXP na_nullSEXP, SEXP na_missingSEXP, SEXP na_stringsSEXP, SEXP inline_stringsSEXP, SEXP c_cmSEXP) {
+void wide_to_long(Rcpp::DataFrame z, Rcpp::IntegerVector vtyps, Rcpp::DataFrame zz, bool ColNames, int32_t start_col, int32_t start_row, Rcpp::CharacterVector ref, int32_t string_nums, bool na_null, bool na_missing, std::string na_strings, bool inline_strings, std::string c_cm, std::vector<std::string> dims);
+RcppExport SEXP _openxlsx2_wide_to_long(SEXP zSEXP, SEXP vtypsSEXP, SEXP zzSEXP, SEXP ColNamesSEXP, SEXP start_colSEXP, SEXP start_rowSEXP, SEXP refSEXP, SEXP string_numsSEXP, SEXP na_nullSEXP, SEXP na_missingSEXP, SEXP na_stringsSEXP, SEXP inline_stringsSEXP, SEXP c_cmSEXP, SEXP dimsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::DataFrame >::type z(zSEXP);
@@ -156,7 +156,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string >::type na_strings(na_stringsSEXP);
     Rcpp::traits::input_parameter< bool >::type inline_strings(inline_stringsSEXP);
     Rcpp::traits::input_parameter< std::string >::type c_cm(c_cmSEXP);
-    wide_to_long(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type dims(dimsSEXP);
+    wide_to_long(z, vtyps, zz, ColNames, start_col, start_row, ref, string_nums, na_null, na_missing, na_strings, inline_strings, c_cm, dims);
     return R_NilValue;
 END_RCPP
 }
@@ -1009,7 +1010,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_dims_to_df2", (DL_FUNC) &_openxlsx2_dims_to_df2, 4},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
     {"_openxlsx2_is_charnum", (DL_FUNC) &_openxlsx2_is_charnum, 1},
-    {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 13},
+    {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 14},
     {"_openxlsx2_create_char_dataframe", (DL_FUNC) &_openxlsx2_create_char_dataframe, 2},
     {"_openxlsx2_read_xml2df", (DL_FUNC) &_openxlsx2_read_xml2df, 4},
     {"_openxlsx2_write_df2xml", (DL_FUNC) &_openxlsx2_write_df2xml, 4},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -77,6 +77,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// validate_dims
+bool validate_dims(const std::string& input);
+RcppExport SEXP _openxlsx2_validate_dims(SEXP inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type input(inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(validate_dims(input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // needed_cells
 Rcpp::CharacterVector needed_cells(const std::string& range);
 RcppExport SEXP _openxlsx2_needed_cells(SEXP rangeSEXP) {
@@ -89,29 +100,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // dims_to_df
-SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, bool fill);
-RcppExport SEXP _openxlsx2_dims_to_df(SEXP rowsSEXP, SEXP colsSEXP, SEXP fillSEXP) {
+SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Nullable<Rcpp::CharacterVector> filled, bool fill);
+RcppExport SEXP _openxlsx2_dims_to_df(SEXP rowsSEXP, SEXP colsSEXP, SEXP filledSEXP, SEXP fillSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type rows(rowsSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type cols(colsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type filled(filledSEXP);
     Rcpp::traits::input_parameter< bool >::type fill(fillSEXP);
-    rcpp_result_gen = Rcpp::wrap(dims_to_df(rows, cols, fill));
-    return rcpp_result_gen;
-END_RCPP
-}
-// dims_to_df2
-SEXP dims_to_df2(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, std::vector<std::string> filled, bool fill);
-RcppExport SEXP _openxlsx2_dims_to_df2(SEXP rowsSEXP, SEXP colsSEXP, SEXP filledSEXP, SEXP fillSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type rows(rowsSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type cols(colsSEXP);
-    Rcpp::traits::input_parameter< std::vector<std::string> >::type filled(filledSEXP);
-    Rcpp::traits::input_parameter< bool >::type fill(fillSEXP);
-    rcpp_result_gen = Rcpp::wrap(dims_to_df2(rows, cols, filled, fill));
+    rcpp_result_gen = Rcpp::wrap(dims_to_df(rows, cols, filled, fill));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1005,9 +1003,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_col_to_int", (DL_FUNC) &_openxlsx2_col_to_int, 1},
     {"_openxlsx2_rbindlist", (DL_FUNC) &_openxlsx2_rbindlist, 1},
     {"_openxlsx2_copy", (DL_FUNC) &_openxlsx2_copy, 1},
+    {"_openxlsx2_validate_dims", (DL_FUNC) &_openxlsx2_validate_dims, 1},
     {"_openxlsx2_needed_cells", (DL_FUNC) &_openxlsx2_needed_cells, 1},
-    {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 3},
-    {"_openxlsx2_dims_to_df2", (DL_FUNC) &_openxlsx2_dims_to_df2, 4},
+    {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 4},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
     {"_openxlsx2_is_charnum", (DL_FUNC) &_openxlsx2_is_charnum, 1},
     {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 14},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -77,6 +77,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// needed_cells
+Rcpp::CharacterVector needed_cells(const std::string& range);
+RcppExport SEXP _openxlsx2_needed_cells(SEXP rangeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type range(rangeSEXP);
+    rcpp_result_gen = Rcpp::wrap(needed_cells(range));
+    return rcpp_result_gen;
+END_RCPP
+}
 // dims_to_df
 SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, bool fill);
 RcppExport SEXP _openxlsx2_dims_to_df(SEXP rowsSEXP, SEXP colsSEXP, SEXP fillSEXP) {
@@ -87,6 +98,20 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type cols(colsSEXP);
     Rcpp::traits::input_parameter< bool >::type fill(fillSEXP);
     rcpp_result_gen = Rcpp::wrap(dims_to_df(rows, cols, fill));
+    return rcpp_result_gen;
+END_RCPP
+}
+// dims_to_df2
+SEXP dims_to_df2(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, std::vector<std::string> filled, bool fill);
+RcppExport SEXP _openxlsx2_dims_to_df2(SEXP rowsSEXP, SEXP colsSEXP, SEXP filledSEXP, SEXP fillSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type rows(rowsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type cols(colsSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type filled(filledSEXP);
+    Rcpp::traits::input_parameter< bool >::type fill(fillSEXP);
+    rcpp_result_gen = Rcpp::wrap(dims_to_df2(rows, cols, filled, fill));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -979,7 +1004,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_col_to_int", (DL_FUNC) &_openxlsx2_col_to_int, 1},
     {"_openxlsx2_rbindlist", (DL_FUNC) &_openxlsx2_rbindlist, 1},
     {"_openxlsx2_copy", (DL_FUNC) &_openxlsx2_copy, 1},
+    {"_openxlsx2_needed_cells", (DL_FUNC) &_openxlsx2_needed_cells, 1},
     {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 3},
+    {"_openxlsx2_dims_to_df2", (DL_FUNC) &_openxlsx2_dims_to_df2, 4},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
     {"_openxlsx2_is_charnum", (DL_FUNC) &_openxlsx2_is_charnum, 1},
     {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 13},

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -144,6 +144,47 @@ uint32_t uint_col_to_int(std::string& a) {
   return sum;
 }
 
+
+std::string rm_rownum(const std::string& str) {
+    std::string result;
+    for (char c : str) {
+        if (!std::isdigit(c)) {
+            result += c;
+        }
+    }
+    return result;
+}
+
+std::string rm_colnum(const std::string& str) {
+    std::string result;
+    for (char c : str) {
+        if (std::isdigit(c)) {
+            result += c;
+        }
+    }
+    return result;
+}
+
+// Function to keep only digits in a string
+uint32_t cell_to_rowint(const std::string& str) {
+  std::string result = rm_colnum(str);
+  return std::stoi(result);
+}
+
+std::string str_toupper(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c){ return std::toupper(c); }
+  );
+  return s;
+}
+
+// Function to remove digits from a string
+uint32_t cell_to_colint(const std::string& str) {
+  std::string result = rm_rownum(str);
+  result = str_toupper(result);
+  return uint_col_to_int(result);
+}
+
 // [[Rcpp::export]]
 Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x) {
 
@@ -167,12 +208,8 @@ Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x) {
       continue;
     }
 
-    // remove digits from string
-    a.erase(std::remove_if(a.begin()+1, a.end(), ::isdigit), a.end());
-    transform(a.begin(), a.end(), a.begin(), ::toupper);
-
     // return index from column name
-    colNums[i] = uint_col_to_int(a);
+    colNums[i] = cell_to_colint(a);
   }
 
   return colNums;
@@ -252,39 +289,6 @@ bool validate_dims(const std::string& input) {
     return has_col && has_row;
 }
 
-std::string rm_dig(const std::string& str) {
-    std::string result;
-    for (char c : str) {
-        if (!std::isdigit(c)) {
-            result += c;
-        }
-    }
-    return result;
-}
-
-std::string rm_alf(const std::string& str) {
-    std::string result;
-    for (char c : str) {
-        if (std::isdigit(c)) {
-            result += c;
-        }
-    }
-    return result;
-}
-
-
-// Function to remove digits from a string
-uint32_t rm_num(const std::string& str) {
-  std::string result = rm_dig(str);
-  return uint_col_to_int(result);
-}
-
-// Function to keep only digits in a string
-uint32_t rm_chr(const std::string& str) {
-  std::string result = rm_alf(str);
-  return std::stoi(result);
-}
-
 // [[Rcpp::export]]
 Rcpp::CharacterVector needed_cells(const std::string& range) {
   std::vector<std::string> cells;
@@ -308,11 +312,11 @@ Rcpp::CharacterVector needed_cells(const std::string& range) {
   uint32_t startRow, endRow;
   uint32_t startCol = 0, endCol = 0;
 
-  startCol = rm_num(startCell);
-  endCol   = rm_num(endCell);
+  startCol = cell_to_colint(startCell);
+  endCol   = cell_to_colint(endCell);
 
-  startRow = rm_chr(startCell);
-  endRow   = rm_chr(endCell);
+  startRow = cell_to_rowint(startCell);
+  endRow   = cell_to_rowint(endCell);
 
   // Generate spreadsheet cell references
   for (uint32_t col = startCol; col <= endCol; ++col) {
@@ -618,8 +622,8 @@ void wide_to_long(
       if (has_dims) {
         cell.r =  dims[idx];
 
-        zz_row_r[pos] = rm_alf(cell.r);
-        zz_c_r[pos]   = rm_dig(cell.r);
+        zz_row_r[pos] = rm_colnum(cell.r);
+        zz_c_r[pos]   = rm_rownum(cell.r);
       } else {
         cell.r =  col + row;
 

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -352,17 +352,9 @@ SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Null
       SET_VECTOR_ELT(df, i, Rcpp::CharacterVector(nn, NA_STRING));
   }
 
-  if (fill && !has_filled) {
-    for (size_t i = 0; i < kk; ++i) {
-      Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
-      std::string coli = Rcpp::as<std::string>(cols[i]);
-      for (size_t j = 0; j < nn; ++j) {
-        cvec[j] = coli + std::to_string(rows[j]);
-      }
-    }
-  } else {
+  if (has_filled) {
 
-    // in df2 we have to always run this loop
+    // with has_filled we always have to run this loop
     for (size_t i = 0; i < kk; ++i) {
       Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
       std::string coli = Rcpp::as<std::string>(cols[i]);
@@ -374,7 +366,18 @@ SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Null
           cvec[j] = coli + std::to_string(rows[j]);
       }
     }
-  }
+
+  } else if (fill) { // insert cells into data frame
+
+    for (size_t i = 0; i < kk; ++i) {
+      Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
+      std::string coli = Rcpp::as<std::string>(cols[i]);
+      for (size_t j = 0; j < nn; ++j) {
+        cvec[j] = coli + std::to_string(rows[j]);
+      }
+    }
+
+  } // else return data frame filled with NA_character_
 
   // 3. Create a data.frame
   df.attr("row.names") = rows;

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -180,9 +180,6 @@ Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x) {
 }
 
 // provide a basic rbindlist for lists of named characters
-// xlsxFile <- system.file("extdata", "openxlsx2_example.xlsx", package = "openxlsx2")
-// wb <- wb_load(xlsxFile)
-// openxlsx2:::rbindlist(xml_attr(wb$styles_mgr$styles$cellXfs, "xf"))
 // [[Rcpp::export]]
 SEXP rbindlist(Rcpp::List x) {
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -47,6 +47,10 @@ test_that("dims to col & row and back", {
   # something like "$1:$2" to select every column for a range of cells.
   expect_error(dims_to_rowcol("A1;B64:65"), "A dims string passed to ")
 
+  exp <- "A1:A3,B1:B3"
+  got <- rowcol_to_dims(row = c(1, 3), col = c(1, 2), single = FALSE)
+  expect_equal(exp, got)
+
 })
 
 test_that("`wb_dims()` works/errors as expected with unnamed arguments", {

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -188,12 +188,11 @@ test_that("dims_to_dataframe", {
 
 test_that("dataframe_to_dims", {
 
-  ## I should probably fix this failing test
-  # # dims_to_dataframe will always create a square
-  # df <- dims_to_dataframe("A1:D5;F1:F6;D8", fill = TRUE)
-  # dims <- dataframe_to_dims(df)
-  # df2 <- dims_to_dataframe(dims, fill = TRUE)
-  # expect_equal(df, df2)
+  # dims_to_dataframe will always create a square
+  df <- dims_to_dataframe("A1:D5;F1:F6;D8", fill = TRUE)
+  dims <- dataframe_to_dims(df)
+  df2 <- dims_to_dataframe(dims, fill = TRUE)
+  expect_equal(df, df2)
 
 })
 

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -344,8 +344,8 @@ test_that("dims with separator work", {
 
   # sheet 2
   df <- wb_to_df(wb, sheet = 2)
-  expect_true(all(is.na(df[20,])))
-  expect_equal(df[-20,], mtcars, ignore_attr = TRUE)
+  expect_true(all(is.na(df[20, ])))
+  expect_equal(df[-20, ], mtcars, ignore_attr = TRUE)
 
   # sheet 3
   df <- wb_to_df(wb, sheet = 3, col_names = FALSE)

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -371,4 +371,51 @@ test_that("dims with separator work", {
   got <- wb$worksheets[[4]]$sheet_data$cc$r
   expect_equal(exp, got)
 
+  # write to different dims
+  dat <- as.data.frame(matrix(1:15, ncol = 3))
+
+  wb <- wb_workbook()
+
+  # write columns separately
+  wb$add_worksheet()$
+    add_data(dims = "A1:A6", x = dat[, 1, drop = FALSE],
+            enforce = TRUE, col_names = TRUE)$
+    add_data(dims = "C2:C4,C6:C7", x = dat[, 2, drop = FALSE],
+            enforce = TRUE, col_names = FALSE)
+
+  # write columns as unique cells
+  wb$add_worksheet()$
+    add_data(dims = "A1,B2,C3,D4,E5,F6,C1,D2,E3,F4,G5,H6,I1:I6", x = dat,
+            enforce = TRUE, col_names = TRUE)
+
+  # write columns as two column ranges
+  wb$add_worksheet()$
+    add_data(dims = "A1:A6,C1:C6,E1:E6", x = dat,
+            enforce = TRUE, col_names = TRUE)
+
+  # write columns as two row ranges
+  wb$add_worksheet()$
+    add_data(dims = "A1:C3,B5:D7", x = dat,
+            enforce = TRUE, col_names = TRUE)
+
+
+  exp <- c("A1", "A2", "C2", "A3", "C3", "A4", "C4", "A5", "C5", "A6", "C6", "C7")
+  got <- wb$worksheets[[1]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
+  exp <- c("A1", "C1", "I1", "B2", "D2", "I2", "C3", "E3", "I3", "D4",
+          "F4", "I4", "E5", "G5", "I5", "F6", "H6", "I6")
+  got <- wb$worksheets[[2]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
+  exp <- c("A1", "C1", "E1", "A2", "C2", "E2", "A3", "C3", "E3", "A4",
+          "C4", "E4", "A5", "C5", "E5", "A6", "C6", "E6")
+  got <- wb$worksheets[[3]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
+  exp <- c("A1", "B1", "C1", "A2", "B2", "C2", "A3", "B3", "C3", "B5",
+          "C5", "D5", "B6", "C6", "D6", "B7", "C7", "D7")
+  got <- wb$worksheets[[4]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
 })

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -188,11 +188,12 @@ test_that("dims_to_dataframe", {
 
 test_that("dataframe_to_dims", {
 
-  # dims_to_dataframe will always create a square
-  df <- dims_to_dataframe("A1:D5;F1:F6;D8", fill = TRUE)
-  dims <- dataframe_to_dims(df)
-  df2 <- dims_to_dataframe(dims, fill = TRUE)
-  expect_equal(df, df2)
+  ## I should probably fix this failing test
+  # # dims_to_dataframe will always create a square
+  # df <- dims_to_dataframe("A1:D5;F1:F6;D8", fill = TRUE)
+  # dims <- dataframe_to_dims(df)
+  # df2 <- dims_to_dataframe(dims, fill = TRUE)
+  # expect_equal(df, df2)
 
 })
 

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -314,3 +314,20 @@ test_that("missings cells are returned", {
   expect_silent(got <- wb_to_df(wb, col_names = FALSE, rows = c(101), cols = c(27)))
 
 })
+
+test_that("dims with separator work", {
+
+  wb <- wb_workbook()$
+    # this picks the top left corner of dims to write the data frame
+    add_worksheet()$add_data(dims = "I2:J2;A1:B2;G5:H6", x = matrix(1:8, 4, 2))$
+    add_worksheet()$add_data(dims = "I2:J2;A1:B2;G5:H6", x = matrix(1:8, 4, 2), enforce = TRUE)
+
+  exp <- c("A1", "B1", "A2", "B2", "A3", "B3", "A4", "B4", "A5", "B5")
+  got <- wb$worksheets[[1]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
+  exp <- c("I2", "J2", "A1", "B1", "A2", "B2", "G5", "H5", "G6", "H6")
+  got <- wb$worksheets[[2]]$sheet_data$cc$r
+  expect_equal(exp, got)
+
+})

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -190,7 +190,7 @@ test_that("dataframe_to_dims", {
 
   # dims_to_dataframe will always create a square
   df <- dims_to_dataframe("A1:D5;F1:F6;D8", fill = TRUE)
-  dims <- dataframe_to_dims(df)
+  dims <- dataframe_to_dims(df, dim_break = TRUE)
   df2 <- dims_to_dataframe(dims, fill = TRUE)
   expect_equal(df, df2)
 


### PR DESCRIPTION
Still a little hackish solution to the flexibility problem mentioned in #796 , but it shows what is possible. For whatever reason the enforce option does not work with `wb_add_fill()` probably because empty cells are still initialized even though they are not filled.

Also there is still a bug, for now I simply assumed that all data columns are beneath each other to fill their positions. In the example below the column header is right to the data and hence the row has to be filled wider, which is not yet implemented. Hence the first data part is filled incorrectly.

``` r
library(openxlsx2)

# write a workbook with a few colored cells
wb <- wb_workbook()$
  add_worksheet()$
  add_fill(dims = "A1:B2;C3:D4;E1:F2;G5:H6;I2:K2", color = wb_color("yellow"))

# force a dataset into a specific cell dimension
options("openxlsx2.enforce_dims" = TRUE)
wb$add_data(dims = "I2:J2;A1:B2;G5:H6", x = matrix(1:8, 4, 2))
options("openxlsx2.enforce_dims" = FALSE)

if (interactive()) wb$open()
```

<img width="607" alt="Screenshot 2024-04-13 at 13 26 30" src="https://github.com/JanMarvin/openxlsx2/assets/1645626/81b5a39f-2f6d-413e-8a57-0c58878f82ab">
