### PR TITLE
[read] reduce date/datetime differences to releases prior 1.15

### DIFF
--- a/R/dates.R
+++ b/R/dates.R
@@ -29,7 +29,9 @@
 #' x <- 0.50918982
 #' convert_hms(x)
 convert_date <- function(x, origin = "1900-01-01", ...) {
-  out <- date_to_unix(x, origin = origin, datetime = FALSE)
+  sel <- is_charnum(x)
+  out <- x
+  out[sel] <- date_to_unix(x[sel], origin = origin, datetime = FALSE)
   out <- as.double(out)
   .Date(out)
 }
@@ -37,7 +39,9 @@ convert_date <- function(x, origin = "1900-01-01", ...) {
 #' @rdname convert_date
 #' @export
 convert_datetime <- function(x, origin = "1900-01-01", ...) {
-  out <- date_to_unix(x, origin = origin, datetime = TRUE)
+  sel <- is_charnum(x)
+  out <- x
+  out[sel] <- date_to_unix(x[sel], origin = origin, datetime = TRUE)
   out <- as.double(out)
   tz <- ifelse(!is.null(tz <- list(...)$tz), tz, "UTC")
   .POSIXct(out, tz)

--- a/R/write.R
+++ b/R/write.R
@@ -1016,7 +1016,7 @@ write_data_table <- function(
     if (transpose) x <- transpose_df(x)
   }
 
-  if (is.vector(x) || is.factor(x) || inherits(x, "Date") || inherits(x, "POSIXt") || inherits(x, "character")) {
+  if (is.vector(x) || is.factor(x) || inherits(x, "Date") || inherits(x, "POSIXt") || inherits(x, "difftime") || inherits(x, "character")) {
     colNames <- FALSE
   } ## this will go to coerce.default and rowNames will be ignored
 

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -242,4 +242,11 @@ test_that("conversion works", {
   got <- wb$to_df(start_row = 2, convert = FALSE)
   expect_equal(exp, got)
 
+  exp <- structure(c(NA, 19838), class = "Date")
+  expect_warning(got <- wb$to_df(types = c(Var3 = "Date")), "coercion")
+  expect_equal(exp, got$Var3)
+
+  exp <- structure(c(NA, 1706745600), class = c("POSIXct", "POSIXt"), tzone = "UTC")
+  expect_warning(got <- wb$to_df(types = c(Var1 = "POSIXct")), "coercion")
+  expect_equal(exp, got$Var1)
 })

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -194,3 +194,52 @@ test_that("date conversion works", {
   got <- rownames(df)
   expect_equal(exp, got)
 })
+
+test_that("conversion works", {
+
+  wb <- wb_workbook()$add_worksheet()
+  # row 1 column name
+  wb$add_data(dims = "A1", x = "Var1")
+  wb$add_data(dims = "B1", x = "Var2")
+  wb$add_data(dims = "C1", x = "Var3")
+  # row 2 character
+  wb$add_data(dims = "A2", x = "2024-01-31")
+  wb$add_data(dims = "B2", x = "2024-01-31")
+  wb$add_data(dims = "C2", x = "2024-01-31")
+  # various dates
+  wb$add_data(dims = "A3", x = as.Date("2024-02-01"))
+  wb$add_data(dims = "B3", x = structure(1234, units = "secs", class = c("hms", "difftime")))
+  wb$add_data(dims = "C3", x = as.POSIXct("2024-04-25 08:47:03", tz = "UTC"))
+
+  exp <- structure(
+    list(
+      Var1 = c("2024-01-31", "2024-02-01"),
+      Var2 = c("2024-01-31", "00:20:34"),
+      Var3 = c("2024-01-31", "2024-04-25 08:47:03")
+    ), row.names = 2:3, class = "data.frame")
+  got <- wb$to_df()
+  expect_equal(exp, got)
+
+  got <- wb$to_df(convert = FALSE)
+  expect_equal(exp, got)
+
+  exp <- structure(
+    list(
+      `2024-01-31` = structure(19754, class = "Date"),
+      `2024-01-31` = "00:20:34",
+      `2024-01-31` = structure(1714034823, class = c("POSIXct", "POSIXt"), tzone = "UTC")
+    ), row.names = 3L, class = "data.frame")
+
+  got <- wb$to_df(start_row = 2)
+  expect_equal(exp, got)
+
+  exp <- structure(
+    list(
+      `2024-01-31` = "2024-02-01",
+      `2024-01-31` = "00:20:34",
+      `2024-01-31` = "2024-04-25 08:47:03"
+    ), row.names = 3L, class = "data.frame")
+  got <- wb$to_df(start_row = 2, convert = FALSE)
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
``` r
library(openxlsx2)
packageVersion("openxlsx2")
#> [1] '1.14.0.9000'

wb <- wb_workbook()$add_worksheet()
# row 1 column name
wb$add_data(dims = "A1", x = "Var1")
wb$add_data(dims = "B1", x = "Var2")
wb$add_data(dims = "C1", x = "Var3")
# row 2 character
wb$add_data(dims = "A2", x = "2024-01-31")
wb$add_data(dims = "B2", x = "2024-01-31")
wb$add_data(dims = "C2", x = "2024-01-31")
# various dates
wb$add_data(dims = "A3", x = as.Date("2024-02-01"))
wb$add_data(dims = "B3", x = structure(1234, units = "secs", class = c("hms", "difftime")))
wb$add_data(dims = "C3", x = as.POSIXct("2024-04-25 08:47:03", tz = "UTC"))

wb$to_df()
#>         Var1       Var2                Var3
#> 2 2024-01-31 2024-01-31          2024-01-31
#> 3 2024-02-01   00:20:34 2024-04-25 08:47:03
```