### PR TITLE
[misc] document compression level option. closes #1113

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -3325,12 +3325,17 @@ wbWorkbook <- R6::R6Class(
       # TODO make self$vbaProject be TRUE/FALSE
       tmpFile <- tempfile(tmpdir = tmpDir, fileext = if (isTRUE(self$vbaProject)) ".xlsm" else ".xlsx")
 
+      # typo until release 1.8
+      compr_level <- getOption("openxlsx2.compression_level") %||%
+        getOption("openxlsx2.compresssionevel") %||%
+        6L
+
       ## zip it
       zip::zip(
         zipfile = tmpFile,
         files = list.files(tmpDir, full.names = FALSE),
         recurse = TRUE,
-        compression_level = getOption("openxlsx2.compresssionevel", 6),
+        compression_level = compr_level,
         include_directories = FALSE,
         # change the working directory for this
         root = tmpDir,

--- a/R/openxlsx2-package.R
+++ b/R/openxlsx2-package.R
@@ -160,6 +160,7 @@
 #'    will be converted. `"1"` will be written as `1`
 #' * `options("openxlsx2.na.strings" = "#N/A")` consulted by `write_xlsx()`,
 #'   `wb_add_data()` and `wb_add_data_table()`.
+#' * `options("openxlsx2.compression_level" = 6)` compression level for the output file. Increasing compression and time consumed from 1-9.
 #' @name openxlsx2_options
 NULL
 # matches enum celltype

--- a/man/openxlsx2_options.Rd
+++ b/man/openxlsx2_options.Rd
@@ -35,5 +35,6 @@ to a cell with \code{\link[=wb_add_thread]{wb_add_thread()}}
 will be converted. \code{"1"} will be written as \code{1}
 \item \code{options("openxlsx2.na.strings" = "#N/A")} consulted by \code{write_xlsx()},
 \code{wb_add_data()} and \code{wb_add_data_table()}.
+\item \code{options("openxlsx2.compression_level" = 6)} compression level for the output file. Increasing compression and time consumed from 1-9.
 }
 }


### PR DESCRIPTION
Could you please double check @olivroy , I fixed a typo in `compressionlevel` (previously with three `s`, therefore no `l`). If you have a smarter solution at hand, I'm all ears :)

This looks kinda strange in comparison
```R
getOption("openxlsx2.compressionlevel", getOption("openxlsx2.compresssionevel", 6L))
```

[Edit] updated for the missing `l`