### PR TITLE
[dims] previously non-consecutive dims could get lost

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 * Silence a warning triggered by a folder called `"[trash]"`. [1012](https://github.com/JanMarvin/openxlsx2/pull/1012)
 
+## Fixes
+
+* Fixed an issue with non consecutive dims, where columns or rows were silently dropped. [1015](https://github.com/JanMarvin/openxlsx2/pull/1015)
+
 
 ***************************************************************************
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -9151,7 +9151,7 @@ wbWorkbook <- R6::R6Class(
         if (length(need_cells) == 1 && grepl(":|;", need_cells))
           need_cells <- dims_to_dataframe(dims, fill = TRUE)
 
-        exp_cells <- unname(unlist(need_cells))
+        exp_cells <- unname(unlist(need_cells[need_cells != ""]))
         got_cells <- self$worksheets[[sheet]]$sheet_data$cc$r
 
         # initialize cell

--- a/R/read.R
+++ b/R/read.R
@@ -249,7 +249,7 @@ wb_to_df <- function(
   xlsx_posix_style <- style_is_posix(wb$styles_mgr$styles$cellXfs, numfmt_posix)
 
   # create temporary data frame. hard copy required
-  z  <- dims_to_dataframe(dims)
+  z  <- dims_to_dataframe(dims, empty_rm = TRUE)
   tt <- copy(z)
 
   keep_cols <- colnames(z)
@@ -738,7 +738,7 @@ wb_data <- function(wb, sheet = current_sheet(), dims, ...) {
   }
 
   z <- wb_to_df(wb, sheet, dims = dims, ...)
-  attr(z, "dims")  <- dims_to_dataframe(dims, fill = TRUE)
+  attr(z, "dims")  <- dims_to_dataframe(dims, fill = TRUE, empty_rm = TRUE)
   attr(z, "sheet") <- sheetname
 
   class(z) <- c("wb_data", "data.frame")

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -2,11 +2,12 @@
 #'
 #' @param dims Character vector of expected dimension.
 #' @param fill If `TRUE`, fills the dataframe with variables
+#' @param empty_rm Logical if empty columns and rows should be included
 #' @examples
 #' dims_to_dataframe("A1:B2")
 #' @keywords internal
 #' @export
-dims_to_dataframe <- function(dims, fill = FALSE) {
+dims_to_dataframe <- function(dims, fill = FALSE, empty_rm = FALSE) {
 
   has_dim_sep <- FALSE
   if (any(grepl(";", dims))) {
@@ -51,8 +52,17 @@ dims_to_dataframe <- function(dims, fill = FALSE) {
   }
 
   if (has_dim_sep) {
-    cols_out <- int2col(sort(col2int(cols_out)))
-    rows_out <- sort(rows_out)
+    if (empty_rm) {
+      cols_out <- int2col(sort(col2int(cols_out)))
+      rows_out <- sort(rows_out)
+    } else {
+      # somehow we have to make sure that all columns are covered
+      col_ints <- col2int(cols_out)
+      cols_out <- int2col(seq.int(from = min(col_ints), to = max(col_ints)))
+
+      row_ints <- rows_out
+      rows_out <- seq.int(from = min(row_ints), to = max(row_ints))
+    }
   }
 
   dims_to_df(

--- a/R/write.R
+++ b/R/write.R
@@ -368,6 +368,9 @@ write_data2 <- function(
   # create <rows ...>
   want_rows <- as.integer(dims_to_rowcol(dims)[[2]])
   rows_attr <- empty_row_attr(n = length(want_rows))
+  # number of rows might differ
+  if (enforce) rows_attr <- empty_row_attr(n = nrow(rtyp))
+
   rows_attr$r <- rownames(rtyp)
 
   # original cc data frame

--- a/man/dims_to_dataframe.Rd
+++ b/man/dims_to_dataframe.Rd
@@ -4,12 +4,14 @@
 \alias{dims_to_dataframe}
 \title{Create dataframe from dimensions}
 \usage{
-dims_to_dataframe(dims, fill = FALSE)
+dims_to_dataframe(dims, fill = FALSE, empty_rm = FALSE)
 }
 \arguments{
 \item{dims}{Character vector of expected dimension.}
 
 \item{fill}{If \code{TRUE}, fills the dataframe with variables}
+
+\item{empty_rm}{Logical if empty columns and rows should be included}
 }
 \description{
 Create dataframe from dimensions


### PR DESCRIPTION
if rows and columns were entirely omitted. This could create a cc object that was to short. fixes #1014