### PR TITLE
[test] avoid using rnorm in checks. For some reason this is failing i…

### DIFF
--- a/tests/testthat/test-read_from_created_wb.R
+++ b/tests/testthat/test-read_from_created_wb.R
@@ -155,12 +155,15 @@ test_that("skipEmptyCols keeps empty named columns", {
 
 test_that("reading with pre defined types works", {
 
-  dat <- data.frame(
-    numeric = rnorm(n = 5),
-    integer = sample(1:5, 5, TRUE),
-    date = Sys.Date() - 0:4,
-    datetime = Sys.time() - 0:4,
-    character = letters[1:5]
+  dat <- structure(
+    list(numeric = c(0.837787044494525, 0.153373117836515, -1.13813693701195, 1.25381492106993, 0.426464221476814),
+         integer = c(4L, 5L, 2L, 1L, 1L),
+         date = structure(c(20023, 20022, 20021, 20020, 20019), class = "Date"),
+         datetime = structure(c(1730064568.89935, 1730064567.89935, 1730064566.89935, 1730064565.89935, 1730064564.89935), class = c("POSIXct", "POSIXt")),
+         character = c("a", "b", "c", "d", "e")
+         ),
+    class = "data.frame",
+    row.names = c(NA, -5L)
   )
 
   wb <- wb_workbook()$add_worksheet()$add_data(x = dat)


### PR DESCRIPTION
…n a current CRAN release, but we should be able to avoid this.


From [here](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/openxlsx2-00check.html)
```R
══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-read_from_created_wb.R:173:3'): reading with pre defined types works ──
  `got` (`actual`) not equal to `dat` (`expected`).
  
    `actual[[4]]`: 1729991700 1729991699 1729991698 1729991697 1729991696
  `expected[[4]]`: 1729988100 1729988099 1729988098 1729988097 1729988096
  
  [ FAIL 1 | WARN 0 | SKIP 69 | PASS 1624 ]
```