### PR TITLE
[styles] allow updates of font elements

### DIFF
--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -3321,6 +3321,7 @@ wb_add_fill <- function(
 #' @param shadow shadow
 #' @param extend extend
 #' @param vert_align vertical alignment
+#' @param update update
 #' @param ... ...
 #' @examples
 #'  wb <- wb_workbook() %>% wb_add_worksheet("S1") %>% wb_add_data("S1", mtcars)
@@ -3351,6 +3352,7 @@ wb_add_font <- function(
       scheme     = "",
       shadow     = "",
       vert_align = "",
+      update     = FALSE,
       ...
 ) {
   assert_workbook(wb)
@@ -3373,6 +3375,7 @@ wb_add_font <- function(
     scheme     = scheme,
     shadow     = shadow,
     vert_align = vert_align,
+    update     = update,
     ...        = ...
   )
 }

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -8442,6 +8442,7 @@ wbWorkbook <- R6::R6Class(
     #' @param shadow shadow
     #' @param extend extend
     #' @param vert_align vertical alignment
+    #' @param update update
     #' @return The `wbWorkbook`, invisibly
     add_font = function(
         sheet      = current_sheet(),
@@ -8462,6 +8463,7 @@ wbWorkbook <- R6::R6Class(
         scheme     = "",
         shadow     = "",
         vert_align = "",
+        update     = FALSE,
         ...
     ) {
       sheet <- private$get_sheet_index(sheet)
@@ -8496,9 +8498,27 @@ wbWorkbook <- R6::R6Class(
           u = underline,
           vertAlign = vert_align
         )
-        self$styles_mgr$add(new_font, new_font)
 
         xf_prev <- get_cell_styles(self, sheet, dim[[1]])
+
+        if (update) {
+          font_id  <- as.integer(sapply(xml_attr(xf_prev, "xf"), "[[", "fontId")) + 1L
+          font_xml <- self$styles_mgr$styles$fonts[[font_id]]
+
+          # read as data frame with xml elements
+          old_font <- read_font(read_xml(font_xml))
+          new_font <- read_font(read_xml(new_font))
+
+          # update elements
+          sel <- new_font != ""
+          old_font[sel] <- new_font[sel]
+
+          # write as xml font
+          new_font <- write_font(old_font)
+        }
+
+        self$styles_mgr$add(new_font, new_font)
+
         xf_new_font <- set_font(xf_prev, self$styles_mgr$get_font_id(new_font))
 
         self$styles_mgr$add(xf_new_font, xf_new_font)

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -3308,6 +3308,7 @@ provide simple font function
   scheme = "",
   shadow = "",
   vert_align = "",
+  update = FALSE,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -3348,6 +3349,8 @@ provide simple font function
 \item{\code{shadow}}{shadow}
 
 \item{\code{vert_align}}{vertical alignment}
+
+\item{\code{update}}{update}
 
 \item{\code{...}}{additional arguments}
 }

--- a/man/wb_add_font.Rd
+++ b/man/wb_add_font.Rd
@@ -23,6 +23,7 @@ wb_add_font(
   scheme = "",
   shadow = "",
   vert_align = "",
+  update = FALSE,
   ...
 )
 }
@@ -62,6 +63,8 @@ wb_add_font(
 \item{shadow}{shadow}
 
 \item{vert_align}{vertical alignment}
+
+\item{update}{update}
 
 \item{...}{...}
 }


### PR DESCRIPTION
Related to [this SO](https://stackoverflow.com/q/79056978/12340029). If `update = TRUE` all non empty font elements will be overwritten. At the moment it is not possible to set a font element to missing. All elements are initialized with either `""` or some value. Might need some additional thinking

``` r
library(openxlsx2)

wb <- wb_workbook() |>
  wb_add_worksheet() |>
  wb_add_data(x = letters) |>
  wb_add_font(dims = wb_dims(x = letters), name = "Calibri", size = 20) |>
  # updates only the font color
  wb_add_font(dims = wb_dims(x = letters), name = "", size = "", color = wb_color("orange"), update = TRUE)

if (interactive()) wb$open()
```
