### PR TITLE
[write] skip blanks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openxlsx2 (development version)
 
+## New features
+
+* When writing a file with `na.strings = NULL`, the file will not contain any reference to the blank cell. Depending on the number of missings in a data set, this can reduce the file size significantly. [1111](https://github.com/JanMarvin/openxlsx2/pull/1111)
+
 ## Fixes
 
 * The integration of the shared formula feature in the previous release broke the silent extension of dims, if a single cell `dims` was provided for an `x` that was larger than a single cell in `wb_add_formula()`. [1131](https://github.com/JanMarvin/openxlsx2/pull/1131)

--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -96,6 +96,26 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
       }
     }
 
+    // update lastrow
+    lastrow = thisrow;
+
+    if ( // skip blank cells entirely
+        cc_c_s[i]   == "" &&
+        cc_c_t[i]   == "" &&
+        cc_c_cm[i]  == "" &&
+        cc_c_ph[i]  == "" &&
+        cc_c_vm[i]  == "" &&
+        cc_v[i]     == "" &&
+        cc_f[i]     == "" &&
+        cc_f_t[i]   == "" &&
+        cc_f_ref[i] == "" &&
+        cc_f_ca[i]  == "" &&
+        cc_f_si[i]  == "" &&
+        cc_is[i]    == ""
+    ) {
+      continue;
+    }
+
     // create node <c>
     pugi::xml_node cell = row.append_child("c");
 
@@ -170,9 +190,6 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
         cell.append_copy(is_node.first_child());
       }
     }
-
-    // update lastrow
-    lastrow = thisrow;
   }
 
   return doc;

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -281,7 +281,7 @@ test_that("write cells without data", {
   expect_equal(exp, got)
 
   sheet <- paste0(tmp_dir, "/xl/worksheets/sheet1.xml")
-  exp <- "<sheetData><row r=\"2\"><c r=\"B2\"/><c r=\"C2\"/></row><row r=\"3\"><c r=\"B3\"/><c r=\"C3\"/></row></sheetData>"
+  exp <- "<sheetData><row r=\"2\"/><row r=\"3\"/></sheetData>"
   got <- xml_node(sheet, "worksheet", "sheetData")
   expect_equal(exp, got)
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -809,7 +809,7 @@ test_that("writing na.strings = NULL works", {
   write_xlsx(matrix(NA, 2, 2), tmp, na.strings = NULL)
   wb <- wb_load(tmp)
 
-  exp <- ""
+  exp <- NA_character_
   got <- unique(wb$worksheets[[1]]$sheet_data$cc$v[3:6])
   expect_equal(exp, got)
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1239,3 +1239,23 @@ test_that("sheet is a valid argument in write_xlsx", {
   wb2 <- write_xlsx(x = mtcars, sheet = "data")
   expect_equal(wb1$get_sheet_names(), wb2$get_sheet_names())
 })
+
+test_that("skipping entirely blank cells works", {
+
+  tp <- temp_xlsx()
+
+  mm <- matrix(1:9, 3, 3)
+  mm[diag(mm)] <- NA
+
+  wb1  <- write_xlsx(x = mm, file = tp, col_names = FALSE, na.strings = NULL)
+  cc1  <- wb1$worksheets[[1]]$sheet_data$cc
+  got1 <- cc1[cc1$r %in% c("A1", "B2", "C3"), ]
+
+  wb2  <- wb_load(tp)
+  cc2  <- wb2$worksheets[[1]]$sheet_data$cc
+  got2 <- cc2[cc2$r %in% c("A1", "B2", "C3"), ]
+
+  expect_equal(3, nrow(got1))
+  expect_equal(0, nrow(got2))
+
+})


### PR DESCRIPTION
This PR skips blank cells entirely as discussed in #1110 .

This reduces the file size significantly for the example data provided and other sparse matrices that are thrown at `openxlsx2`, but due to possible faulty impacts, this is still unlikely to be added without extensive testing.

Maybe merge after the next release or never.