### PR TITLE
[dims] extend wb_dims() to accept multiple columns

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -8394,7 +8394,7 @@ wbWorkbook <- R6::R6Class(
     #' @return The `wbWorksheetObject`, invisibly
     set_cell_style = function(sheet = current_sheet(), dims, style) {
 
-      if (length(dims) == 1 && grepl(":|;", dims))
+      if (length(dims) == 1 && grepl(":|;|,", dims))
         dims <- dims_to_dataframe(dims, fill = TRUE)
       sheet <- private$get_sheet_index(sheet)
 
@@ -9721,7 +9721,7 @@ wbWorkbook <- R6::R6Class(
         # there are some cells already available, we have to create the missing cells
 
         need_cells <- dims
-        if (length(need_cells) == 1 && grepl(":|;", need_cells))
+        if (length(need_cells) == 1 && grepl(":|;|,", need_cells))
           need_cells <- dims_to_dataframe(dims, fill = TRUE)
 
         exp_cells <- unname(unlist(need_cells[need_cells != ""]))

--- a/R/utils.R
+++ b/R/utils.R
@@ -823,15 +823,7 @@ wb_dims <- function(..., select = NULL) {
     is_cols_a_colname <- cols_arg %in% colnames(x)
 
     if (any(is_cols_a_colname)) {
-      if (length(is_cols_a_colname) != 1) {
-        stop(
-          "Supplying multiple column names is not supported by the `wb_dims()` helper, ",
-          "use the `cols` with a range instead of `x` column names.",
-          "\n Use a single `cols` at a time with `wb_dims()`"
-        )
-      }
-      # message("Transforming col name = '", cols_arg, "' to `cols = ", which(colnames(x) == cols_arg), "`")
-      cols_arg <- which(colnames(x) == cols_arg)
+      cols_arg <- which(colnames(x) %in% cols_arg)
     }
   }
 
@@ -844,8 +836,8 @@ wb_dims <- function(..., select = NULL) {
     cols_arg <- 1L # no more NULL for cols_arg and rows_arg if `x` is not supplied
   }
 
-  if (!is.null(cols_arg) && (min(cols_arg) < 1L || (length(cols_arg) > 1 && any(diff(cols_arg) != 1)))) {
-    stop("You must supply positive, consecutive values to `cols`")
+  if (!is.null(cols_arg) && (min(cols_arg) < 1L)) {
+    stop("You must supply positive values to `cols`")
   }
 
   if (!is.null(rows_arg) && (min(rows_arg) < 1L || (length(rows_arg) > 1 && any(diff(rows_arg) != 1)))) {
@@ -873,14 +865,20 @@ wb_dims <- function(..., select = NULL) {
   }
 
   if (select == "col_names") {
-    ncol_to_span <- ncol(x)
+    if (is.null(cols_arg) || length(cols_arg) %in% c(0, 1))
+        ncol_to_span <- ncol(x)
+      else
+        ncol_to_span <- cols_arg
     nrow_to_span <- 1L
   } else if (select == "row_names") {
     ncol_to_span <- 1L
     nrow_to_span <- nrow(x) %||% 1L
   } else if (select %in% c("x", "data")) {
     if (!is.null(cols_arg)) {
-      ncol_to_span <- length(cols_arg)
+      if (length(cols_arg) == 1)
+        ncol_to_span <- length(cols_arg)
+      else
+        ncol_to_span <- cols_arg
     } else {
       ncol_to_span <- ncol(x) %||% 1L
     }
@@ -904,10 +902,12 @@ wb_dims <- function(..., select = NULL) {
     fcol <- fcol + row_names
     frow <- frow
   } else if (select %in% c("x", "data")) {
-    if (!is.null(cols_arg)) {
+    if (!is.null(cols_arg) && length(cols_arg) == 1L && all(diff(cols_arg) == 1L)) {
       if (min(cols_arg) > 1) {
-        fcol <- fcol + min(cols_arg) - 1L
+        fcol <- fcol + min(cols_arg) - 1L # does not work with multi select
       }
+    } else {
+      fcol <- fcol #+ row_names
     }
 
     if (!is.null(rows_arg)) {
@@ -932,19 +932,45 @@ wb_dims <- function(..., select = NULL) {
   }
 
   row_span <- frow + seq_len(nrow_to_span) - 1L
-  col_span <- fcol + seq_len(ncol_to_span) - 1L
 
-  if (length(row_span) == 1 && length(col_span) == 1) {
+  if (length(ncol_to_span) == 1)
+    col_span <- fcol + seq_len(ncol_to_span) - 1L
+  else # what does this do?
+    col_span <- fcol + ncol_to_span - 1L
+
+  # return single cells (A1 or A1,B1)
+  if (length(row_span) == 1 && (length(col_span) == 1 || any(diff(col_span) != 1L))) {
+
     # A1
     row_start <- row_span
     col_start <- col_span
-    dims <- rowcol_to_dim(row_start, col_start)
-  } else {
-    # A1:B2
-    dims <- rowcol_to_dims(row_span, col_span)
+
+    dims <- NULL
+
+    if (any(diff(col_span) != 1L)) {
+      for (col_start in col_span) {
+        tmp  <- rowcol_to_dim(row_start, col_start)
+        dims <- c(dims, tmp)
+      }
+    } else {
+      dims <- rowcol_to_dim(row_start, col_start)
+    }
+
+  } else { # return range "A1:A7" or "A1:A7,B1:B7"
+
+    dims <- NULL
+    if (any(diff(col_span) != 1L)) {
+      for (col_start in col_span) {
+        tmp  <- rowcol_to_dims(row_span, col_start)
+        dims <- c(dims, tmp)
+      }
+    } else {
+      dims <- rowcol_to_dims(row_span, col_span)
+    }
+
   }
 
-  dims
+  paste0(dims, collapse = ",")
 }
 
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -9,6 +9,10 @@
 #' @export
 dims_to_dataframe <- function(dims, fill = FALSE, empty_rm = FALSE) {
 
+  # in R 4.4.0 grepl(",", data.frame(x = paste0("K",))) == TRUE
+  if (inherits(dims, "data.frame"))
+    dims <- unlist(dims)
+
   has_dim_sep <- FALSE
   if (any(grepl(";", dims))) {
     dims <- unlist(strsplit(dims, ";"))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -77,7 +77,7 @@ test_that("`wb_dims()` works/errors as expected with unnamed arguments", {
   expect_error(wb_dims(mtcars), "Supplying a single unnamed argument")
 
 
-  expect_error(wb_dims(rows = c(1, 3, 4), cols = c(1, 4)), "You must supply positive, consecutive values to `cols`")
+  expect_error(wb_dims(rows = c(1, 3, 4), cols = c(1, 4)), "You must supply positive, consecutive values to `rows`")
 
   expect_error(wb_dims(1, 2, 3))
 })
@@ -168,6 +168,22 @@ test_that("`wb_dims()` can select content in a nice fashion with `x`", {
   expect_equal(wb_dims_cars(rows = 1:5, select = "x"), dims_row1_to_5_and_names)
 })
 
+test_that("wb_dims can select multiple columns", {
+
+  exp <- "B2:B33"
+  got <- wb_dims(x = mtcars, cols = c("cyl"))
+  expect_equal(exp, got)
+
+  exp <- "B2:B33,J2:J33"
+  got <- wb_dims(x = mtcars, cols = c("cyl", "gear"))
+  expect_equal(exp, got)
+
+  exp <- "B1,J1"
+  got <- wb_dims(x = mtcars, cols = c("cyl", "gear"), select = "col_names")
+  expect_equal(exp, got)
+
+})
+
 test_that("`wb_dims()` works for a matrix without column names", {
   mt <- matrix(c(1, 2))
   expect_equal(wb_dims(x = mt), "A1:A3")
@@ -196,7 +212,7 @@ test_that("`wb_dims()` works when Supplying an object `x`.", {
   expect_equal(wb_dims(x = mtcars, rows = 5:10, from_col = "C"), "C6:M11")
   # Write without column names on top
 
-  expect_error(wb_dims(x = mtcars, cols = 0, from_col = "C"), "supply positive.+ values to `cols`")
+  expect_error(wb_dims(x = mtcars, cols = 0, from_col = "C"), "You must supply positive values to `cols`")
 
   # select rows and columns work
   expect_equal(wb_dims(x = mtcars, rows = 2:10, cols = "cyl"), "B3:B11")
@@ -221,10 +237,7 @@ test_that("`wb_dims()` works when Supplying an object `x`.", {
   expect_error(wb_dims(cols = "hp"), "Supplying a single argument")
   # using non-existing character column doesn't work
   expect_error(wb_dims(x = mtcars, cols = "A"), "`cols` must be an integer or an existing column name of `x`.")
-  expect_error(
-    wb_dims(x = mtcars, cols = c("hp", "vs")),
-    regexp = "Supplying multiple column names is not supported"
-  )
+  expect_equal(wb_dims(x = mtcars, cols = c("hp", "vs")), "D2:D33,H2:H33")
   expect_error(expect_warning(wb_dims(x = mtcars, rows = "hp")), "[Uu]se `cols` instead.")
   # Access only row / col name
   expect_no_message(wb_dims(x = mtcars, select = "col_names"))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -77,7 +77,8 @@ test_that("`wb_dims()` works/errors as expected with unnamed arguments", {
   expect_error(wb_dims(mtcars), "Supplying a single unnamed argument")
 
 
-  expect_error(wb_dims(rows = c(1, 3, 4), cols = c(1, 4)), "You must supply positive, consecutive values to `rows`")
+  expect_error(wb_dims(rows = c(1), cols = c(-1)), "You must supply positive values to `cols`")
+  expect_error(wb_dims(rows = c(-1), cols = c(1)), "You must supply positive values to `rows`")
 
   expect_error(wb_dims(1, 2, 3))
 })
@@ -168,7 +169,7 @@ test_that("`wb_dims()` can select content in a nice fashion with `x`", {
   expect_equal(wb_dims_cars(rows = 1:5, select = "x"), dims_row1_to_5_and_names)
 })
 
-test_that("wb_dims can select multiple columns", {
+test_that("wb_dims can select multiple columns and rows", {
 
   exp <- "B2:B33"
   got <- wb_dims(x = mtcars, cols = c("cyl"))
@@ -180,6 +181,30 @@ test_that("wb_dims can select multiple columns", {
 
   exp <- "B1,J1"
   got <- wb_dims(x = mtcars, cols = c("cyl", "gear"), select = "col_names")
+  expect_equal(exp, got)
+
+  exp <- "A1:K33"
+  got <- wb_dims(x = mtcars)
+  expect_equal(exp, got)
+
+  exp <- "B2:B33"
+  got <- wb_dims(x = mtcars, cols = c(2))
+  expect_equal(exp, got)
+
+  exp <- "B2:B33,D2:D33"
+  got <- wb_dims(x = mtcars, cols = c(2, 4))
+  expect_equal(exp, got)
+
+  exp <- "A5:K5"
+  got <- wb_dims(x = mtcars, rows = c(4))
+  expect_equal(exp, got)
+
+  exp <- "A3:K3,A5:K5,A6:K6"
+  got <- wb_dims(x = mtcars, rows = c(2, 4:5))
+  expect_equal(exp, got)
+
+  exp <- "B3:B3,D3:D3,B5:B5,D5:D5,B6:B6,D6:D6"
+  got <- wb_dims(x = mtcars, cols = c(2, 4), rows = c(2, 4:5))
   expect_equal(exp, got)
 
 })


### PR DESCRIPTION
Fix #843

This PR extends `wb_dims()` to accept multiple columns:

``` r
library(openxlsx2)
wb <- wb_workbook() %>% 
  wb_add_worksheet() %>% 
  wb_add_data(x = mtcars) %>% 
  wb_add_fill(dims = wb_dims(x = mtcars, cols = c("cyl", "gear"), select = "col_names"), color = wb_color("blue")) %>% 
  wb_add_fill(dims = wb_dims(x = mtcars, cols = c("cyl", "gear")), color = wb_color("orange"))

if (interactive())  wb %>% wb_open()
```

<img width="640" alt="Screenshot 2024-05-18 at 13 54 04" src="https://github.com/JanMarvin/openxlsx2/assets/1645626/0c09c407-3e69-470d-a3e2-2c007edd7402">



``` r
# just to show what is going on
wb_dims(x = mtcars, cols = c("cyl"))
#> [1] "B2:B33"

wb_dims(x = mtcars, cols = c("cyl", "gear"))
#> [1] "B2:B33,J2:J33"

wb_dims(x = mtcars, select = "col_names")
#> [1] "A1:K1"

wb_dims(x = mtcars, cols = c("cyl", "gear"), select = "col_names")
#> [1] "B1,J1"
```