### PR TITLE
[xlsb] add data validations

### DIFF
--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -1571,6 +1571,17 @@ wb_load <- function(
           )
       }
 
+      for (i in seq_along(wb$worksheets)) {
+        if (!wb$is_chartsheet[[i]])
+          wb$worksheets[[i]]$extLst <-
+            stringi::stri_replace_all_fixed(
+              wb$worksheets[[i]]$extLst,
+              xti$name_id,
+              xti$sheets,
+              vectorize_all = FALSE
+            )
+      }
+
       ### for external references we need to get the required sheet names first
       # For now this is all a little guess work
 
@@ -1648,6 +1659,16 @@ wb_load <- function(
                   vectorize_all = FALSE
                 )
             }
+
+
+            if (!wb$is_chartsheet[[i]])
+              wb$worksheets[[j]]$dataValidations <-
+                stringi::stri_replace_all_fixed(
+                  wb$worksheets[[j]]$dataValidations,
+                  nri$name_id,
+                  nri$name,
+                  vectorize_all = FALSE
+                )
           }
 
         }

--- a/src/xlsb.cpp
+++ b/src/xlsb.cpp
@@ -3787,11 +3787,18 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
         break;
       }
 
+      case BrtBeginConditionalFormattings:
+      case BrtBeginConditionalFormatting14:
+      {
+        if (debug) Rcpp::Rcout << "BrtBegin/EndDCon" << std::endl;
+
+        Rcpp::warning("Worksheet contains unhandled conditional formatting.");
+        bin.seekg(size, bin.cur);
+        break;
+      }
 
       case BrtBeginConditionalFormatting:
       {
-
-        Rcpp::warning("Worksheet contains unhandled conditional formatting.");
 
         if (debug) Rcpp::Rcout << "<conditionalFormatting>" << std::endl;
 
@@ -3885,6 +3892,27 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
         break;
       }
 
