### PR TITLE
[vignette] add `purl = FALSE` to chunks using `ggplot2`. fixes #1073

### DIFF
--- a/vignettes/openxlsx2_charts_manual.Rmd
+++ b/vignettes/openxlsx2_charts_manual.Rmd
@@ -46,7 +46,7 @@ wb$add_worksheet("add_image")$add_image(file = myplot)
 
 You can include `{ggplot2}` plots similar to how you would include them with `openxlsx`. Call the plot first and afterwards use `wb_add_plot()`.
 
-```{r ggplot}
+```{r ggplot, purl = FALSE}
 if (requireNamespace("ggplot2")) {
 
 library(ggplot2)
@@ -67,7 +67,7 @@ wb$add_worksheet("add_plot")$
 
 If you want vector graphics that can be modified in spreadsheet software the `dml_xlsx()` device comes in handy. You can pass the output via `wb_add_drawing()`.
 
-```{r rvg}
+```{r rvg, purl = FALSE}
 if (requireNamespace("ggplot2") && requireNamespace("rvg")) {
 
 library(rvg)
@@ -164,4 +164,3 @@ wb <- wb %>%
 
 }
 ```
-


### PR DESCRIPTION
As discussed in https://github.com/yihui/knitr/issues/2338 this solves #1073.

Unfortunately, I can't say I fully understand the problem (and I can't say I'm a big fan of a certain party making everyone's life harder by letting people figure it out for themselves). 

If the environment variable `_R_CHECK_VIGNETTES_SKIP_RUN_MAYBE_` is `false`, for some reason `R CMD check openxlsx2_*` throws an error with the chart vignette in sections containing `ggplot2` (and `print()`). I assume this is somehow due to the fact that the `print()` statement is not available in non-interactive mode and another option would be to look for `interactive()`? Anyway, this problem is hidden with `R CMD check --as-cran openxlsx2_*`, which disables `knitr::purl()`.

Now for some reason the CRAN oldrel Macs are configured differently than all other machines ...

What's important to me is that the code in the vignettes is valid and works (and that I - preferably - never have to check that), so I didn't want to silence those parts entirely. Otherwise, I think it's fair to assume that no one else in the world is running R on a system configured similarly to the CRAN machines, so hopefully additional checks shouldn't be necessary.