### PR TITLE
[xlsb] fix more array fmls

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -3309,19 +3309,22 @@ wbWorkbook <- R6::R6Class(
           }, FUN.VALUE = ""), collapse = "")
           if (WR != "") {
             WR <- rbindlist(xml_attr(WR, "Relationships", "Relationship"))
-            WR$tmpDirPartName <- paste0(tmpDir, "/xl/", folder, "/", WR$Target)
-            WR$fileExists <- file.exists(WR$tmpDirPartName)
 
-            # exclude hyperlinks
-            WR$type <- basename(WR$Type)
-            WR <- WR[WR$type != "hyperlink", ]
+            if (NROW(WR)) { # in xlsb files it can be that WR has no rows
+              WR$tmpDirPartName <- paste0(tmpDir, "/xl/", folder, "/", WR$Target)
+              WR$fileExists <- file.exists(WR$tmpDirPartName)
 
-            if (!all(WR$fileExists)) {
-              missing_in_tmp <- WR$Target[!WR$fileExists]
-              warning(
-                "[", folder, "] file expected to be in output is missing: ",
-                paste(missing_in_tmp, collapse = " ")
-              )
+              # exclude hyperlinks
+              WR$type <- basename(WR$Type)
+              WR <- WR[WR$type != "hyperlink", ]
+
+              if (!all(WR$fileExists)) {
+                missing_in_tmp <- WR$Target[!WR$fileExists]
+                warning(
+                  "[", folder, "] file expected to be in output is missing: ",
+                  paste(missing_in_tmp, collapse = " ")
+                )
+              }
             }
           }
         }

--- a/src/xlsb_defines.h
+++ b/src/xlsb_defines.h
@@ -179,6 +179,19 @@ typedef struct {
   uint16_t unused : 13;
 } BrtWbPropFields;
 
+
+typedef struct {
+  uint8_t columns : 2;
+  uint8_t rowType : 5;
+  bool squareBracketSpace : 1;
+  bool commaSpace : 1;
+  bool unused : 1;
+  uint8_t type : 2;
+  bool invalid : 1;
+  bool nonresident : 1;
+  uint8_t reserved2 : 2;
+} PtgListFields;
+
 enum RgbExtra
 {
   PtgExtraArray = 0,


### PR DESCRIPTION
This fixes formulas like:

`SUM({1,2,3;4,5,6})`

Works now too:

`SUMIFS(A1:A2,foo!B2:B3,{"A"})`

Because of the reference at another worksheet, the formula is broken. Probably something in `RevExtern`.