### PR TITLE
[formula] Restore extending single cell dims for `wb_add_formula()`. fixes #1130

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openxlsx2
 Title: Read, Write and Edit 'xlsx' Files
-Version: 1.9
+Version: 1.9.0.9000
 Language: en-US
 Authors@R: c(
   person("Jordan Mark", "Barbone", email = "jmbarbone@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-9788-3628")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# openxlsx2 (development version)
+
+## Fixes
+
+* The integration of the shared formula feature in the previous release broke the silent extension of dims, if a single cell `dims` was provided for an `x` that was larger than a single cell in `wb_add_formula()`. [1131](https://github.com/JanMarvin/openxlsx2/pull/1131)
+
+
+***************************************************************************
+
 # openxlsx2 1.9
 
 ## New features

--- a/R/write.R
+++ b/R/write.R
@@ -1214,7 +1214,12 @@ do_write_formula <- function(
   if (array || enforce) {
     dfx <- data.frame("X" = x, stringsAsFactors = FALSE)
   } else {
-    dfx   <- dims_to_dataframe(dims)
+    # if dims a single cell and x > dfx, increase dfx
+    if (!grepl(":", dims) && (NROW(x) > 1 || NCOL(x) > 1)) {
+      dfx   <- dims_to_dataframe(wb_dims(x = x, from_dims = dims))
+    } else {
+      dfx   <- dims_to_dataframe(dims)
+    }
     dfx[] <- x
   }
 

--- a/tests/testthat/test-formulas.R
+++ b/tests/testthat/test-formulas.R
@@ -184,3 +184,22 @@ test_that("writing shared formulas works", {
   expect_equal(exp, got)
 
 })
+
+test_that("increase formula dims if required", {
+
+  fml <- c("SUM(A2:B2)", "SUM(A3:B3)")
+
+  # This only handles single cells, if C2 is passed and length(x) > 1
+  wb <- wb_workbook()$
+    add_worksheet()$
+    add_data(x = matrix(1:4, 2, 2))
+
+  wb1 <- wb_add_formula(wb, dims = "C2", x = fml)
+  wb2 <- wb_add_formula(wb, dims = "C2:D2", x = fml)
+
+  expect_equal(
+    wb1$worksheets[[1]]$sheet_data$cc,
+    wb2$worksheets[[1]]$sheet_data$cc
+  )
+
+})


### PR DESCRIPTION
If dims is a single cell and formula is larger than a single cell