### PR TITLE
[dims] column names should not be evaluated. fixes #1132

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The integration of the shared formula feature in the previous release broke the silent extension of dims, if a single cell `dims` was provided for an `x` that was larger than a single cell in `wb_add_formula()`. [1131](https://github.com/JanMarvin/openxlsx2/pull/1131)
 
+* Fixed a regression in the previous release, where `wb_dims()` would pass column names passed via `cols` to `col2int()` which could cause overflow errors resulting in a failing check. [1133](https://github.com/JanMarvin/openxlsx2/pull/1133)
+
 
 ***************************************************************************
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -715,8 +715,18 @@ wb_dims <- function(..., select = NULL) {
     cols_arg <- args[[cols_pos]]
   }
 
-  if (!is.null(cols_arg) && (min(col2int(cols_arg)) < 1L)) {
-    stop("You must supply positive values to `cols`")
+  if (!is.null(cols_arg)) {
+    # cols_arg could be name(s) in x or must indicate a positive integer
+    is_lwr_one <- FALSE
+    if (!is.null(args$x)) {
+      if (!all(cols_arg %in% names(args$x)))
+        is_lwr_one <- min(col2int(cols_arg)) < 1L
+    } else {
+      is_lwr_one <- min(col2int(cols_arg)) < 1L
+    }
+
+    if (is_lwr_one)
+      stop("You must supply positive values to `cols`")
   }
 
   # in case the user mixes up column and row

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -682,3 +682,26 @@ test_that("dims are quick", {
   expect_equal(ddims, edims)
 
 })
+
+test_that("wb_dims does not try to validate column names", {
+
+  df <- data.frame(
+    a1 = 1,
+    aa2 = 2,
+    aaa3 = 3,
+    aaaa4 = 4,
+    aaaaa5 = 5,
+    aaaaaa6 = 6,
+    aaaaaaa7 = 7,
+    aaaaaaaa8 = 8,
+    aaaaaaaaa9 = 9
+  )
+
+  exp <- paste0(LETTERS[1:9], "2")
+  got <- vector("character", length = ncol(df))
+  for (i in seq_along(df)) {
+    got[i] <- wb_dims(x = df, cols = colnames(df)[i], rows = 1)
+  }
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
fixes a regression in `wb_dims` that caused overflow errors resulting in a failing check for valid column input.