### PR TITLE
Create setup.R

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1016,6 +1016,12 @@ testfile_path <- function(x, replace = FALSE) {
     try({
       download.file(url, destfile = out, quiet = TRUE, mode = "wb")
     })
+
+    i <- 1
+    while (!file.exists(out)) {
+      i <- i + 1
+      if (i > 1000) return(testthat::skip("Skip slow download"))
+    }
   }
 
   if (!file.exists(fl)) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,1 @@
+testsetup()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,1 +1,0 @@
-testsetup()


### PR DESCRIPTION
Addresses https://github.com/JanMarvin/openxlsx2/pull/991#issuecomment-2059190184.

Possible cause: addition of 
https://github.com/JanMarvin/openxlsx2/blob/eebb43c8e514cb14ef561ce9ea813f3ee0ef5487/DESCRIPTION#L46

which may have prevented `testsetup()` from being triggered in time?

Will possibly enable to delete other instances of `testsetup()`?

If this is a reasonable approach, I will use this PR to delete other instances of  `testsetup()`.

According to https://testthat.r-lib.org/articles/special-files.html#setup-files

Setup files live in tests/testthat/, start with setup, and end with .r or .R. Typically there is only one setup file which, by convention, is tests/testthat/setup.R. Setup files are sourced by [test_check()](https://testthat.r-lib.org/reference/test_package.html) and friends (so that they’re available no matter how your tests are executed), but they are not sourced by devtools::load_all().

Setup files are good place to put truly global test setup that would be impractical to build into every single test and that might be tailored for test execution in non-interactive or remote environments. Examples:

* Turning off behaviour aimed at an interactive user, such as messaging or writing to the clipboard.
* Setting up a cache folder.