### PR TITLE
[load] read file with d3p1 namespace

### DIFF
--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -470,3 +470,15 @@ test_that("file extension handling works", {
   expect_silent(wb_save(wb, file = tempfile(fileext = ".XLSM")))
 
 })
+
+test_that("loading d3p1 file works", {
+
+  fl  <- testfile_path("gh_issue_1194.xlsx")
+
+  df <- wb_to_df(fl)
+
+  exp <- c(1347, 31)
+  got <- dim(df)
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
Allows reading the file shared in https://github.com/tidyverse/readxl/issues/736 by @hidekoji. The xml scheme is somewhat inconsistent. For instance it is mixing all lower case letters and camel case: 
* in `[content_types.xml]` there is a reference to `sharedStrings.xml`, the same is in `/xl/_rels/workbook.xml.rels`
* in `xl/` there is `sharedstrings.xml`
* there is also a custom xml namespace `d3p1` available in `workbook.xml`

There might be other shenanigans with these type of files, after all this only contains two worksheets with data. It looks like some Japanese finance data, at least I can read IFRS? So far there is only this single file available, therefore not sure that I will merge this.

``` r
library(openxlsx2)
url <- "https://www.dropbox.com/scl/fi/jirejqyyxig0cikk6i2bn/P_P1.xlsx?rlkey=iwhm91t9npo40596me1lewls8&dl=1"
wb <- wb_load(url)
wb_to_df(wb, sheet = 2) %>% .[seq_len(5), seq_len(5)]
#>           NA NA.1         NA.2               NA.3 日経会社コード
#> 2 カネコ種苗    P セグメント１ 連結優先(IFRS優先)        0021804
#> 3 カネコ種苗    P セグメント２ 連結優先(IFRS優先)        0021804
#> 4 カネコ種苗    P セグメント３ 連結優先(IFRS優先)        0021804
#> 5 カネコ種苗    P セグメント４ 連結優先(IFRS優先)        0021804
#> 6 カネコ種苗    P セグメント５ 連結優先(IFRS優先)        0021804
```