### PR TITLE
[misc] cleanups and avoid some unneeded `Rcpp::String`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## Fixes
 
-* Formulas that do not have a `A1` cell reference to increase, are now shareable too. `wb_add_formula(x = "1", dims = "A1:A2", shared = TRUE)`
+* The first formula in a workbook can now be a shared formula. [1223](https://github.com/JanMarvin/openxlsx2/pull/1223)
+* Avoid passing ASCII strings through `Rcpp::String()`. Previously all `cc` columns were passed through `Rcpp::String()` to avoid encoding issues on non unicode systems. [1224](https://github.com/JanMarvin/openxlsx2/pull/1224)
 
 
 ***************************************************************************

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -16,8 +16,8 @@ col_to_int <- function(x) {
     .Call(`_openxlsx2_col_to_int`, x)
 }
 
-ox_int_to_col <- function(cell) {
-    .Call(`_openxlsx2_ox_int_to_col`, cell)
+ox_int_to_col <- function(x) {
+    .Call(`_openxlsx2_ox_int_to_col`, x)
 }
 
 rbindlist <- function(x) {

--- a/R/converters.R
+++ b/R/converters.R
@@ -14,7 +14,7 @@ int2col <- function(x) {
     stop("x must be finite and numeric.")
   }
 
-  sapply(x, ox_int_to_col)
+  ox_int_to_col(x)
 }
 
 #' Convert Excel column to integer

--- a/R/read.R
+++ b/R/read.R
@@ -486,7 +486,7 @@ wb_to_df <- function(
   zz$cols <- match(cc$c_r, colnames(z)) - 1L
   zz$rows <- match(cc$row_r, rownames(z)) - 1L
 
-  zz <- zz[order(zz[, "cols"], zz[, "rows"]), ]
+  # zz <- zz[order(zz[, "cols"], zz[, "rows"]), ]
   if (any(zz$val == "", na.rm = TRUE)) zz <- zz[zz$val != "", ]
   long_to_wide(z, tt, zz)
 
@@ -658,7 +658,7 @@ wb_to_df <- function(
       fmls <- names(which(types[sel] == 6))
       # convert "#NUM!" to "NaN" -- then converts to NaN
       # maybe consider this an option to instead return NA?
-      if (length(nums)) z[nums] <- lapply(z[nums], function(i) as.numeric(ifelse(i == "#NUM!", "NaN", i)))
+      if (length(nums)) z[nums] <- lapply(z[nums], function(i) as.numeric(replace(i, i == "#NUM!", "NaN")))
       if (length(dtes)) z[dtes] <- lapply(z[dtes], date_conv, origin = origin)
       if (length(poxs)) z[poxs] <- lapply(z[poxs], datetime_conv, origin = origin)
       if (length(logs)) z[logs] <- lapply(z[logs], as.logical)

--- a/R/read.R
+++ b/R/read.R
@@ -432,7 +432,8 @@ wb_to_df <- function(
   }
 
   # remaining values are numeric?
-  if (any(sel <- is.na(cc$typ))) {
+  if (any(cc_tab %in% c("n", ""))) {
+    sel <- which(is.na(cc$typ))
     cc$val[sel] <- cc$v[sel]
     cc$typ[sel] <- "n"
   }

--- a/R/read.R
+++ b/R/read.R
@@ -235,14 +235,16 @@ wb_to_df <- function(
   # If no dims are requested via named_region, simply construct them from min
   # and max columns and row found on worksheet
   # TODO it would be useful to have both named_region and dims?
+  has_dims <- TRUE
   if (missing(named_region) && missing(dims)) {
+    has_dims <- FALSE
 
     sd <- wb$worksheets[[sheet]]$sheet_data$cc[c("row_r", "c_r")]
-    sd$row <- as.integer(sd$row_r)
-    sd$col <- col2int(sd$c_r)
+    row <- range(as.integer(unique(sd$row_r)))
+    col <- range(col2int(unique(sd$c_r)))
 
-    dims <- paste0(int2col(min(sd$col)), min(sd$row), ":",
-                   int2col(max(sd$col)), max(sd$row))
+    dims <- paste0(int2col(col[1]), row[1], ":",
+                   int2col(col[2]), row[2])
 
   }
 
@@ -336,7 +338,7 @@ wb_to_df <- function(
   keep_rows <- keep_rows[keep_rows %in% rnams]
 
   # reduce data to selected cases only
-  if (length(keep_rows) && length(keep_cols))
+  if (has_dims && length(keep_rows) && length(keep_cols))
     cc <- cc[cc$row_r %in% keep_rows & cc$c_r %in% keep_cols, ]
 
   cc$val <- NA_character_
@@ -656,7 +658,7 @@ wb_to_df <- function(
       fmls <- names(which(types[sel] == 6))
       # convert "#NUM!" to "NaN" -- then converts to NaN
       # maybe consider this an option to instead return NA?
-      if (length(nums)) z[nums] <- lapply(z[nums], function(i) as.numeric(replace(i, i == "#NUM!", "NaN")))
+      if (length(nums)) z[nums] <- lapply(z[nums], function(i) as.numeric(ifelse(i == "#NUM!", "NaN", i)))
       if (length(dtes)) z[dtes] <- lapply(z[dtes], date_conv, origin = origin)
       if (length(poxs)) z[poxs] <- lapply(z[poxs], datetime_conv, origin = origin)
       if (length(logs)) z[logs] <- lapply(z[logs], as.logical)

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -216,11 +216,15 @@ wb_load <- function(
   ## feature property bag
   featureProperty   <- grep_xml("featurePropertyBag.xml$")
 
+  cleanup_dir <- function(data_only) {
+    grep_xml("media|vmlDrawing|customXml|embeddings|activeX|vbaProject", ignore.case = TRUE, invert = TRUE)
+  }
+
   ## remove all EXCEPT media and charts
-  on.exit(
+  if (!data_only) on.exit(
     unlink(
-      # TODO: this removes all files, the folders remain. grep instead grep_xml?
-      grep_xml("media|vmlDrawing|customXml|embeddings|activeX|vbaProject", ignore.case = TRUE, invert = TRUE),
+      # TODO: this removes all files, the folders remain
+      cleanup_dir(data_only),
       recursive = TRUE, force = TRUE
     ),
     add = TRUE

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -45,13 +45,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // ox_int_to_col
-std::string ox_int_to_col(int32_t cell);
-RcppExport SEXP _openxlsx2_ox_int_to_col(SEXP cellSEXP) {
+Rcpp::CharacterVector ox_int_to_col(Rcpp::NumericVector x);
+RcppExport SEXP _openxlsx2_ox_int_to_col(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< int32_t >::type cell(cellSEXP);
-    rcpp_result_gen = Rcpp::wrap(ox_int_to_col(cell));
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(ox_int_to_col(x));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -118,34 +118,37 @@ SEXP openxlsx2_type(SEXP x) {
   return type;
 }
 
-
 // [[Rcpp::export]]
 Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x) {
 
   // This function converts the Excel column letter to an integer
   R_xlen_t n = static_cast<R_xlen_t>(x.size());
-
-  std::string a;
+  std::unordered_map<std::string, int> col_map;
   Rcpp::IntegerVector colNums(n);
 
-  for (R_xlen_t i = 0; i < n; i++) {
-    a = x[i];
+  for (R_xlen_t i = 0; i < n; ++i) {
+    std::string a = Rcpp::as<std::string>(x[i]);
 
     // check if the value is digit only, if yes, add it and continue the loop
     // at the top. This avoids slow:
     // suppressWarnings(isTRUE(as.character(as.numeric(x)) == x))
-    if (std::all_of(a.begin(), a.end(), ::isdigit))
-    {
+    if (std::all_of(a.begin(), a.end(), ::isdigit)) {
       colNums[i] = std::stoi(a);
       continue;
     }
 
-    // return index from column name
-    colNums[i] = cell_to_colint(a);
+    // Check if the column name is already in the map
+    if (col_map.find(a) != col_map.end()) {
+      colNums[i] = col_map[a];
+    } else {
+      // Compute the integer value and store it in the map
+      int col_int = cell_to_colint(a);
+      col_map[a] = col_int;
+      colNums[i] = col_int;
+    }
   }
 
   return colNums;
-
 }
 
 // [[Rcpp::export]]

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -343,8 +343,8 @@ void long_to_wide(Rcpp::DataFrame z, Rcpp::DataFrame tt, Rcpp::DataFrame zz) {
   R_xlen_t n = static_cast<R_xlen_t>(zz.nrow());
   R_xlen_t col = 0, row = 0;
 
-  Rcpp::IntegerVector rows = zz["rows"];
   Rcpp::IntegerVector cols = zz["cols"];
+  Rcpp::IntegerVector rows = zz["rows"];
   Rcpp::CharacterVector vals = zz["val"];
   Rcpp::CharacterVector typs = zz["typ"];
 

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -152,9 +152,26 @@ Rcpp::IntegerVector col_to_int(Rcpp::CharacterVector x) {
 }
 
 // [[Rcpp::export]]
-std::string ox_int_to_col(int32_t cell) {
-  uint32_t cell_u32 = static_cast<uint32_t>(cell);
-  return int_to_col(cell_u32);
+Rcpp::CharacterVector ox_int_to_col(Rcpp::NumericVector x) {
+  R_xlen_t n = static_cast<R_xlen_t>(x.size());
+  Rcpp::CharacterVector colNames(n);
+  std::unordered_map<int, std::string> cache;
+
+  for (R_xlen_t i = 0; i < n; ++i) {
+    uint32_t num = static_cast<uint32_t>(x[i]);
+
+    // Check if the column name is already in the cache
+    if (cache.find(num) != cache.end()) {
+      colNames[i] = cache[num];
+    } else {
+      // Compute the column name and store it in the cache
+      std::string col_name = int_to_col(num);
+      cache[num] = col_name;
+      colNames[i] = col_name;
+    }
+  }
+
+  return colNames;
 }
 
 // provide a basic rbindlist for lists of named characters

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -245,13 +245,11 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
           single_xml_col.r = buffer;
 
           // get col name
-          std::string colrow = buffer;
-          single_xml_col.c_r = rm_rownum(colrow);
+          single_xml_col.c_r = rm_rownum(buffer);
           has_colname = true;
 
           // get colnum
-          colrow = buffer;
-          single_xml_col.row_r = rm_colnum(colrow);
+          single_xml_col.row_r = rm_colnum(buffer);
 
           // if some cells of the workbook have colnames but other dont,
           // this will increase itr_cols and avoid duplicates in cc

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -98,7 +98,7 @@ Rcpp::CharacterVector df_to_xml(std::string name, Rcpp::DataFrame df_col) {
 }
 
 
-Rcpp::DataFrame row_to_df(XPtrXML doc) {
+inline Rcpp::DataFrame row_to_df(XPtrXML doc) {
 
   auto ws = doc->child("worksheet").child("sheetData");
 
@@ -246,21 +246,12 @@ void loadvals(Rcpp::Environment sheet_data, XPtrXML doc) {
 
           // get col name
           std::string colrow = buffer;
-          colrow.erase(std::remove_if(colrow.begin(),
-                                      colrow.end(),
-                                      &isdigit),
-                                      colrow.end());
-          single_xml_col.c_r = colrow;
+          single_xml_col.c_r = rm_rownum(colrow);
           has_colname = true;
 
           // get colnum
           colrow = buffer;
-          // remove numeric from string
-          colrow.erase(std::remove_if(colrow.begin(),
-                                      colrow.end(),
-                                      &isalpha),
-                                      colrow.end());
-          single_xml_col.row_r = colrow;
+          single_xml_col.row_r = rm_colnum(colrow);
 
           // if some cells of the workbook have colnames but other dont,
           // this will increase itr_cols and avoid duplicates in cc

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -85,6 +85,8 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
   Rcpp::CharacterVector is(no_init(n));        // <is> tag
 
   // struct to vector
+  // We have to convert utf8 inputs via Rcpp::String for non unicode R sessions
+  // Ideally there would be a function that calls Rcpp::String only if needed
   for (R_xlen_t i = 0; i < n; ++i) {
     size_t ii = static_cast<size_t>(i);
     if (!x[ii].r.empty())     r[i]     = std::string(x[ii].r);
@@ -93,9 +95,12 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
     if (!x[ii].c_s.empty())   c_s[i]   = std::string(x[ii].c_s);
     if (!x[ii].c_t.empty())   c_t[i]   = std::string(x[ii].c_t);
     if (!x[ii].c_cm.empty())  c_cm[i]  = std::string(x[ii].c_cm);
-    if (!x[ii].c_ph.empty())  c_ph[i]  = std::string(x[ii].c_ph);
+    if (!x[ii].c_ph.empty())  c_ph[i]  = Rcpp::String(x[ii].c_ph);
     if (!x[ii].c_vm.empty())  c_vm[i]  = std::string(x[ii].c_vm);
-    if (!x[ii].v.empty())     v[i]     = Rcpp::String(x[ii].v);
+    if (!x[ii].v.empty()) { // can only be utf8 if c_t = "str"
+        if (x[ii].c_t.empty()) v[i]    = std::string(x[ii].v);
+        else                   v[i]    = Rcpp::String(x[ii].v);
+    }
     if (!x[ii].f.empty())     f[i]     = Rcpp::String(x[ii].f);
     if (!x[ii].f_t.empty())   f_t[i]   = std::string(x[ii].f_t);
     if (!x[ii].f_ref.empty()) f_ref[i] = std::string(x[ii].f_ref);

--- a/src/openxlsx2_types.h
+++ b/src/openxlsx2_types.h
@@ -87,20 +87,20 @@ inline SEXP wrap(const std::vector<xml_col> &x) {
   // struct to vector
   for (R_xlen_t i = 0; i < n; ++i) {
     size_t ii = static_cast<size_t>(i);
-    if (!x[ii].r.empty())     r[i]     = Rcpp::String(x[ii].r);
-    if (!x[ii].row_r.empty()) row_r[i] = Rcpp::String(x[ii].row_r);
-    if (!x[ii].c_r.empty())   c_r[i]   = Rcpp::String(x[ii].c_r);
-    if (!x[ii].c_s.empty())   c_s[i]   = Rcpp::String(x[ii].c_s);
-    if (!x[ii].c_t.empty())   c_t[i]   = Rcpp::String(x[ii].c_t);
-    if (!x[ii].c_cm.empty())  c_cm[i]  = Rcpp::String(x[ii].c_cm);
-    if (!x[ii].c_ph.empty())  c_ph[i]  = Rcpp::String(x[ii].c_ph);
-    if (!x[ii].c_vm.empty())  c_vm[i]  = Rcpp::String(x[ii].c_vm);
+    if (!x[ii].r.empty())     r[i]     = std::string(x[ii].r);
+    if (!x[ii].row_r.empty()) row_r[i] = std::string(x[ii].row_r);
+    if (!x[ii].c_r.empty())   c_r[i]   = std::string(x[ii].c_r);
+    if (!x[ii].c_s.empty())   c_s[i]   = std::string(x[ii].c_s);
+    if (!x[ii].c_t.empty())   c_t[i]   = std::string(x[ii].c_t);
+    if (!x[ii].c_cm.empty())  c_cm[i]  = std::string(x[ii].c_cm);
+    if (!x[ii].c_ph.empty())  c_ph[i]  = std::string(x[ii].c_ph);
+    if (!x[ii].c_vm.empty())  c_vm[i]  = std::string(x[ii].c_vm);
     if (!x[ii].v.empty())     v[i]     = Rcpp::String(x[ii].v);
     if (!x[ii].f.empty())     f[i]     = Rcpp::String(x[ii].f);
-    if (!x[ii].f_t.empty())   f_t[i]   = Rcpp::String(x[ii].f_t);
-    if (!x[ii].f_ref.empty()) f_ref[i] = Rcpp::String(x[ii].f_ref);
-    if (!x[ii].f_ca.empty())  f_ca[i]  = Rcpp::String(x[ii].f_ca);
-    if (!x[ii].f_si.empty())  f_si[i]  = Rcpp::String(x[ii].f_si);
+    if (!x[ii].f_t.empty())   f_t[i]   = std::string(x[ii].f_t);
+    if (!x[ii].f_ref.empty()) f_ref[i] = std::string(x[ii].f_ref);
+    if (!x[ii].f_ca.empty())  f_ca[i]  = std::string(x[ii].f_ca);
+    if (!x[ii].f_si.empty())  f_si[i]  = std::string(x[ii].f_si);
     if (!x[ii].is.empty())    is[i]    = Rcpp::String(x[ii].is);
   }
 

--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -47,18 +47,18 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
   // Have to extract the columns and use these
   Rcpp::CharacterVector cc_row_r = cc["row_r"]; // 1
   Rcpp::CharacterVector cc_r     = cc["r"];     // A1
-  Rcpp::CharacterVector cc_v     = cc["v"];
+  Rcpp::CharacterVector cc_v     = cc["v"];     // can be utf8
   Rcpp::CharacterVector cc_c_t   = cc["c_t"];
   Rcpp::CharacterVector cc_c_s   = cc["c_s"];
   Rcpp::CharacterVector cc_c_cm  = cc["c_cm"];
-  Rcpp::CharacterVector cc_c_ph  = cc["c_ph"];
+  Rcpp::CharacterVector cc_c_ph  = cc["c_ph"];  // can be utf8
   Rcpp::CharacterVector cc_c_vm  = cc["c_vm"];
-  Rcpp::CharacterVector cc_f     = cc["f"];
+  Rcpp::CharacterVector cc_f     = cc["f"];     // can be utf8
   Rcpp::CharacterVector cc_f_t   = cc["f_t"];
   Rcpp::CharacterVector cc_f_ref = cc["f_ref"];
   Rcpp::CharacterVector cc_f_ca  = cc["f_ca"];
   Rcpp::CharacterVector cc_f_si  = cc["f_si"];
-  Rcpp::CharacterVector cc_is    = cc["is"];
+  Rcpp::CharacterVector cc_is    = cc["is"];    // can be utf8
 
   Rcpp::CharacterVector row_r    = row_attr["r"];
 
@@ -123,26 +123,26 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
     // additional attr list.
 
     // append attributes <c r="A1" ...>
-    cell.append_attribute("r") = to_string(cc_r[i]).c_str();
+    cell.append_attribute("r") = std::string(cc_r[i]).c_str();
 
-    if (!to_string(cc_c_s[i]).empty())
-      cell.append_attribute("s") = to_string(cc_c_s[i]).c_str();
+    if (!std::string(cc_c_s[i]).empty())
+      cell.append_attribute("s") = std::string(cc_c_s[i]).c_str();
 
     // assign type if not <v> aka numeric
-    if (!to_string(cc_c_t[i]).empty())
-      cell.append_attribute("t") = to_string(cc_c_t[i]).c_str();
+    if (!std::string(cc_c_t[i]).empty())
+      cell.append_attribute("t") = std::string(cc_c_t[i]).c_str();
 
     // CellMetaIndex: suppress curly brackets in spreadsheet software
-    if (!to_string(cc_c_cm[i]).empty())
-      cell.append_attribute("cm") = to_string(cc_c_cm[i]).c_str();
+    if (!std::string(cc_c_cm[i]).empty())
+      cell.append_attribute("cm") = std::string(cc_c_cm[i]).c_str();
 
     // phonetics spelling
-    if (!to_string(cc_c_ph[i]).empty())
+    if (!std::string(cc_c_ph[i]).empty())
       cell.append_attribute("ph") = to_string(cc_c_ph[i]).c_str();
 
     // suppress curly brackets in spreadsheet software
-    if (!to_string(cc_c_vm[i]).empty())
-      cell.append_attribute("vm") = to_string(cc_c_vm[i]).c_str();
+    if (!std::string(cc_c_vm[i]).empty())
+      cell.append_attribute("vm") = std::string(cc_c_vm[i]).c_str();
 
     // append nodes <c r="A1" ...><v>...</v></c>
 
@@ -150,19 +150,19 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
 
     // <f> ... </f>
     // f node: formula to be evaluated
-    if (!to_string(cc_f[i]).empty() || !to_string(cc_f_t[i]).empty() || !to_string(cc_f_si[i]).empty()) {
+    if (!std::string(cc_f[i]).empty() || !std::string(cc_f_t[i]).empty() || !std::string(cc_f_si[i]).empty()) {
       pugi::xml_node f = cell.append_child("f");
-      if (!to_string(cc_f_t[i]).empty()) {
-        f.append_attribute("t") = to_string(cc_f_t[i]).c_str();
+      if (!std::string(cc_f_t[i]).empty()) {
+        f.append_attribute("t") = std::string(cc_f_t[i]).c_str();
       }
-      if (!to_string(cc_f_ref[i]).empty()) {
-        f.append_attribute("ref") = to_string(cc_f_ref[i]).c_str();
+      if (!std::string(cc_f_ref[i]).empty()) {
+        f.append_attribute("ref") = std::string(cc_f_ref[i]).c_str();
       }
-      if (!to_string(cc_f_ca[i]).empty()) {
-        f.append_attribute("ca") = to_string(cc_f_ca[i]).c_str();
+      if (!std::string(cc_f_ca[i]).empty()) {
+        f.append_attribute("ca") = std::string(cc_f_ca[i]).c_str();
       }
-      if (!to_string(cc_f_si[i]).empty()) {
-        f.append_attribute("si") = to_string(cc_f_si[i]).c_str();
+      if (!std::string(cc_f_si[i]).empty()) {
+        f.append_attribute("si") = std::string(cc_f_si[i]).c_str();
         f_si = true;
       }
 
@@ -170,7 +170,7 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
     }
 
     // v node: value stored from evaluated formula
-    if (!to_string(cc_v[i]).empty()) {
+    if (!std::string(cc_v[i]).empty()) {
       if (!f_si & (to_string(cc_v[i]).compare(xml_preserver.c_str()) == 0)) {
         cell.append_child("v").append_attribute("xml:space").set_value("preserve");
         cell.child("v").append_child(pugi::node_pcdata).set_value(" ");
@@ -180,8 +180,8 @@ pugi::xml_document xml_sheet_data(Rcpp::DataFrame row_attr, Rcpp::DataFrame cc) 
     }
 
     // <is><t> ... </t></is>
-    if (to_string(cc_c_t[i]).compare("inlineStr") == 0) {
-      if (!to_string(cc_is[i]).empty()) {
+    if (std::string(cc_c_t[i]).compare("inlineStr") == 0) {
+      if (!std::string(cc_is[i]).empty()) {
 
         pugi::xml_document is_node;
         pugi::xml_parse_result result = is_node.load_string(to_string(cc_is[i]).c_str(), pugi_parse_flags);


### PR DESCRIPTION
TL;DR: This PR lifts the burden of calling `Rcpp::String()` for the `cc` columns `r`, `row_r` and `c_r`, which are filled for every cell of data frame (`A1`, `1` `A`). This should bring some speedups.

Back in the day we were troubled by non unicode systems which were unable to convert unicode characters into their locale. The solution is to pass strings through `Rcpp::String()` which makes sure that the correct locale is picked up. Unfortunately this is quite slow in comparison to `std::string()` (IIRC every string has to be created in R, contrary to `std::string()` which does not have to be passed to R). Using `Rcpp::String()` is not only slow, it also worsens with more data. Ultimately, if `Rcpp::String()` is called a lot, it will slow things down.

Sadly we will have to remain using `Rcpp::String()`, for the foreseeable future, because non unicode locales wont go away anytime soon. Maybe another solution is to use `enc2utf8()` and `enc2native()`, similarly to how IIRC `cpp11` does it, but this would require other code changes and I'm not entirely sure that we will see additional gains.

Still, we do not have to pass every cell of every `cc` column through `Rcpp::String()`. There are AFAIK only a few that can actually contain unicode strings and _only_ the ones containing unicode characters, actually benefit from `Rcpp::String()`:
`is` and maybe `ph` and in some rarer cases `v` (only in combination with `str`, otherwise it should always return integers or numerics) and `f` (formula using UTF8-strings). Hence, we should treat only these.

We have many more `Rcpp::String()` calls in the code, but (hopefully) these are not called hundreds of times (unless when parsing the shared string table) and would require further testing in non UTF-8 operating system and R. And I don't have any non UTF-8 system and I don't want to further research this :)