### PR TITLE
[read] treat blank inlineStr/sst as ""

### DIFF
--- a/src/strings_xml.cpp
+++ b/src/strings_xml.cpp
@@ -43,7 +43,7 @@ SEXP xml_to_txt(Rcpp::CharacterVector vec, std::string type) {
     std::string tmp = Rcpp::as<std::string>(vec[i]);
 
     if (tmp.compare("") == 0) {
-      res[i] = NA_STRING;
+      res[i] = "";
       continue;
     }
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -490,3 +490,9 @@ test_that("loading file with featurePropertyBag works", {
   expect_silent(wb <- wb_load(fl))
   expect_silent(wb$save(tmp))
 })
+
+test_that("blank inlineStr can be treated as na.string", {
+  xlsxFile <- testfile_path("pandas.xlsx")
+  df <- wb_to_df(xlsxFile)
+  expect_true(inherits(df$lspeed, "numeric"))
+})

--- a/tests/testthat/test-strings_xml.R
+++ b/tests/testthat/test-strings_xml.R
@@ -52,7 +52,7 @@ test_that("strings_xml", {
   is <- "<is><t>foo</t>"
   expect_error(is_to_txt(is))
 
-  exp <- c("a", NA_character_, "")
+  exp <- c("a", "", "")
   got <- is_to_txt(c("<is><t>a</t></is>", "", "<is><t/></is>"))
   expect_equal(exp, got)
 


### PR DESCRIPTION
Previously they were treated as `NA_character_`. This caused issues with files imported from third party software. In these files, cells with blank `inlineStr` were treated as character, irritating our guess column type logic resulting in character columns instead of numeric columns