### PR TITLE
[dims] code cleanup

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -36,8 +36,8 @@ needed_cells <- function(range) {
     .Call(`_openxlsx2_needed_cells`, range)
 }
 
-dims_to_df <- function(rows, cols, filled, fill) {
-    .Call(`_openxlsx2_dims_to_df`, rows, cols, filled, fill)
+dims_to_df <- function(rows, cols, filled, fill, fcols) {
+    .Call(`_openxlsx2_dims_to_df`, rows, cols, filled, fill, fcols)
 }
 
 long_to_wide <- function(z, tt, zz) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1236,3 +1236,33 @@ print.fmt_txt <- function(x, ...) {
 is_dims  <- function(x) {
   grepl("^[A-Z]+[0-9]+(:[A-Z]+[0-9]+)?$", x)
 }
+
+#' check if non consecutive dims is equal sized: "A1:A4,B1:B4"
+get_dims <- function(dims, check = TRUE, cols = TRUE) {
+
+  rows <- unique(
+    lapply(dims, FUN = function(dim) {
+      dimensions <- strsplit(dim, ":")[[1]]
+      as.integer(gsub("[[:upper:]]", "", dimensions))
+    })
+  )
+
+  if (check)
+    return(length(rows) == 1)
+
+  if (cols) {
+    cols <- unique(
+      lapply(dims, FUN = function(dim) {
+        dimensions <- strsplit(dim, ":")[[1]]
+        col2int(gsub("[[:digit:]]", "", dimensions))
+      })
+    )
+
+    cols <- lapply(cols, function(icols) seq.int(min(icols), max(icols)))
+
+    return(unique(unlist(cols)))
+  }
+
+  return(rows)
+
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -100,8 +100,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // dims_to_df
-SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Nullable<Rcpp::CharacterVector> filled, bool fill);
-RcppExport SEXP _openxlsx2_dims_to_df(SEXP rowsSEXP, SEXP colsSEXP, SEXP filledSEXP, SEXP fillSEXP) {
+SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Nullable<Rcpp::CharacterVector> filled, bool fill, Rcpp::Nullable<Rcpp::IntegerVector> fcols);
+RcppExport SEXP _openxlsx2_dims_to_df(SEXP rowsSEXP, SEXP colsSEXP, SEXP filledSEXP, SEXP fillSEXP, SEXP fcolsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -109,7 +109,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type cols(colsSEXP);
     Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type filled(filledSEXP);
     Rcpp::traits::input_parameter< bool >::type fill(fillSEXP);
-    rcpp_result_gen = Rcpp::wrap(dims_to_df(rows, cols, filled, fill));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::IntegerVector> >::type fcols(fcolsSEXP);
+    rcpp_result_gen = Rcpp::wrap(dims_to_df(rows, cols, filled, fill, fcols));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1005,7 +1006,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_copy", (DL_FUNC) &_openxlsx2_copy, 1},
     {"_openxlsx2_validate_dims", (DL_FUNC) &_openxlsx2_validate_dims, 1},
     {"_openxlsx2_needed_cells", (DL_FUNC) &_openxlsx2_needed_cells, 1},
-    {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 4},
+    {"_openxlsx2_dims_to_df", (DL_FUNC) &_openxlsx2_dims_to_df, 5},
     {"_openxlsx2_long_to_wide", (DL_FUNC) &_openxlsx2_long_to_wide, 3},
     {"_openxlsx2_is_charnum", (DL_FUNC) &_openxlsx2_is_charnum, 1},
     {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 14},

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -353,30 +353,31 @@ SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Null
       SET_VECTOR_ELT(df, i, Rcpp::CharacterVector(nn, NA_STRING));
   }
 
-  if (has_filled && fill) {
+  if (fill) {
+    if (has_filled) {
 
-    std::vector<std::string> flld = Rcpp::as<std::vector<std::string>>(filled.get());
-    std::unordered_set<std::string> flls(flld.begin(), flld.end());
+      std::vector<std::string> flld = Rcpp::as<std::vector<std::string>>(filled.get());
+      std::unordered_set<std::string> flls(flld.begin(), flld.end());
 
-    // with has_filled we always have to run this loop
-    for (size_t i = 0; i < kk; ++i) {
-      Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
-      std::string coli = Rcpp::as<std::string>(cols[i]);
-      for (size_t j = 0; j < nn; ++j) {
-        std::string cell = coli + std::to_string(rows[j]);
-        if (has_cell(cell, flls))
-          cvec[j] = coli + std::to_string(rows[j]);
-        // else cvec[j] = "";
+      // with has_filled we always have to run this loop
+      for (size_t i = 0; i < kk; ++i) {
+        Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
+        std::string coli = Rcpp::as<std::string>(cols[i]);
+        for (size_t j = 0; j < nn; ++j) {
+          std::string cell = coli + std::to_string(rows[j]);
+          if (has_cell(cell, flls))
+            cvec[j] = cell;
+        }
       }
-    }
 
-  } else if (fill) { // insert cells into data frame
+    } else { // insert cells into data frame
 
-    for (size_t i = 0; i < kk; ++i) {
-      Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
-      std::string coli = Rcpp::as<std::string>(cols[i]);
-      for (size_t j = 0; j < nn; ++j) {
-        cvec[j] = coli + std::to_string(rows[j]);
+      for (size_t i = 0; i < kk; ++i) {
+        Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
+        std::string coli = Rcpp::as<std::string>(cols[i]);
+        for (size_t j = 0; j < nn; ++j) {
+          cvec[j] = coli + std::to_string(rows[j]);
+        }
       }
     }
 

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -336,11 +336,13 @@ bool has_cell(const std::string& str, const std::unordered_set<std::string>& vec
 
 // provide a basic rbindlist for lists of named characters
 // [[Rcpp::export]]
-SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Nullable<Rcpp::CharacterVector> filled, bool fill) {
+SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Nullable<Rcpp::CharacterVector> filled, bool fill,
+                Rcpp::Nullable<Rcpp::IntegerVector> fcols) {
 
   size_t kk = cols.size();
   size_t nn = rows.size();
 
+  bool has_fcols  = fcols.isNotNull();
   bool has_filled = filled.isNotNull();
 
   // 1. create the list
@@ -372,7 +374,14 @@ SEXP dims_to_df(Rcpp::IntegerVector rows, Rcpp::CharacterVector cols, Rcpp::Null
 
     } else { // insert cells into data frame
 
+      std::vector<size_t> fcls;
+      if (has_fcols) {
+        fcls = Rcpp::as<std::vector<size_t>>(fcols.get());
+      }
+
       for (size_t i = 0; i < kk; ++i) {
+        if (has_fcols && std::find(fcls.begin(), fcls.end(), i) == fcls.end())
+          continue;
         Rcpp::CharacterVector cvec = Rcpp::as<Rcpp::CharacterVector>(df[i]);
         std::string coli = Rcpp::as<std::string>(cols[i]);
         for (size_t j = 0; j < nn; ++j) {


### PR DESCRIPTION
``` r
library(openxlsx2)

n <- 5e5

data1 <- data.frame(
  T1 = rep("test", n),
  T2 = rep("test", n),
  T3 = rep(as.POSIXct("2024-01-01"), n),
  T4 = rep(as.POSIXct("2024-01-01"), n)
)

data2 <- data.frame(
  T1 = rep("test", n),
  T3 = rep(as.POSIXct("2024-01-01"), n),
  T2 = rep("test", n),
  T4 = rep(as.POSIXct("2024-01-01"), n)
)

fun <- function(x) {
  wb_workbook()$
    add_worksheet(
      sheet = "test",
      grid_lines = FALSE
    )$
    add_data(
      sheet = "test",
      x = x,
      na.strings = ""
    )
}

res <- microbenchmark::microbenchmark(
  fun(data1)
  ,
  fun(data2)
  ,
  times = 5
)
#> Warning in microbenchmark::microbenchmark(fun(data1), fun(data2), times = 5):
#> less accurate nanosecond times to avoid potential integer overflows
```

``` r
res
#> Unit: seconds
#>        expr      min       lq     mean   median       uq      max neval
#>  fun(data1) 3.862173 3.958761 4.018850 4.018531 4.088205 4.166579     5
#>  fun(data2) 4.180478 4.184563 4.464448 4.250347 4.312143 5.394709     5
```

This is the performance without this PR:
``` r
res
#> Unit: seconds
#>        expr      min       lq     mean   median       uq      max neval
#>  fun(data1) 3.929952 3.942532 4.212159 3.986681 4.006506 5.195121     5
#>  fun(data2) 5.501840 5.585661 5.651573 5.624333 5.699867 5.846163     5
```