### PR TITLE
Add an option to specify colour in a RGBA format (default in R) -- Fix for #1340

### DIFF
--- a/R/class-color.R
+++ b/R/class-color.R
@@ -30,7 +30,7 @@ wb_color <- function(
     tint = NULL,
     format = c("ARGB", "RGBA")
   ) {
-  format = match.arg(format)
+  format <- match.arg(format)
 
   if (!is.null(name)) hex <-  validate_color(name, format = format)
   if (!is.null(hex))  hex <-  validate_color(hex, format = format)

--- a/R/class-color.R
+++ b/R/class-color.R
@@ -1,12 +1,23 @@
 #' Helper to create a color
 #'
 #' Creates a `wbColour` object.
-#' @param name A name of a color known to R either as name or RGB/ARGB value.
+#'
+#' The **format** of the hex color representation  can be either RGB, ARGB, or RGBA.
+#' These hex formats differ only in a way how they encode the transparency value alpha,
+#' ARGB expecting the alpha value before the RGB values (default in spreadsheets),
+#' RGBA expects the alpha value after the RGB values (default in R),
+#' and RGB is not encoding transparency at all.
+#' If the colors some from functions such as `adjustcolor` that provide color in the
+#' RGBA format, it is necessary to specify the `format = "RGBA"` when calling the
+#' `wb_color()` function.
+#'
+#' @param name A name of a color known to R either as name or RGB/ARGB/RGBA value.
 #' @param auto A boolean.
 #' @param indexed An indexed color value. This color has to be provided by the workbook.
-#' @param hex A rgb color either a ARGB hex value or RGB hex value With or without leading "#".
+#' @param hex A rgb color a RGB/ARGB/RGBA hex value with or without leading "#".
 #' @param theme A zero based index referencing a value in the theme.
 #' @param tint A tint value applied. Range from -1 (dark) to 1 (light).
+#' @param format A colour format, one of ARGB (default) or RGBA.
 #' @seealso [wb_get_base_colors()] [grDevices::colors()]
 #' @return a `wbColour` object
 #' @export
@@ -16,11 +27,13 @@ wb_color <- function(
     indexed = NULL,
     hex = NULL,
     theme = NULL,
-    tint = NULL
+    tint = NULL,
+    format = c("ARGB", "RGBA")
   ) {
+  format = match.arg(format)
 
-  if (!is.null(name)) hex <-  validate_color(name)
-  if (!is.null(hex))  hex <-  validate_color(hex)
+  if (!is.null(name)) hex <-  validate_color(name, format = format)
+  if (!is.null(hex))  hex <-  validate_color(hex, format = format)
 
   z <- c(
     auto    = as_xml_attr(auto),

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -136,7 +136,7 @@ validate_color <- function(
     s <- nchar(color) == 8
     alpha <- substring(color[s], 7, 8)
     color[s] <- paste0(alpha, substring(color[s], 1, 6))
-    }
+  }
 
   ## create a total size of 8 in ARGB format
   color <- stringi::stri_pad_left(str = color, width = 8, pad = "F")

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -106,7 +106,12 @@ col2hex <- function(my.col) {
 #' @param envir parent frame for use in assert
 #' @param msg return message
 #' @noRd
-validate_color <- function(color = NULL, or_null = FALSE, envir = parent.frame(), msg = NULL) {
+validate_color <- function(
+  color = NULL, or_null = FALSE,
+  envir = parent.frame(), msg = NULL,
+  format = c("ARGB", "RGBA")
+){
+  format <- match.arg(format)
   sx <- as.character(substitute(color, envir))
 
   if (identical(color, "none") && or_null) {
@@ -125,6 +130,13 @@ validate_color <- function(color = NULL, or_null = FALSE, envir = parent.frame()
 
   # remove any # from color strings
   color <- gsub("^#", "", toupper(color))
+
+  # if the format is RGBA (R's default), switch first two with last two characters
+  if(format == "RGBA"){
+    s <- nchar(color) == 8
+    alpha <- substring(color[s], 7, 8)
+    color[s] <- paste0(alpha, substring(color[s], 1, 6))
+    }
 
   ## create a total size of 8 in ARGB format
   color <- stringi::stri_pad_left(str = color, width = 8, pad = "F")

--- a/R/helper-functions.R
+++ b/R/helper-functions.R
@@ -110,7 +110,7 @@ validate_color <- function(
   color = NULL, or_null = FALSE,
   envir = parent.frame(), msg = NULL,
   format = c("ARGB", "RGBA")
-){
+) {
   format <- match.arg(format)
   sx <- as.character(substitute(color, envir))
 
@@ -132,7 +132,7 @@ validate_color <- function(
   color <- gsub("^#", "", toupper(color))
 
   # if the format is RGBA (R's default), switch first two with last two characters
-  if(format == "RGBA"){
+  if (format == "RGBA") {
     s <- nchar(color) == 8
     alpha <- substring(color[s], 7, 8)
     color[s] <- paste0(alpha, substring(color[s], 1, 6))

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -45,3 +45,4 @@ Ulrich Keller
 Vishal Katti
 Yan Lyesin
 yasirs
+Jiří Moravec

--- a/man/wb_color.Rd
+++ b/man/wb_color.Rd
@@ -11,27 +11,40 @@ wb_color(
   indexed = NULL,
   hex = NULL,
   theme = NULL,
-  tint = NULL
+  tint = NULL,
+  format = c("ARGB", "RGBA")
 )
 }
 \arguments{
-\item{name}{A name of a color known to R either as name or RGB/ARGB value.}
+\item{name}{A name of a color known to R either as name or RGB/ARGB/RGBA value.}
 
 \item{auto}{A boolean.}
 
 \item{indexed}{An indexed color value. This color has to be provided by the workbook.}
 
-\item{hex}{A rgb color either a ARGB hex value or RGB hex value With or without leading "#".}
+\item{hex}{A rgb color a RGB/ARGB/RGBA hex value with or without leading "#".}
 
 \item{theme}{A zero based index referencing a value in the theme.}
 
 \item{tint}{A tint value applied. Range from -1 (dark) to 1 (light).}
+
+\item{format}{A colour format, one of ARGB (default) or RGBA.}
 }
 \value{
 a \code{wbColour} object
 }
 \description{
 Creates a \code{wbColour} object.
+}
+\details{
+The \strong{format} of the hex color representation  can be either RGB, ARGB, or RGBA.
+These hex formats differ only in a way how they encode the transparency value alpha,
+ARGB expecting the alpha value before the RGB values (default in spreadsheets),
+RGBA expects the alpha value after the RGB values (default in R),
+and RGB is not encoding transparency at all.
+If the colors some from functions such as \code{adjustcolor} that provide color in the
+RGBA format, it is necessary to specify the \code{format = "RGBA"} when calling the
+\code{wb_color()} function.
 }
 \seealso{
 \code{\link[=wb_get_base_colors]{wb_get_base_colors()}} \code{\link[grDevices:colors]{grDevices::colors()}}

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -430,6 +430,18 @@ test_that("validate_colors() works", {
   got <- validate_color(col)
   expect_equal(exp, got)
 
+  # switch from RGBA to ARGB format
+  col <- c("#000000FF", adjustcolor("black"), "#000000", "black")
+  exp <- c("FF000000", "FF000000", "FF000000", "FF000000")
+  got <- validate_color(col, format = "RGBA")
+  expect_equal(got, exp)
+
+  # handle non-standard input (too short, missing hash)
+  # short input is padded with F, this might not be the desired color
+  col <- c("000000", "#000000", "#00", "00")
+  exp <- c("FF000000", "FF000000", "FFFFFF00", "FFFFFF00")
+  got <- validate_color(col)
+  expect_equal(got, exp)
 })
 
 test_that("basename2() works", {


### PR DESCRIPTION
This PR allows specifying colour format in the RGBA format and fixes #1340 

RGBA format is the default colour format in R, e.g., from `adjustcolor("black")`.
The default for spreadsheets and assumed by openxlsx2 even for the R interface is ARGB.

The ARGB format seems to be baked deeply within the codebase, so transition ARGB -> RGBA for a more natural R interface is likely out of question.

Thus, a simple `format` argument was added to `validate_color` and `wb_color` functions so that user can specify R-native format if they are passing RGBA value, without having to do the transformation themselves.