### PR TITLE
Add modify date, don't auto-change create date

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,12 @@
 ## New features
 
 * Add `hide_no_data_items` option in `wb_add_slicer()`. [1169](https://github.com/JanMarvin/openxlsx2/pull/1169)
+* `wb_set_properties()` now has a `datetime_modify` option. [1176](https://github.com/JanMarvin/openxlsx2/pull/1176)
 
 ## Fixes
 
 * Previously rows that trigger scientific notation (e.g. `1e+05`) would cause issues, when matched against a non scientific version.  [1170](https://github.com/JanMarvin/openxlsx2/pull/1170)
+* Create date is not reset to the present time in each call to `wb_set_properties()` [1176](https://github.com/JanMarvin/openxlsx2/pull/1176)
 * When using `wb_add_data_table(..., total_row = TRUE)` the last row of the returned data tabled was replaced with the total row. This caused loss of data. [1179](https://github.com/JanMarvin/openxlsx2/issues/1179)
 
 

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -14,6 +14,7 @@
 #' @param creator Creator of the workbook (your name). Defaults to login username or `options("openxlsx2.creator")` if set.
 #' @param title,subject,category,keywords,comments,manager,company Workbook property, a string.
 #' @param datetime_created The time of the workbook is created
+#' @param datetime_modified The time of the workbook was last modified
 #' @param theme Optional theme identified by string or number.
 #'   See **Details** for options.
 #' @param ... additional arguments
@@ -34,30 +35,32 @@
 #'   category = "sales"
 #' )
 wb_workbook <- function(
-  creator          = NULL,
-  title            = NULL,
-  subject          = NULL,
-  category         = NULL,
-  datetime_created = Sys.time(),
-  theme            = NULL,
-  keywords         = NULL,
-  comments         = NULL,
-  manager          = NULL,
-  company          = NULL,
+  creator           = NULL,
+  title             = NULL,
+  subject           = NULL,
+  category          = NULL,
+  datetime_created  = Sys.time(),
+  datetime_modified = NULL,
+  theme             = NULL,
+  keywords          = NULL,
+  comments          = NULL,
+  manager           = NULL,
+  company           = NULL,
   ...
 ) {
   wbWorkbook$new(
-    creator          = creator,
-    title            = title,
-    subject          = subject,
-    category         = category,
-    datetime_created = datetime_created,
-    theme            = theme,
-    keywords         = keywords,
-    comments         = comments,
-    manager          = manager,
-    company          = company,
-    ...              = ...
+    creator           = creator,
+    title             = title,
+    subject           = subject,
+    category          = category,
+    datetime_created  = datetime_created,
+    datetime_modified = datetime_modified,
+    theme             = theme,
+    keywords          = keywords,
+    comments          = comments,
+    manager           = manager,
+    company           = company,
+    ...               = ...
   )
 }
 
@@ -2767,7 +2770,7 @@ wb_get_properties <- function(wb) {
 
 #' @rdname properties-wb
 #' @export
-wb_set_properties <- function(wb, creator = NULL, title = NULL, subject = NULL, category = NULL, datetime_created = Sys.time(), modifier = NULL, keywords = NULL, comments = NULL, manager = NULL, company = NULL, custom = NULL) {
+wb_set_properties <- function(wb, creator = NULL, title = NULL, subject = NULL, category = NULL, datetime_created = NULL, datetime_modified = NULL, modifier = NULL, keywords = NULL, comments = NULL, manager = NULL, company = NULL, custom = NULL) {
   assert_workbook(wb)
   wb$clone()$set_properties(
     creator           = creator,
@@ -2775,6 +2778,7 @@ wb_set_properties <- function(wb, creator = NULL, title = NULL, subject = NULL, 
     subject           = subject,
     category          = category,
     datetime_created  = datetime_created,
+    datetime_modified = datetime_modified,
     modifier          = modifier,
     keywords          = keywords,
     comments          = comments,

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -25,6 +25,7 @@ Luca Braglia
 Luke Symes
 Martins Liberts
 Mikael Elenius
+Moritz Lell
 Noam Ross
 olivroy
 Philipp Schauberger

--- a/man/properties-wb.Rd
+++ b/man/properties-wb.Rd
@@ -14,7 +14,8 @@ wb_set_properties(
   title = NULL,
   subject = NULL,
   category = NULL,
-  datetime_created = Sys.time(),
+  datetime_created = NULL,
+  datetime_modified = NULL,
   modifier = NULL,
   keywords = NULL,
   comments = NULL,
@@ -31,6 +32,8 @@ wb_set_properties(
 \item{title, subject, category, keywords, comments, manager, company}{Workbook property, a string.}
 
 \item{datetime_created}{The time of the workbook is created}
+
+\item{datetime_modified}{The time of the workbook was last modified}
 
 \item{modifier}{A character string indicating who was the last person to modify the workbook}
 

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -279,6 +279,7 @@ Creates a new \code{wbWorkbook} object
   subject = NULL,
   category = NULL,
   datetime_created = Sys.time(),
+  datetime_modified = NULL,
   theme = NULL,
   keywords = NULL,
   comments = NULL,
@@ -298,6 +299,9 @@ Creates a new \code{wbWorkbook} object
 \item{\code{datetime_created}}{The datetime (as \code{POSIXt}) the workbook is
 created.  Defaults to the current \code{Sys.time()} when the workbook object
 is created, not when the Excel files are saved.}
+
+\item{\code{datetime_modified}}{The datetime (as \code{POSIXt}) that should be recorded
+as last modification date. Defaults to the creation date.}
 
 \item{\code{theme}}{Optional theme identified by string or number}
 
@@ -2459,7 +2463,8 @@ Set a property of a workbook
   title = NULL,
   subject = NULL,
   category = NULL,
-  datetime_created = Sys.time(),
+  datetime_created = NULL,
+  datetime_modified = NULL,
   modifier = NULL,
   keywords = NULL,
   comments = NULL,
@@ -2474,7 +2479,7 @@ Set a property of a workbook
 \describe{
 \item{\code{creator}}{character vector of creators. Duplicated are ignored.}
 
-\item{\code{title, subject, category, datetime_created, modifier, keywords, comments, manager, company, custom}}{A workbook property to set}
+\item{\code{title, subject, category, datetime_created, datetime_modified, modifier, keywords, comments, manager, company, custom}}{A workbook property to set}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/wb_workbook.Rd
+++ b/man/wb_workbook.Rd
@@ -10,6 +10,7 @@ wb_workbook(
   subject = NULL,
   category = NULL,
   datetime_created = Sys.time(),
+  datetime_modified = NULL,
   theme = NULL,
   keywords = NULL,
   comments = NULL,
@@ -24,6 +25,8 @@ wb_workbook(
 \item{title, subject, category, keywords, comments, manager, company}{Workbook property, a string.}
 
 \item{datetime_created}{The time of the workbook is created}
+
+\item{datetime_modified}{The time of the workbook was last modified}
 
 \item{theme}{Optional theme identified by string or number.
 See \strong{Details} for options.}

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -471,6 +471,16 @@ test_that("Loading a workbook with property preserves it.", {
 
 })
 
+test_that("Creation time is not changed by set_property unless specified", {
+  op <- options("openxlsx2.datetimeCreated" = NULL)
+  on.exit(options(op), add = TRUE)
+  t1 <- "2000-01-01T00:00:00Z"
+  wb <- wb_workbook(datetime_created = as.POSIXct(t1, tz = "UTC"))
+  wb$set_properties()
+  t2 <- wb$get_properties()[["datetime_created"]]
+  expect_equal(t1, t2)
+})
+
 test_that("failing to unzip works as expected", {
 
   # try to read from single file


### PR DESCRIPTION
I want to have openxlsx2 reset the authorship dates of my manually-generated test file to a default date, so that
it only shows up in git when its contents are saved and not when I do a save in excel without changes.

I could not do it because openxlsx2 automatically resets the create_date to the current time and does not have
a way of setting the modified date. This patch:

* Stops openxlsx2 from setting the create date with every call to `wb_set_property()`. Only in `wb_workbook()`, the current date is set as default create date
* Allows to manually set the last modified date