### PR TITLE
[shape] enable markup compability

### DIFF
--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -1649,7 +1649,22 @@ create_shape <- function(
 
   standardize(...)
 
-  text <- fmt_txt2(text, text_color = text_color, text_transparency)
+  if (!is_xml(text)) {
+    # if not a a14:m node
+    text <- fmt_txt2(text, text_color = text_color, text_transparency)
+    mc_beg <- ""
+    mc_end <- ""
+  } else {
+    # we need some markup compability
+    mc_beg <- c(
+      '<mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+      <mc:Choice xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" Requires="a14">'
+    )
+    mc_end <- c(
+      '</mc:Choice>
+      </mc:AlternateContent>'
+    )
+  }
 
   line_color <- get_color(line_color, line_transparency)
   fill_color <- get_color(fill_color, fill_transparency)
@@ -1663,6 +1678,7 @@ create_shape <- function(
      <xdr:absoluteAnchor>
       <xdr:pos x="0" y="0" />
       <xdr:ext cx="0" cy="0" />
+      %s
       <xdr:sp macro="" textlink="">
        <xdr:nvSpPr>
         <xdr:cNvPr id="%s" name="%s" />
@@ -1709,11 +1725,14 @@ create_shape <- function(
         </a:p>
        </xdr:txBody>
       </xdr:sp>
+      %s
       <xdr:clientData />
      </xdr:absoluteAnchor>
      </xdr:wsDr>',
-    id, name, st_guid(), rotation * 60000, shape,
-    fill_color, line_color, text_align[1], text
+     mc_beg,
+     id, name, st_guid(), rotation * 60000, shape,
+     fill_color, line_color, text_align[1], text,
+     mc_end
   )
 
   read_xml(xml, pointer = FALSE)


### PR DESCRIPTION
This allows creating formula shapes (see #784):

``` r
library(openxlsx2)

xml_fml <- function(x) {
  out <- vapply(x, FUN = function(y) {
    sprintf(
      '<a14:m>
    <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
     <m:oMathParaPr>
      <m:jc m:val="centerGroup" />
     </m:oMathParaPr>
     %s
    </m:oMathPara>
  </a14:m>
  <a:endParaRPr lang="en-GB" sz="1100" />',
      read_xml(
        equatags::transform_mathjax(y, to = "mml"),
        pointer = FALSE)
    )
  }, FUN.VALUE = NA_character_)
  vapply(out, read_xml, pointer = FALSE, NA_character_)
}

eqs <- c(
  "x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}"
)

fml <- xml_fml(eqs)[1]

fml <- paste0(
  openxlsx2:::fmt_txt2("Some formula: \n"),
  fml
)

shp <- create_shape(text = fml, shape = "heart")

wb <- wb_workbook()$add_worksheet()$
  add_drawing(dims = "A1:D8", xml = shp)
if (interactive()) wb$open()
```
<img width="261" alt="Screenshot 2025-03-29 at 13 01 57" src="https://github.com/user-attachments/assets/ee567681-6908-423f-a063-550ddd5dbf45" />

