### PR TITLE
[wb_to_df] make equal sized non consecutive dims behave similar to unequal sized non concsecutive dims.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openxlsx2 (development version)
 
+## New features
+
+* Make non consecutive equal sized dims behave similar to non equal sized non consecutive dims. This makes `dims = "A1:A5,C1:D5"` behave similar to `dims = "A1,C1:D1,A2:A5,C2:D5"`.
+
 
 ***************************************************************************
 

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -38,6 +38,7 @@ dims_to_dataframe <- function(dims, fill = FALSE, empty_rm = FALSE) {
     full_cols <- sort(get_dims(dims, cols = TRUE))
 
     rows_out  <- unlist(full_rows)
+    rows_out  <- seq.int(rows_out[1], rows_out[2])
     cols_out  <- int2col(full_cols)
     full_cols <- full_cols - min(full_cols) # is always a zero offset
 

--- a/tests/testthat/test-wb_functions.R
+++ b/tests/testthat/test-wb_functions.R
@@ -513,6 +513,21 @@ test_that("improve non consecutive dims", {
   expect_contains(got, exp)
 })
 
+test_that("reading equal sized ranges works", {
+
+  df <- as.data.frame(matrix(rep(1:4, 4), 4, 4, byrow = TRUE))
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = df)
+
+  exp <- df[, -2]
+  got <- wb_to_df(wb, dims = "A1:A5,C1:D5")
+  expect_equal(exp, got, ignore_attr = TRUE)
+
+  got <- wb_to_df(wb, dims = "A1,C1:D1,A2:A5,C2:D5")
+  expect_equal(exp, got, ignore_attr = TRUE)
+
+})
+
 test_that("creating a formula matrix works", {
 
   df <- matrix(


### PR DESCRIPTION
`dims = "A1:A5,C1:D5"` behaves similar to `dims = "A1,C1:D1,A2:A5,C2:D5"`