### PR TITLE
[read] Document changes to reading date/datetime

### DIFF
--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -1315,10 +1315,15 @@ fits_in_dims <- function(x, dims, startCol, startRow) {
   dims
 }
 
-# transpose single column or row data frames to wide/long. keeps attributes and class
+# transpose single column or row data frames to wide/long. keeps attributes and
+# class.
+# The magic of t(). A Date can be something like a numeric with a
+# format attached. After t(x) it will be a string "yyyy-mm-dd".
+# Therefore unclass first and apply the class afterwards.
 transpose_df <- function(x) {
   attribs <- attr(x, "c_cm")
   classes <- class(x[[1]])
+  x[[1]] <- unclass(x[[1]])
   x <- as.data.frame(t(x), stringsAsFactors = FALSE)
   for (i in seq_along(x)) {
     class(x[[i]]) <- classes

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -1323,7 +1323,7 @@ fits_in_dims <- function(x, dims, startCol, startRow) {
 transpose_df <- function(x) {
   attribs <- attr(x, "c_cm")
   classes <- class(x[[1]])
-  x[[1]] <- unclass(x[[1]])
+  x[] <- lapply(x[], unclass)
   x <- as.data.frame(t(x), stringsAsFactors = FALSE)
   for (i in seq_along(x)) {
     class(x[[i]]) <- classes

--- a/R/read.R
+++ b/R/read.R
@@ -77,14 +77,17 @@ convert_df <- function(z, types, date_conv, datetime_conv, hms_conv, as_characte
 #' Opening, saving and closing the file in a spreadsheet software will resolve
 #' this.
 #'
-#' Prior to release `1.15`, datetime variables (yyyy-mm-dd hh:mm:ss) were
-#' imported in the users current timezone (`Sys.timezone()`). This was
-#' changed. All datetime variables are now imported with timezone `"UTC"`.
-#' If date detection is enabled, but fails, fails (e.g., in a mixed column
-#' of strings/numerics and dates), the date might appear as a unix time
-#' stamp. This can be converted using [as.POSIXct()] If date detection is
-#' disabled, dates might appear as spreadsheet date that can be converted
-#' with [convert_date()], [convert_datetime] or [convert_hms()].
+#' Before release 1.15, datetime variables (in 'yyyy-mm-dd hh:mm:ss' format)
+#' were imported using the user's local system timezone (`Sys.timezone()`).
+#' This behavior has been updated. Now, all datetime variables are imported
+#' with the timezone set to "UTC".
+#' If automatic date detection and conversion are enabled but the conversion
+#' is unsuccessful (for instance, in a column containing a mix of data types
+#' like strings, numbers, and dates), the dates will be displayed as a Unix
+#' timestamp. These can be transformed using the [as.POSIXct()] function.
+#' If date detection is disabled, dates will show up as a spreadsheet date
+#' format. To convert these, you can use the functions [convert_date()],
+#' [convert_datetime()], or [convert_hms()].
 #'
 #' @seealso [wb_get_named_regions()]
 #'

--- a/R/read.R
+++ b/R/read.R
@@ -80,6 +80,11 @@ convert_df <- function(z, types, date_conv, datetime_conv, hms_conv, as_characte
 #' Prior to release `1.15`, datetime variables (yyyy-mm-dd hh:mm:ss) were
 #' imported in the users current timezone (`Sys.timezone()`). This was
 #' changed. All datetime variables are now imported with timezone `"UTC"`.
+#' If date detection is enabled, but fails, fails (e.g., in a mixed column
+#' of strings/numerics and dates), the date might appear as a unix time
+#' stamp. This can be converted using [as.POSIXct()] If date detection is
+#' disabled, dates might appear as spreadsheet date that can be converted
+#' with [convert_date()], [convert_datetime] or [convert_hms()].
 #'
 #' @seealso [wb_get_named_regions()]
 #'

--- a/man/wb_to_df.Rd
+++ b/man/wb_to_df.Rd
@@ -172,6 +172,11 @@ this.
 Prior to release \code{1.15}, datetime variables (yyyy-mm-dd hh:mm:ss) were
 imported in the users current timezone (\code{Sys.timezone()}). This was
 changed. All datetime variables are now imported with timezone \code{"UTC"}.
+If date detection is enabled, but fails, fails (e.g., in a mixed column
+of strings/numerics and dates), the date might appear as a unix time
+stamp. This can be converted using \code{\link[=as.POSIXct]{as.POSIXct()}} If date detection is
+disabled, dates might appear as spreadsheet date that can be converted
+with \code{\link[=convert_date]{convert_date()}}, \link{convert_datetime} or \code{\link[=convert_hms]{convert_hms()}}.
 }
 \examples{
 ###########################################################################

--- a/man/wb_to_df.Rd
+++ b/man/wb_to_df.Rd
@@ -169,14 +169,17 @@ to be evaluated when the file is opened in a spreadsheet software.
 Opening, saving and closing the file in a spreadsheet software will resolve
 this.
 
-Prior to release \code{1.15}, datetime variables (yyyy-mm-dd hh:mm:ss) were
-imported in the users current timezone (\code{Sys.timezone()}). This was
-changed. All datetime variables are now imported with timezone \code{"UTC"}.
-If date detection is enabled, but fails, fails (e.g., in a mixed column
-of strings/numerics and dates), the date might appear as a unix time
-stamp. This can be converted using \code{\link[=as.POSIXct]{as.POSIXct()}} If date detection is
-disabled, dates might appear as spreadsheet date that can be converted
-with \code{\link[=convert_date]{convert_date()}}, \link{convert_datetime} or \code{\link[=convert_hms]{convert_hms()}}.
+Before release 1.15, datetime variables (in 'yyyy-mm-dd hh:mm:ss' format)
+were imported using the user's local system timezone (\code{Sys.timezone()}).
+This behavior has been updated. Now, all datetime variables are imported
+with the timezone set to "UTC".
+If automatic date detection and conversion are enabled but the conversion
+is unsuccessful (for instance, in a column containing a mix of data types
+like strings, numbers, and dates), the dates will be displayed as a Unix
+timestamp. These can be transformed using the \code{\link[=as.POSIXct]{as.POSIXct()}} function.
+If date detection is disabled, dates will show up as a spreadsheet date
+format. To convert these, you can use the functions \code{\link[=convert_date]{convert_date()}},
+\code{\link[=convert_datetime]{convert_datetime()}}, or \code{\link[=convert_hms]{convert_hms()}}.
 }
 \examples{
 ###########################################################################

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -184,7 +184,7 @@ test_that("date conversion works", {
 
   # conversion works for rownames
   df <- data.frame(
-    x = x,
+    x = as.Date(paste0("2025-0", 1:4, "-01")),
     y = 1:4
   )
   wb <- wb_workbook()$add_worksheet()

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -159,3 +159,38 @@ test_that("date 1904 works as expected", {
   # ignore rounding differences
   expect_equal(as.Date(df$pos), as.Date(got[["pos"]], tz = "UTC"))
 })
+
+test_that("date conversion works", {
+
+  wb <- wb_workbook()$add_worksheet()
+  wb$add_data(dims = "A1:D1", x = as.Date(paste0("2025-0", 1:4, "-01")), col_names = FALSE)
+  wb$add_data(dims = "A2:D4", x = matrix(1:12, 3, 4), col_names = FALSE)
+
+  # column name is converted date, column is numeric
+  df <- wb$to_df()
+  expect_true(is.numeric(df$`2025-01-01`))
+
+  # column name is converted date, column is character
+  df <- wb$to_df(convert = FALSE)
+  expect_true(is.character(df$`2025-01-01`))
+
+  # column name is spreadsheet date, column is numeric
+  df <- wb$to_df(convert = TRUE, detect_dates = FALSE)
+  expect_true(is.numeric(df$`45658`))
+
+  # column name is spreadsheet date, column is character
+  df <- wb$to_df(convert = FALSE, detect_dates = FALSE)
+  expect_true(is.character(df$`45658`))
+
+  # conversion works for rownames
+  df <- data.frame(
+    x = x,
+    y = 1:4
+  )
+  wb <- wb_workbook()$add_worksheet()
+  wb$add_data(x = df)
+  df <- wb$to_df(row_names = TRUE)
+  exp <- c("2025-01-01", "2025-02-01", "2025-03-01", "2025-04-01")
+  got <- rownames(df)
+  expect_equal(exp, got)
+})

--- a/tests/testthat/test-named_regions.R
+++ b/tests/testthat/test-named_regions.R
@@ -48,7 +48,7 @@ test_that("Maintaining Named Regions on Load", {
 
   # nonsense
   # df1 is a single value and this single value is now used as rowName
-  expect_warning(df1 <- read_xlsx(wb, named_region = "region1", row_names = TRUE))
+  df1 <- read_xlsx(wb, named_region = "region1", row_names = TRUE)
   expect_s3_class(df1, "data.frame")
   expect_equal(nrow(df1), 0)
   expect_equal(ncol(df1), 0)


### PR DESCRIPTION
closes #1334

Various things can happen with date/datetime variables.
* date detection enabled and works
  * conversion to date/datetime (either to a character, if `convert = FALSE` or to a Date/POSIXct column)
  * mixed column not primarily dates: conversion to unixtime (probably the most confusing change)

*  date detection disabled
   * date/datetime will show as spreadsheet date

``` r
library(openxlsx2)
packageVersion("openxlsx2")
#> [1] '1.14.0.9000'

wb <- wb_workbook()$add_worksheet()
wb$add_data(dims = "A1", x = "Var1")
wb$add_data(dims = "A2", x = "2024-01-01")
wb$add_data(dims = "A3", x = as.Date("2024-01-01"))

## mixed column - date is unixtimestamp
wb$to_df()
#>                Var1
#> 2        2024-01-01
#> 3 1704067200.000000

## date is converted to character
wb$to_df(convert = FALSE)
#>         Var1
#> 2 2024-01-01
#> 3 2024-01-01

## without date detection - date is spreadsheet date
wb$to_df(detect_dates = FALSE)
#>         Var1
#> 2 2024-01-01
#> 3      45292

## without date detection - date is spreadsheet date
wb$to_df(detect_dates = FALSE, convert = FALSE)
#>         Var1
#> 2 2024-01-01
#> 3      45292
```