### PR TITLE
[misc] avoid cryptic error on blank inline string. fixes #1038

### DIFF
--- a/src/strings_xml.cpp
+++ b/src/strings_xml.cpp
@@ -46,6 +46,11 @@ SEXP xml_to_txt(Rcpp::CharacterVector vec, std::string type) {
 
     std::string tmp = Rcpp::as<std::string>(vec[i]);
 
+    if (tmp.compare("") == 0) {
+      res[i] = NA_STRING;
+      continue;
+    }
+
     pugi::xml_document doc;
     pugi::xml_parse_result result = doc.load_string(tmp.c_str(), pugi::parse_default | pugi::parse_ws_pcdata | pugi::parse_escapes);
 

--- a/tests/testthat/test-strings_xml.R
+++ b/tests/testthat/test-strings_xml.R
@@ -52,6 +52,9 @@ test_that("strings_xml", {
   is <- "<is><t>foo</t>"
   expect_error(is_to_txt(is))
 
+  exp <- c("a", NA_character_, "")
+  got <- is_to_txt(c("<is><t>a</t></is>", "", "<is><t/></is>"))
+  expect_equal(exp, got)
 
   txt <- "foo"
   expect_equal(


### PR DESCRIPTION
This was triggered by some SAS exported xlsx file which has:

```XML
<c r="A1" t="inlineStr"/>
```