+      case BrtEndConditionalFormatting14:
+      case BrtBeginCFRule14:
+      case BrtEndCFRule14:
+      {
+        if (debug) Rcpp::Rcout << "BrtBegin/EndDCon 14" << std::endl;
+        bin.seekg(size, bin.cur);
+        break;
+      }
+
+      // dxf styles for conditional formatting can be (or is always?) embedded in the worksheet
+      // the xlsx conversion creates <x14:dxf/>
+      case BrtBeginDXFs:
+      case BrtDXF:
+      case BrtEndDXFs:
+      {
+        if (debug) Rcpp::Rcout << "BrtBegin/EndDXFs in worksheet (?)" << std::endl;
+        bin.seekg(size, bin.cur);
+        break;
+      }
+
+
       case BrtEndCFRule:
       {
 
@@ -3896,10 +3924,17 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtEndConditionalFormatting:
       {
-
         if (debug) Rcpp::Rcout << "</conditionalFormatting>" << std::endl;
         out << "</conditionalFormatting>" << std::endl;
+        bin.seekg(size, bin.cur);
+        break;
+      }
 
+      case BrtEndConditionalFormattings:
+      {
+        // UNHANDLED
+        if (debug) Rcpp::Rcout << "</conditionalFormattings>" << std::endl;
+        bin.seekg(size, bin.cur);
         break;
       }
 

--- a/src/xlsb.cpp
+++ b/src/xlsb.cpp
@@ -2026,6 +2026,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
       if (debug) Rcpp::Rcout << "." << std::endl;
 
       RECORD(x, size, bin, swapit);
+      if (debug) Rcpp::Rcout << x << ": " << size << std::endl;
 
       switch(x) {
 
@@ -2186,6 +2187,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtPane:
       {
+        if (debug) Rcpp::Rcout << "BrtPane: " << std::endl;
         uint8_t flags = 0;
         uint32_t rwTop = 0, colLeft = 0, pnnAct = 0;
         double xnumXSplit = 0.0, xnumYSplit = 0.0;
@@ -2304,6 +2306,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtPageSetup:
       {
+        if (debug) Rcpp::Rcout << "BrtPageSetup: " << std::endl;
         uint16_t flags = 0;
         uint32_t iPaperSize = 0, iScale = 0, iRes = 0, iVRes = 0, iCopies = 0, iPageStart = 0, iFitWidth = 0, iFitHeight = 0;
 
@@ -2345,6 +2348,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtPhoneticInfo:
       {
+        if (debug) Rcpp::Rcout << "BrtPhoneticInfo: " << std::endl;
         uint16_t iFnt = 0;
         uint32_t phType = 0, phAll = 0;
         iFnt = readbin(iFnt, bin, swapit);
@@ -2359,6 +2363,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtBeginHeaderFooter:
       {
+        if (debug) Rcpp::Rcout << "BrtBeginHeaderFooter: " << std::endl;
         uint16_t flags = 0;
         flags = readbin(flags, bin, swapit); // unused
 
@@ -3060,6 +3065,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtArrFmla:
       {
+        if (debug) Rcpp::Rcout << "BrtArrFmla: " << bin.tellg() << std::endl;
         int is_shared_formula = false;
 
         uint8_t flags = 0;
@@ -3241,14 +3247,21 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
         xnumHeader = Xnum(bin, swapit);
         xnumFooter = Xnum(bin, swapit);
 
-        out << "<pageMargins";
-        out << " left=\"" << xnumLeft << "\"";
-        out << " right=\"" << xnumRight << "\"";
-        out << " top=\"" << xnumTop << "\"";
-        out << " bottom=\"" << xnumBottom << "\"";
-        out << " header=\"" << xnumHeader << "\"";
-        out << " footer=\"" << xnumFooter << "\"";
-        out << " />" << std::endl;
+        if (xnumLeft < 0   || xnumLeft > 49)   Rcpp::stop("xnumLeft size out of bounds");
+        if (xnumRight < 0  || xnumRight > 49)  Rcpp::stop("xnumRight size out of bounds");
+        if (xnumTop < 0    || xnumTop > 49)    Rcpp::stop("xnumTop size out of bounds");
+        if (xnumBottom < 0 || xnumBottom > 49) Rcpp::stop("xnumBottom size out of bounds");
+        if (xnumHeader < 0 || xnumHeader > 49) Rcpp::stop("xnumHeader size out of bounds");
+        if (xnumFooter < 0 || xnumFooter > 49) Rcpp::stop("xnumFooter size out of bounds");
+
+        out << "<pageMargins" <<
+          " left=\"" << xnumLeft << "\"" <<
+          " right=\"" << xnumRight << "\"" <<
+          " top=\"" << xnumTop << "\"" <<
+          " bottom=\"" << xnumBottom << "\"" <<
+          " header=\"" << xnumHeader << "\"" <<
+          " footer=\"" << xnumFooter << "\"" <<
+          " />" << std::endl;
 
         break;
       }
@@ -3262,7 +3275,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtDrawing:
       {
-        if (debug) Rcpp::Rcout << "<drawing>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtDrawing" << std::endl;
         std::string stRelId = XLNullableWideString(bin, swapit);
         out << "<drawing r:id=\"" << stRelId << "\" />" << std::endl;
         break;
@@ -3270,7 +3283,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtLegacyDrawing:
       {
-        if (debug) Rcpp::Rcout << "<legacyDrawing>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtLegacyDrawing" << std::endl;
         std::string stRelId = XLNullableWideString(bin, swapit);
         out << "<legacyDrawing r:id=\"" << stRelId << "\" />" << std::endl;
         break;
@@ -3278,7 +3291,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtLegacyDrawingHF:
       {
-        if (debug) Rcpp::Rcout << "<BrtLegacyDrawingHF>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtLegacyDrawingHF" << std::endl;
         std::string stRelId = XLNullableWideString(bin, swapit);
         out << "<legacyDrawingHF r:id=\"" << stRelId << "\" />" << std::endl;
         break;
@@ -3286,7 +3299,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtHLink:
       {
-        if (debug) Rcpp::Rcout << "<BrtHLink>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtHLink" << std::endl;
 
         std::vector<int> rfx = UncheckedRfX(bin, swapit);
         std::string relId = XLNullableWideString(bin, swapit);
@@ -3313,7 +3326,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtBeginAFilter:
       {
-        if (debug) Rcpp::Rcout << "<autofilter>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtBeginAFilter" << std::endl;
         std::vector<int> rfx = UncheckedRfX(bin, swapit);
 
         std::string lref = int_to_col(rfx[2] + 1) + std::to_string(rfx[0] + 1);
@@ -3336,7 +3349,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtBeginFilterColumn:
       {
-        if (debug) Rcpp::Rcout << "<filterColumn>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtBeginFilterColumn" << std::endl;
 
         uint16_t flags = 0;
         uint32_t dwCol = 0;
@@ -3352,7 +3365,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtBeginFilters:
       {
-        if (debug) Rcpp::Rcout << "<filters>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtBeginFilters" << std::endl;
         // bin.seekg(size, bin.cur);
 
         uint32_t fBlank = 0, unused = 0;
@@ -3364,7 +3377,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtFilter:
       {
-        if (debug) Rcpp::Rcout << "<BrtFilter>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtFilter" << std::endl;
         std::string rgch = XLWideString(bin, swapit);
         out << "<filter val=\"" << rgch << "\" />" << std::endl;
         // bin.seekg(size, bin.cur);
@@ -3373,7 +3386,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtEndFilters:
       {
-        if (debug) Rcpp::Rcout << "</filters>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtEndFilters" << std::endl;
         out << "</filters>" << std::endl;
         bin.seekg(size, bin.cur);
         break;
@@ -3381,7 +3394,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtColorFilter:
       {
-        if (debug) Rcpp::Rcout << "<BrtColorFilter>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtColorFilter" << std::endl;
         uint32_t dxfid = 0, fCellColor = 0;
         dxfid = readbin(dxfid, bin, swapit);
         fCellColor = readbin(fCellColor, bin, swapit);
@@ -3395,6 +3408,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
       case BrtBeginCustomFilters14:
       case BrtBeginCustomRichFilters:
       {
+        if (debug) Rcpp::Rcout << "BrtBeginCustom..." << std::endl;
         Rcpp::warning("Custom Filter found. This is not handled.");
         bin.seekg(size, bin.cur);
 
@@ -3403,6 +3417,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtDynamicFilter:
       {
+        if (debug) Rcpp::Rcout << "BrtDynamicFilter" << std::endl;
         Rcpp::warning("Dynamic Filter found. This is not handled.");
         bin.seekg(size, bin.cur);
         break;
@@ -3426,7 +3441,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
 
       case BrtEndFilterColumn:
       {
-        if (debug) Rcpp::Rcout << "</filterColumn>" << std::endl;
+        if (debug) Rcpp::Rcout << "BrtEndFilterColumn" << std::endl;
         out << "</filterColumn>" << std::endl;
         bin.seekg(size, bin.cur);
         break;
@@ -3502,21 +3517,272 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
       }
 
       case BrtBeginDVals:
-      case BrtBeginDVals14:
       {
-        Rcpp::warning("Worksheet contains unhandled data validation.");
+        if (debug) Rcpp::Rcout << "BrtBeginDVals" << std::endl;
+
+        uint16_t flags = 0;
+        uint32_t xLeft = 0, yTop = 0, unused3 = 0, idvMac = 0;
+
+        // openxlsx2 does not handle this?
+        flags   = readbin(flags, bin, swapit);
+        xLeft   = readbin(xLeft, bin, swapit);
+        yTop    = readbin(yTop, bin, swapit);
+        unused3 = readbin(unused3, bin, swapit);
+        idvMac  = readbin(idvMac, bin, swapit);
+
+        if (idvMac > 65534) Rcpp::stop("idvMac to big");
+
+        out << "<dataValidations>" << std::endl;
+        break;
+      }
+
+
+      case BrtDVal:
+      {
+        if (debug) Rcpp::Rcout << "BrtDVal" << std::endl;
+
+        uint32_t flags = 0;
+        std::vector<int> sqrfx;
+        std::string strErrorTitle = "", strError = "", strPromptTitle = "", strPrompt = "";
+
+        flags = readbin(flags, bin, swapit);
+
+        BrtDValFields *fields = (BrtDValFields *)&flags;
+
+        sqrfx          = UncheckedSqRfX(bin, swapit);
+        strErrorTitle  = XLNullableWideString(bin, swapit);
+        strError       = XLNullableWideString(bin, swapit);
+        strPromptTitle = XLNullableWideString(bin, swapit);
+        strPrompt      = XLNullableWideString(bin, swapit);
+
+        int sharedFormula = false;
+        std::string formula1 = CellParsedFormula(bin, swapit, debug, 0, 0, sharedFormula, has_revision_record);
+        std::string formula2 = CellParsedFormula(bin, swapit, debug, 0, 0, sharedFormula, has_revision_record);
+
+        std::string lref = int_to_col(sqrfx[3] + 1) + std::to_string(sqrfx[1] + 1);
+        std::string rref = int_to_col(sqrfx[4] + 1) + std::to_string(sqrfx[2] + 1);
+
+        std::string sqref;
+        if (lref.compare(rref) == 0) {
+          sqref = lref;
+        } else {
+          sqref =  lref + ":" + rref;
+        }
+
+        out << "<dataValidation " <<
+         "type=\"" << valType(fields->valType) << "\" " <<
+         "operator=\"" << typOperator(fields->typOperator) << "\" " <<
+         "allowBlank=\"" << (bool)fields->fAllowBlank << "\" " <<
+         "showInputMessage=\"" << (bool)fields->fShowInputMsg << "\" " <<
+         "showErrorMessage=\"" << (bool)fields->fShowErrorMsg << "\" " <<
+         "sqref=\"" << sqref << "\" >" <<
+         "<formula1>" << formula1 << "</formula1>" <<
+         "<formula2>" << formula2 << "</formula2>" <<
+         "</dataValidation>" << std::endl;
+
+        break;
+      }
+
+      case BrtDValList:
+      {
+        Rcpp::Rcout << "BrtDValList" << std::endl;
+
+        std::string strDvalList = XLWideString(bin, swapit);
+        Rcpp::Rcout << strDvalList << std::endl;
+
+        break;
+      }
+
+      case BrtEndDVals:
+      {
+        if (debug) Rcpp::Rcout << "BrtEndDVals" << std::endl;
+        out << "</dataValidations>" << std::endl;
         bin.seekg(size, bin.cur);
         break;
       }
 
-      case BrtDVal:
+      case BrtBeginDVals14:
+      {
+        if (debug) Rcpp::Rcout << "BrtBeginDVals14" << std::endl;
+        // Rcpp::warning("Worksheet contains unhandled data validation.");
+
+        // FRT blank
+        uint32_t reserved = 0;
+        reserved = readbin(reserved, bin, swapit);
+
+        // Dvals
+        uint16_t flags = 0;
+        uint32_t xLeft = 0, yTop = 0, unused3 = 0, idvMac = 0;
+
+        // openxlsx2 does not handle this?
+        flags   = readbin(flags, bin, swapit);
+        xLeft   = readbin(xLeft, bin, swapit);
+        yTop    = readbin(yTop, bin, swapit);
+        unused3 = readbin(unused3, bin, swapit);
+        idvMac  = readbin(idvMac, bin, swapit);
+
+        if (idvMac > 65534) Rcpp::stop("idvMac to big");
+
+        out << "<x14:dataValidations count=\"" <<
+          std::to_string(idvMac) <<
+          "\" xmlns:xm=\"http://schemas.microsoft.com/office/excel/2006/main\""
+          ">" << std::endl;
+
+        break;
+      }
+
       case BrtDVal14:
-      case BrtDValList:
-      case BrtBeginDCon:
-      case BrtEndDCon:
-      case BrtEndDVals:
+      {
+        if (debug) Rcpp::Rcout << "BrtDVal14" << std::endl;
+
+        // Start FRTHeader
+        uint32_t flags_frt = 0;
+        std::vector<std::string> frt_sqrefs;
+        std::vector<std::string> frt_fmls;
+
+        flags_frt = readbin(flags_frt, bin, swapit);
+
+        FRTHeaderFields *fields_frt = (FRTHeaderFields *)&flags_frt;
+
+        if (fields_frt->fRef) { // but must be 0
+          // Rcpp::Rcout << "fRef" << std::endl;
+          uint32_t cref = 0;
+          cref = readbin(cref, bin, swapit);
+          // Rcpp::Rcout << "Refs: " << cref << std::endl;
+
+          for (uint32_t crf = 0; crf < cref; ++crf) {
+            uint32_t flags_cref = 0;
+            flags_cref = readbin(flags_cref, bin, swapit);
+            std::vector<int> rfx_cref = UncheckedRfX(bin, swapit);
+          }
+
+        }
+
+        if (fields_frt->fSqref) { // must be 1
+          // Rcpp::Rcout << "fSqref" << std::endl;
+          uint32_t csqref = 0;
+          csqref = readbin(csqref, bin, swapit);
+          // Rcpp::Rcout << "Sqrefs: " << csqref << std::endl;
+
+          for (uint32_t csqrf = 0; csqrf < csqref; ++csqrf) {
+            uint32_t flags_csqrf = 0;
+            flags_csqrf = readbin(flags_csqrf, bin, swapit);
+
+            /* beg move this to function -------------------------------------*/
+            std::vector<int> rfx_csqrfx = UncheckedSqRfX(bin, swapit);
+
+            std::string lref = int_to_col(rfx_csqrfx[3] + 1) + std::to_string(rfx_csqrfx[1] + 1);
+            std::string rref = int_to_col(rfx_csqrfx[4] + 1) + std::to_string(rfx_csqrfx[2] + 1);
+
+            std::string sqref;
+            if (lref.compare(rref) == 0) {
+              sqref = lref;
+            } else {
+              sqref =  lref + ":" + rref;
+            }
+            /* end move this to function -------------------------------------*/
+
+            frt_sqrefs.push_back(sqref);
+
+          }
+
+        }
+
+        if (fields_frt->fFormula) { // 0 or 1
+          // Rcpp::Rcout << "fFormula" << std::endl;
+          uint32_t cformula = 0;
+          cformula = readbin(cformula, bin, swapit);
+          // Rcpp::Rcout << "Formulas: " << cformula << std::endl;
+
+          for (uint32_t cfml = 0; cfml < cformula; ++cfml) {
+            uint32_t flags_cfml = 0;
+            flags_cfml = readbin(flags_cfml, bin, swapit);
+            int sharedFormula = false;
+            std::string frt_fml = FRTParsedFormula(bin, swapit, debug, 0, 0, sharedFormula, has_revision_record);
+            frt_fmls.push_back(frt_fml);
+            // Rcpp::Rcout << frt_fmls[cfml] << std::endl;
+          }
+
+        }
+
+        if (fields_frt->fRelID) { // 0
+          // Rcpp::Rcout << "fRelID" << std::endl;
+          std::string relId = LPWideString(bin, swapit);
+        }
+        // End FRTHeader
+
+        uint32_t flags = 0;
+        std::string strErrorTitle = "", strError = "", strPromptTitle = "", strPrompt = "";
+
+        flags = readbin(flags, bin, swapit);
+
+        BrtDValFields *fields = (BrtDValFields *)&flags;
+
+
+        // if (debug)
+        // Rprintf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+        //   (uint32_t)fields->valType,
+        //   (uint32_t)fields->errStyle,
+        //   (uint32_t)fields->unused,
+        //   (uint32_t)fields->fAllowBlank,
+        //   (uint32_t)fields->fSuppressCombo,
+        //   (uint32_t)fields->mdImeMode,
+        //   (uint32_t)fields->fShowInputMsg,
+        //   (uint32_t)fields->fShowErrorMsg,
+        //   (uint32_t)fields->typOperator,
+        //   (uint32_t)fields->fDVMinFmla,
+        //   (uint32_t)fields->fDVMaxFmla
+        // );
+
+        strErrorTitle  = XLNullableWideString(bin, swapit);
+        strError       = XLNullableWideString(bin, swapit);
+        strPromptTitle = XLNullableWideString(bin, swapit);
+        strPrompt      = XLNullableWideString(bin, swapit);
+
+        out << "<x14:dataValidation " <<
+         "type=\"" << valType(fields->valType) << "\" " <<
+         "operator=\"" << typOperator(fields->typOperator) << "\" " <<
+         "allowBlank=\"" << (bool)fields->fAllowBlank << "\" " <<
+         "showInputMessage=\"" << (bool)fields->fShowInputMsg << "\" " <<
+         "showErrorMessage=\"" << (bool)fields->fShowErrorMsg << "\" " <<
+         // "xr:uid=\"{00000000-0002-0000-0200-000000000000}\" " <<
+         ">";
+
+        for (size_t len = 0; len < frt_fmls.size(); ++len) {
+
+          out <<
+            "<x14:formula" << std::to_string(len + 1) << ">" <<
+            "<xm:f>" <<
+            frt_fmls[len] <<
+            "</xm:f>" <<
+            "</x14:formula" << std::to_string(len + 1) << ">";
+        }
+        for (size_t len = 0; len < frt_fmls.size(); ++len) {
+
+          out <<
+            "<xm:sqref>" <<
+            frt_sqrefs[len] <<
+            "</xm:sqref>";
+        }
+
+        out  << "</x14:dataValidation>" << std::endl;
+
+        break;
+      }
+
       case BrtEndDVals14:
       {
+        if (debug) Rcpp::Rcout << "BrtEndDVals14" << std::endl;
+        out << "</x14:dataValidations>" << std::endl;
+        bin.seekg(size, bin.cur);
+        break;
+      }
+
+
+      case BrtBeginDCon:
+      case BrtEndDCon:
+      {
+        if (debug) Rcpp::Rcout << "BrtBegin/EndDCon" << std::endl;
         bin.seekg(size, bin.cur);
         break;
       }
@@ -3677,11 +3943,28 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
       }
       // end unhandled page breaks
 
-      // TODO it is not correct to stop here for future records, but we ignore
-      // this <ext/> segments currently. Otherwise the calendar_stress.xlsb
-      // file breaks. Somehow there are new blank cell and row header entries.
       case BrtFRTBegin:
+      {
+        if (debug) Rcpp::Rcout << "BrtFRTBegin" << std::endl;
+
+        // we only handle this for data validation lists.
+        out << "<extLst>" <<
+          "<ext uri=\"{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\">" <<
+            std::endl;
+
+        ProductVersion(bin, swapit, debug);
+
+        break;
+      }
+
       case BrtFRTEnd:
+      {
+        if (debug) Rcpp::Rcout << "BrtFRTEnd" << std::endl;
+        out << "</ext></extLst>" << std::endl;
+        bin.seekg(size, bin.cur);
+        break;
+      }
+
       case BrtEndSheet:
       {
 
@@ -3711,6 +3994,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
       case BrtCellIgnoreEC:
       case BrtEndCellIgnoreECs:
       {
+        if (debug) Rcpp::Rcout << "BrtBeginCell" << std::endl;
         // Rcpp::warning("Worksheet contains unhandled data validation.");
         bin.seekg(size, bin.cur);
         break;
@@ -3749,6 +4033,7 @@ int worksheet_bin(std::string filePath, bool chartsheet, std::string outPath, bo
       case BrtSheetProtectionIso:
       case BrtCsProtection:
       {
+        if (debug) Rcpp::Rcout << "protection" << std::endl;
         // uint16_t protpwd = 0;
         // uint32_t fLocked = 0, fObjects = 0;
         // unhandled

--- a/src/xlsb_defines.h
+++ b/src/xlsb_defines.h
@@ -179,6 +179,33 @@ typedef struct {
   uint16_t unused : 13;
 } BrtWbPropFields;
 
+typedef struct {
+  uint8_t valType : 4;
+  uint8_t errStyle : 3;
+  bool unused : 1;
+  bool fAllowBlank : 1;
+  bool fSuppressCombo : 1;
+  uint8_t mdImeMode : 8;
+  bool fShowInputMsg : 1;
+  bool fShowErrorMsg : 1;
+  uint8_t typOperator : 4;
+  bool fDVMinFmla : 1; // only in 14
+  bool fDVMaxFmla : 1; // only in 14
+  uint8_t reserved : 6;
+} BrtDValFields;
+
+typedef struct {
+  uint16_t product : 15;
+  bool reserved : 1;
+} FRTVersionFields;
+
+typedef struct {
+  bool fRef : 1;
+  bool fSqref : 1;
+  bool fFormula : 1;
+  bool fRelID : 1;
+  uint32_t reserved : 28;
+} FRTHeaderFields;
 
 typedef struct {
   uint8_t columns : 2;

--- a/tests/testthat/test-read_xlsb.R
+++ b/tests/testthat/test-read_xlsb.R
@@ -145,3 +145,18 @@ test_that("xlsb formulas", {
   )
 
 })
+
+test_that("shared formulas are detected correctly", {
+
+  xlsb <- testfile_path("formula_checks.xlsb")
+  xlsx <- testfile_path("formula_checks.xlsx")
+
+  wbb <- wb_load(xlsb)
+  wbx <- wb_load(xlsx)
+
+  expect_equal(
+    wbb$worksheets[[4]]$sheet_data$cc,
+    wbx$worksheets[[4]]$sheet_data$cc
+  )
+
+})


### PR DESCRIPTION
I have a broken test file from here: https://github.com/SheetJS/test_files/blob/master/calendar_stress_test.xlsb

Not sure why, but if I read the file as is, it reads just fine. Once the end of the file is reached, it tries to read

* `BrtFRTBegin` - fine whatever
* `BrtCellBlank`  - it looks like something went wrong
* `BrtRowHdr`    - ???

and here it errors out, because there is no row. I guess the file is damaged. Because the maximal amount of rows was reached Excel might have ended the file saving prematurely and it's only able to read the file, because it does some additional checks. After all, if I read the file with Excel in MS365 and save it as xlsx first and then again as xlsb, `openxlsx2` is able to read the file just fine.

Why do I write this? Because I wanted to read the data validation lists from an xlsb file, which is stored in the future record section (`<extLst/>`) and to be able to do this, I had to remove a hack which allowed us to read the broken file.