### PR TITLE
Avoid adding the worksheet styling image on the CRAN vignette

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,3 +23,4 @@ cran-comments.md
 ^inst/img$
 ^tests/testthat/_snaps$
 ^tests/testthat/testfiles$
+vignettes/img/worksheet_styling.jpg

--- a/vignettes/openxlsx2_style_manual.Rmd
+++ b/vignettes/openxlsx2_style_manual.Rmd
@@ -28,6 +28,11 @@ incl_graph_in_pkgdown <- function(path) {
 }
 ```
 
+```{asis, echo=!in_pkgdown()}
+You can read the [styling vignette](https://janmarvin.github.io/openxlsx2/articles/openxlsx2_style_manual.html) online to see images.
+```
+
+
 Welcome to the styling manual for `openxlsx2`. In this manual you will learn how to use `openxlsx2` to style your worksheets. data from xlsx-files to R as well as how to export data from R to xlsx, and how to import and modify these `openxml` workbooks in R.
 
 ```{r}

--- a/vignettes/openxlsx2_style_manual.Rmd
+++ b/vignettes/openxlsx2_style_manual.Rmd
@@ -9,15 +9,30 @@ vignette: >
 
 
 ```{r setup, include = FALSE}
-library(openxlsx2)
 options(rmarkdown.html_vignette.check_title = FALSE)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+
+# Mechanism to avoid including all images in the package, but display them on
+# the pkgdown site
+in_pkgdown <- function() {
+  identical(Sys.getenv("IN_PKGDOWN"), "true")
+}
+
+incl_graph_in_pkgdown <- function(path) {
+  if (in_pkgdown()) {
+    knitr::include_graphics(path)
+  }
+}
 ```
 
 Welcome to the styling manual for `openxlsx2`. In this manual you will learn how to use `openxlsx2` to style your worksheets. data from xlsx-files to R as well as how to export data from R to xlsx, and how to import and modify these `openxml` workbooks in R.
+
+```{r}
+library(openxlsx2)
+```
 
 # Styling showcase
 
@@ -26,7 +41,7 @@ Welcome to the styling manual for `openxlsx2`. In this manual you will learn how
 Below we show you two ways how to create styled tables with `openxlsx2` one using the high level functions to style worksheet areas and one using the bare metal approach of creating the identical table. We show both ways to create styles in `openxlsx2` to show how you could build on our functions or create your very own functions.
 
 ```{r echo=FALSE, warning=FALSE, out.width="100%", fig.cap="The example below, with increased column width."}
-knitr::include_graphics("img/worksheet_styling.jpg")
+incl_graph_in_pkgdown("img/worksheet_styling.jpg")
 ```
 
 ### the quick way: using high level functions


### PR DESCRIPTION
I noticed that this image alone had 500 kb. 

Here is an approachto include this image only on pkgdown, but not on CRAN.

The cf images are pretty small around 30kb on average.