### PR TITLE
[write] Inf, -Inf, and NaN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Grouping of rows does no longer require the groups to be initialized in the worksheet. [1303](https://github.com/JanMarvin/openxlsx2/pull/1303)
 * Fix another case where `cc` was unintentionally shorten when applying a `cm` formula. Not sure if the cause for this is in the `cm` formula or in some other place.
 * `write_xlsx()` now handles `table_name` as documented. [1314](https://github.com/JanMarvin/openxlsx2/pull/1314)
+* Writing the character strings `"Inf"`, `"-Inf"`, and `"NaN"` is now possible.
 
 ## Internal changes
 

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -139,7 +139,9 @@ wb_save <- function(wb, file = NULL, overwrite = TRUE, path = NULL, flush = FALS
 #' not get picked up by `read_xlsx()`. This is because only the formula is written
 #' and left to Excel to evaluate the formula when the file is opened in Excel.
 #' The string `"_openxlsx_NA"` is reserved for `openxlsx2`.
-#' If the data frame contains this string, the output will be broken.
+#' If the data frame contains this string, the output will be broken. Similar
+#' factor labels `"_openxlsx_Inf"`, `"_openxlsx_nInf"`, and `"_openxlsx_NaN"`
+#' are reserved.
 #'
 #' Supported classes are data frames, matrices and vectors of various types and
 #' everything that can be converted into a data frame with `as.data.frame()`.

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -688,9 +688,9 @@ to_string <- function(x) {
   lbls <- attr(x, "labels")
   chr  <- as.character(x)
   if (!is.null(lbls) && !is.null(names(lbls))) {
-    lbls <- lbls[match(x, lbls)]
-    sel_l <- which(!is.na(lbls))
-    if (length(sel_l)) chr[sel_l] <- names(lbls[!is.na(lbls)])
+    idx <- match(x, lbls)
+    has_label <- !is.na(idx)
+    chr[has_label] <- names(lbls)[idx[has_label]]
   }
   chr
 }

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -702,11 +702,10 @@ to_string <- function(x) {
   # Only replace specials where no label was used
   chr[is.infinite(x_num) & x_num > 0 & !used_label] <- "_openxlsx_Inf"
   chr[is.infinite(x_num) & x_num < 0 & !used_label] <- "_openxlsx_nInf"
-  chr[is.nan(x_num)               & !used_label] <- "_openxlsx_NaN"
+  chr[is.nan(x_num)                  & !used_label] <- "_openxlsx_NaN"
 
   chr
 }
-
 
 # get the next free relationship id
 get_next_id <- function(x, increase = 1L) {

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -686,14 +686,27 @@ write_workbook.xml.rels <- function(x, rm_sheet = NULL) {
 #' @noRd
 to_string <- function(x) {
   lbls <- attr(x, "labels")
+  x_num <- suppressWarnings(as.numeric(as.character(x)))  # safely convert to numeric
   chr  <- as.character(x)
-  if (!is.null(lbls) && !is.null(names(lbls))) {
+
+  has_labels <- !is.null(lbls) && !is.null(names(lbls))
+  used_label <- logical(length(x))  # default to FALSE
+
+  if (has_labels) {
     idx <- match(x, lbls)
     has_label <- !is.na(idx)
+    used_label <- has_label
     chr[has_label] <- names(lbls)[idx[has_label]]
   }
+
+  # Only replace specials where no label was used
+  chr[is.infinite(x_num) & x_num > 0 & !used_label] <- "_openxlsx_Inf"
+  chr[is.infinite(x_num) & x_num < 0 & !used_label] <- "_openxlsx_nInf"
+  chr[is.nan(x_num)               & !used_label] <- "_openxlsx_NaN"
+
   chr
 }
+
 
 # get the next free relationship id
 get_next_id <- function(x, increase = 1L) {

--- a/man/wb_add_data.Rd
+++ b/man/wb_add_data.Rd
@@ -77,7 +77,9 @@ Formulae written using \code{\link[=wb_add_formula]{wb_add_formula()}} to a Work
 not get picked up by \code{read_xlsx()}. This is because only the formula is written
 and left to Excel to evaluate the formula when the file is opened in Excel.
 The string \code{"_openxlsx_NA"} is reserved for \code{openxlsx2}.
-If the data frame contains this string, the output will be broken.
+If the data frame contains this string, the output will be broken. Similar
+factor labels \code{"_openxlsx_Inf"}, \code{"_openxlsx_nInf"}, and \code{"_openxlsx_NaN"}
+are reserved.
 
 Supported classes are data frames, matrices and vectors of various types and
 everything that can be converted into a data frame with \code{as.data.frame()}.

--- a/man/wb_add_data_table.Rd
+++ b/man/wb_add_data_table.Rd
@@ -91,7 +91,9 @@ Formulae written using \code{\link[=wb_add_formula]{wb_add_formula()}} to a Work
 not get picked up by \code{read_xlsx()}. This is because only the formula is written
 and left to Excel to evaluate the formula when the file is opened in Excel.
 The string \code{"_openxlsx_NA"} is reserved for \code{openxlsx2}.
-If the data frame contains this string, the output will be broken.
+If the data frame contains this string, the output will be broken. Similar
+factor labels \code{"_openxlsx_Inf"}, \code{"_openxlsx_nInf"}, and \code{"_openxlsx_NaN"}
+are reserved.
 
 Supported classes are data frames, matrices and vectors of various types and
 everything that can be converted into a data frame with \code{as.data.frame()}.

--- a/man/write_datatable.Rd
+++ b/man/write_datatable.Rd
@@ -92,7 +92,9 @@ Formulae written using \code{\link[=wb_add_formula]{wb_add_formula()}} to a Work
 not get picked up by \code{read_xlsx()}. This is because only the formula is written
 and left to Excel to evaluate the formula when the file is opened in Excel.
 The string \code{"_openxlsx_NA"} is reserved for \code{openxlsx2}.
-If the data frame contains this string, the output will be broken.
+If the data frame contains this string, the output will be broken. Similar
+factor labels \code{"_openxlsx_Inf"}, \code{"_openxlsx_nInf"}, and \code{"_openxlsx_NaN"}
+are reserved.
 
 Supported classes are data frames, matrices and vectors of various types and
 everything that can be converted into a data frame with \code{as.data.frame()}.

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -550,11 +550,12 @@ void wide_to_long(
           }
         }
 
-      } else if (vtyp == numeric && strcmp(vals, "NaN") == 0) {
+      } else if ((vtyp == numeric && strcmp(vals, "NaN") == 0) || (vtyp == factor && strcmp(vals, "_openxlsx_NaN") == 0)) {
         // v = "#VALUE!"
         SET_STRING_ELT(zz_v,   pos, value_sexp);
         SET_STRING_ELT(zz_c_t, pos, expr_sexp);
-      } else if (vtyp == numeric && (strcmp(vals, "-Inf") == 0 || strcmp(vals, "Inf") == 0)) {
+      } else if ((vtyp == numeric && (strcmp(vals, "-Inf") == 0 || strcmp(vals, "Inf") == 0)) ||
+                 (vtyp == factor  && (strcmp(vals, "_openxlsx_nInf") == 0 || strcmp(vals, "_openxlsx_Inf") == 0))) {
         // v = "#NUM!"
         SET_STRING_ELT(zz_v,   pos, num_sexp);
         SET_STRING_ELT(zz_c_t, pos, expr_sexp);

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -550,11 +550,11 @@ void wide_to_long(
           }
         }
 
-      } else if (strcmp(vals, "NaN") == 0) {
+      } else if (vtyp == numeric && strcmp(vals, "NaN") == 0) {
         // v = "#VALUE!"
         SET_STRING_ELT(zz_v,   pos, value_sexp);
         SET_STRING_ELT(zz_c_t, pos, expr_sexp);
-      } else if (strcmp(vals, "-Inf") == 0 || strcmp(vals, "Inf") == 0) {
+      } else if (vtyp == numeric && (strcmp(vals, "-Inf") == 0 || strcmp(vals, "Inf") == 0)) {
         // v = "#NUM!"
         SET_STRING_ELT(zz_v,   pos, num_sexp);
         SET_STRING_ELT(zz_c_t, pos, expr_sexp);

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1488,3 +1488,11 @@ test_that("writing without pugixml works", {
   expect_silent(wb <- wb_load(temp))
 
 })
+
+test_that("writing Inf, -Inf and NaN works", {
+  x <- c("Inf", "-Inf", "NaN")
+  wb <- wb_workbook()$add_worksheet()$
+    add_data(x = x)
+  got <- wb$to_df(col_names = FALSE)$A
+  expect_equal(x, got)
+})

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1498,13 +1498,11 @@ test_that("writing Inf, -Inf and NaN works", {
 
   # labelled vector with Inf, -Inf, and NaN
   lbl <- c("INF", "-INF", "NAN")
-  df <- data.frame(
-    ff = structure(c(Inf, -Inf, NaN),
-                   labels = c(INF = Inf, `-INF` = -Inf, NAN = NaN),
-                   # "vctrs_vctr", breaks if labelled is not loaded
-                   class = c("haven_labelled", "double")
-    )
-  )
+  df <- structure(
+    list(ff = structure(c(Inf, -Inf, NaN),
+                        labels = c(INF = Inf, `-INF` = -Inf, NAN = NaN),
+                        class = c("haven_labelled", "double"))
+         ), class = "data.frame", row.names = c(NA, -3L))
   wb <- wb_workbook()$add_worksheet()$
     add_data(x = df, col_names = FALSE)
   got <- wb$to_df(col_names = FALSE)$A
@@ -1512,11 +1510,13 @@ test_that("writing Inf, -Inf and NaN works", {
 
   # And Something confusing
   lbl <- c("INF", "#NUM!", "NaN")
-  ff <- structure(c(Inf, -Inf, NaN),
-                  labels = c(INF = Inf, `NaN` = NaN),
-                  class = c("haven_labelled", "numeric"))
+  df <- structure(
+    list(ff = structure(c(Inf, -Inf, NaN),
+                        labels = c(INF = Inf, `NaN` = NaN),
+                        class = c("haven_labelled", "double"))
+         ), class = "data.frame", row.names = c(NA, -3L))
   wb <- wb_workbook()$add_worksheet()$
-    add_data(x = ff, col_names = FALSE)
+    add_data(x = df, col_names = FALSE)
   got <- wb$to_df(col_names = FALSE)$A
   expect_equal(lbl, got)
 })

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1495,4 +1495,14 @@ test_that("writing Inf, -Inf and NaN works", {
     add_data(x = x)
   got <- wb$to_df(col_names = FALSE)$A
   expect_equal(x, got)
+
+  # labelled vector with Inf, -Inf, and NaN
+  lbl <- c("INF", "-INF", "NAN")
+  ff <- structure(c(Inf, -Inf, NaN),
+                  labels = c(INF = Inf, `-INF` = -Inf, NAN = NaN),
+                  class = c("haven_labelled", "double"))
+  wb <- wb_workbook()$add_worksheet()$
+    add_data(x = ff, col_names = FALSE)
+  got <- wb$to_df(col_names = FALSE)$A
+  expect_equal(lbl, got)
 })

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -1498,9 +1498,23 @@ test_that("writing Inf, -Inf and NaN works", {
 
   # labelled vector with Inf, -Inf, and NaN
   lbl <- c("INF", "-INF", "NAN")
+  df <- data.frame(
+    ff = structure(c(Inf, -Inf, NaN),
+                   labels = c(INF = Inf, `-INF` = -Inf, NAN = NaN),
+                   # "vctrs_vctr", breaks if labelled is not loaded
+                   class = c("haven_labelled", "double")
+    )
+  )
+  wb <- wb_workbook()$add_worksheet()$
+    add_data(x = df, col_names = FALSE)
+  got <- wb$to_df(col_names = FALSE)$A
+  expect_equal(lbl, got)
+
+  # And Something confusing
+  lbl <- c("INF", "#NUM!", "NaN")
   ff <- structure(c(Inf, -Inf, NaN),
-                  labels = c(INF = Inf, `-INF` = -Inf, NAN = NaN),
-                  class = c("haven_labelled", "double"))
+                  labels = c(INF = Inf, `NaN` = NaN),
+                  class = c("haven_labelled", "numeric"))
   wb <- wb_workbook()$add_worksheet()$
     add_data(x = ff, col_names = FALSE)
   got <- wb$to_df(col_names = FALSE)$A


### PR DESCRIPTION
We can assign labels to `NaN` using `labelled`. Since R factors are integers, any `NaN`, `Inf` or `-Inf` will be converted to `NA`. And both the underlying value and the label will be lost, because we want to create a label for `NaN` and the actual value is now `NA_character_`.

``` r
factor(c(1, NaN, 3), c("1", "NAN", "3"))
#> [1] 1    <NA> 3   
#> Levels: 1 NAN 3
```
