### PR TITLE
[misc] further file type and file extension checking

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -2912,6 +2912,15 @@ wbWorkbook <- R6::R6Class(
         stop("File already exists!")
       }
 
+      valid_extensions <- c("xlsx", "xlsm") # "xlsb"
+      file_extension   <- tolower(tools::file_ext(file))
+
+      if (!file_extension %in% valid_extensions) {
+        warning("The file extension '", file_extension,
+        "' is invalid. Expected one of: ", paste0(valid_extensions, collapse = ", "),
+        call. = FALSE)
+      }
+
       ## temp directory to save XML files prior to compressing
       tmpDir <- file.path(tempfile(pattern = "workbookTemp_"))
       on.exit(unlink(tmpDir, recursive = TRUE), add = TRUE)

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -111,10 +111,11 @@ wb_load <- function(
     grep(pattern, xmlFiles, perl = perl, value = value, ...)
   }
 
-  ## Not used
+  ## We have found a zip file, but it must not necessarily be a spreadsheet
   ContentTypesXML   <- grep_xml("\\[Content_Types\\].xml$")
+  worksheetsXML     <- grep_xml("/worksheets/sheet[0-9]+")
 
-  if (length(ContentTypesXML) == 0 && !debug) {
+  if ((length(ContentTypesXML) == 0 || length(worksheetsXML) == 0) && !debug) {
     msg <- paste("File does not appear to be xlsx, xlsm or xlsb: ", file)
     stop(msg)
   }
@@ -134,7 +135,6 @@ wb_load <- function(
   workbookXMLRels   <- grep_xml("workbook.xml.rels")
 
   drawingsXML       <- grep_xml("drawings/drawing[0-9]+.xml$")
-  worksheetsXML     <- grep_xml("/worksheets/sheet[0-9]+")
 
   stylesBIN         <- grep_xml("styles.bin$")
   stylesXML         <- grep_xml("styles.xml$")

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -452,3 +452,21 @@ test_that("show_hyperlink works", {
   got <- has_hl$D[1]
   expect_equal(exp, got)
 })
+
+test_that("file extension handling works", {
+  docx_path <- "https://github.com/JanMarvin/msoc/raw/refs/heads/main/inst/extdata/Untitled1.docx"
+
+  # confusing error on docx
+  expect_error(wb_load(docx_path), "File does not appear to be xlsx, xlsm or xlsb")
+
+  wb <- wb_workbook()$add_worksheet()
+
+  # warns
+  expect_warning(wb_save(wb, file = tempfile(fileext = ".xslx")), "The file extension 'xslx' is invalid. Expected one of: xlsx, xlsm")
+  expect_warning(wb_save(wb, file = tempfile(fileext = ".docx")), "The file extension 'docx' is invalid. Expected one of: xlsx, xlsm")
+
+  # silent
+  expect_silent(wb_save(wb, file = tempfile(fileext = ".XLSX")))
+  expect_silent(wb_save(wb, file = tempfile(fileext = ".XLSM")))
+
+})


### PR DESCRIPTION
``` r
library(openxlsx2)

xlsx_path <- system.file("extdata", "openxlsx2_example.xlsx", package = "openxlsx2")
xslx_path <- tempfile(fileext = ".xslx")

file.copy(xlsx_path, xslx_path)
#> [1] TRUE

xls_path  <- system.file("extdata", "datasets.xls", package = "readxl")
docx_path <- system.file("doc_examples", "landscape.docx", package = "officer")
csv_path  <- system.file("csv", "pt.csv", package = "sf")

# typo path works
wb <- wb_load(xslx_path)

# confusing error on docx
wb_load(docx_path)
#> Error in wb_load(docx_path): File does not appear to be xlsx, xlsm or xlsb:  /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/officer/doc_examples/landscape.docx
wb_load(xls_path)
#> Error: Unable to open and load file:  /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/readxl/extdata/datasets.xls
wb_load(csv_path)
#> Error: Unable to open and load file:  /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/sf/csv/pt.csv

# warns
wb_save(wb, file = tempfile(fileext = ".xslx"))
#> Warning: The file extension 'xslx' is invalid. Expected one of: xlsx, xlsm
wb_save(wb, file = tempfile(fileext = ".docx"))
#> Warning: The file extension 'docx' is invalid. Expected one of: xlsx, xlsm

# silent
wb_save(wb, file = tempfile(fileext = ".XLSX"))
wb_save(wb, file = tempfile(fileext = ".XLSM"))

packageVersion("openxlsx2")
#> [1] '1.11.0.9000'
```