### PR TITLE
[load] apply fix when loading earlier created output files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,14 @@
 
 ## New features
 
-* A new experimental `flush` argument has been introduced to `wb_save()`, allowing a custom XML streaming function for worksheets to help prevent memory spikes. This feature has only been tested within `openxlsx2` and not extensively with spreadsheet software. Since it bypasses certain failsafe mechanisms, including XML validity checks, it should only be used as a last-resort solution. [1255](https://github.com/JanMarvin/openxlsx2/pull/1255)
+* A new experimental `flush` argument has been introduced to `wb_save()`, allowing a custom XML streaming function for worksheets to help prevent memory spikes. This feature has only been tested within `openxlsx2` and not extensively with spreadsheet software. Since it bypasses certain fail-safe mechanisms, including XML validity checks, it should only be used as a last-resort solution. [1255](https://github.com/JanMarvin/openxlsx2/pull/1255)
+  This expects all inputs to be UTF-8, therefore it might not work with R running in different locale sessions, if non ASCII characters are used.
 
 ## Fixes
 
 * Input validation has been added to `fmt_txt()`, similar to how it has been added to the `create_*()` family a while ago.
 * Aligned with the standard, `openxlsx2` now uses a `baseColWith` of `8` (previously `8.43`). The standard required an integer and we provided a float. This fixes an issue with third party software. [1284](https://github.com/JanMarvin/openxlsx2/pull/1284)
+  Files with the previously incorrect `baseColWidth` can be loaded and saved and the fix will be applied.
 
 ## Breaking changes
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -929,7 +929,11 @@ wb_load <- function(
         # wb$worksheets[[i]]$tableParts <- xml_node(worksheet_xml, "worksheet", "tableParts")
         wb$worksheets[[i]]$webPublishItems <- xml_node(worksheet_xml, "worksheet", "webPublishItems")
 
-        wb$worksheets[[i]]$sheetFormatPr <- xml_node(worksheet_xml, "worksheet", "sheetFormatPr")
+        # check if file loaded was written with incorrect baseColWidth by openxlsx2 <= 1.13
+        sheetFormatPrt <- xml_node(worksheet_xml, "worksheet", "sheetFormatPr")
+        if (sheetFormatPrt == "<sheetFormatPr baseColWidth=\"8.43\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>")
+          sheetFormatPrt <- "<sheetFormatPr baseColWidth=\"8\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>"
+        wb$worksheets[[i]]$sheetFormatPr <- sheetFormatPrt
 
         # extract freezePane from sheetViews. This intends to match our freeze
         # pane approach. Though I do not really like it. This blindly shovels

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -930,10 +930,10 @@ wb_load <- function(
         wb$worksheets[[i]]$webPublishItems <- xml_node(worksheet_xml, "worksheet", "webPublishItems")
 
         # check if file loaded was written with incorrect baseColWidth by openxlsx2 <= 1.13
-        sheetFormatPrt <- xml_node(worksheet_xml, "worksheet", "sheetFormatPr")
-        if (sheetFormatPrt == "<sheetFormatPr baseColWidth=\"8.43\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>")
-          sheetFormatPrt <- "<sheetFormatPr baseColWidth=\"8\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>"
-        wb$worksheets[[i]]$sheetFormatPr <- sheetFormatPrt
+        sheetFormatPr <- xml_node(worksheet_xml, "worksheet", "sheetFormatPr")
+        if (length(sheetFormatPr) && sheetFormatPr == "<sheetFormatPr baseColWidth=\"8.43\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>")
+          sheetFormatPr <- "<sheetFormatPr baseColWidth=\"8\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>"
+        wb$worksheets[[i]]$sheetFormatPr <- sheetFormatPr
 
         # extract freezePane from sheetViews. This intends to match our freeze
         # pane approach. Though I do not really like it. This blindly shovels

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -519,3 +519,20 @@ test_that("file with [trash] folder works", {
   expect_silent(wb <- wb_load(fl))
 
 })
+
+test_that("openxlsx2 until release 1.13 used a float for baseColWidth", {
+
+  tmp <- temp_xlsx()
+  was <- "<sheetFormatPr baseColWidth=\"8.43\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>"
+  fix <- "<sheetFormatPr baseColWidth=\"8\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>"
+
+  wb <- wb_workbook()$add_worksheet()
+  wb$worksheets[[1]]$sheetFormatPr <- was
+
+  wb$save(tmp)
+
+  wb <- wb_load(tmp)
+  got <- wb$worksheets[[1]]$sheetFormatPr
+  expect_equal(fix, got)
+
+})


### PR DESCRIPTION
``` r
wb <- openxlsx2::wb_load("https://foss.heptapod.net/-/project/322/uploads/01141236733f5f5173ded0f7dad5b59f/2_pis.xlsx")
wb$worksheets[[1]]$sheetFormatPr
#> [1] "<sheetFormatPr baseColWidth=\"8\" defaultRowHeight=\"16\" x14ac:dyDescent=\"0.2\"/>"
```