### PR TITLE
use `Rf_isBlankString()`

### DIFF
--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -307,7 +307,7 @@ bool is_double(std::string x) {
 
   res = R_strtod(x.c_str(), &endp);
 
-  if (isBlankString(endp) && std::isfinite(res)) {
+  if (Rf_isBlankString(endp) && std::isfinite(res)) {
     return 1;
   }
 


### PR DESCRIPTION
> Dear maintainer,
>
> Please see the problems shown on
>[<https://cran.r-project.org/web/checks/check_results_openxlsx2.html>](https://cran.r-project.org/web/checks/>check_results_openxlsx2.html).
>
>Please correct before 2024-05-04 to safely retain your package on CRAN.
>
>The CRAN Team

```R
Result: NOTE
  File ‘openxlsx2/libs/openxlsx2.so’:
    Found non-API call to R: ‘Rf_isBlankString’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
```