### PR TITLE
[cf] Allow multiple non-consequtive dims

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## Breaking changes
 * `dims` will now respect the order in which they are sorted. So `"B2:A1"` will no longer equal `"A1:B2"`. [1353](https://github.com/JanMarvin/openxlsx2/pull/1353)
+* Conditional formatting allows now for non consecutive dims such as `"A1:B2,C2:D3"`. This causes a change in previous behavior, where the outer cells of a dimension were used to construct the range to which the conditional formatting was applied. [1347](https://github.com/JanMarvin/openxlsx2/pull/1347)
 
 
 ***************************************************************************

--- a/R/class-workbook-wrappers.R
+++ b/R/class-workbook-wrappers.R
@@ -4063,6 +4063,7 @@ wb_add_form_control <- function(
 #' @details
 #' Conditional formatting `type` accept different parameters. Unless noted,
 #' unlisted parameters are ignored.
+#' If an expression is pointing to a cell `"A1=1"`, this cell reference is fluid and not fixed like `"$A$1=1"`. It will behave similar to a formula, when `dims` is spanning multiple columns or rows (A1, A2, A3 ... in vertical direction, A1, B1, C1 ... in horizontal direction). If `dims` is a non consecutive range ("A1:B2,D1:F2"), the expression is applied to each range. For the second `dims` range it will be evaluated again as `"A1=1"`.
 #' \describe{
 #'   \item{`expression`}{
 #'     `[style]`\cr A `Style` object\cr\cr

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5800,13 +5800,10 @@ wbWorkbook <- R6::R6Class(
         dims <- rowcol_to_dims(rows, cols)
       }
 
-      ddims <- dims_to_rowcol(dims, as_integer = TRUE)
-      rows <- ddims[["row"]]
-      cols <- ddims[["col"]]
-
-      if (length(cols) > 2 && any(diff(cols) != 1)) {
-        warning("cols > 2, will create range from min to max.")
-      }
+      # as_integer returns a range, but we want to know all columns
+      ddims <- dims_to_rowcol(dims, as_integer = FALSE)
+      rows <- as.integer(ddims[["row"]])
+      cols <- col2int(ddims[["col"]])
 
       if (!is.null(style)) assert_class(style, "character")
       assert_class(type, "character")
@@ -5830,239 +5827,258 @@ wbWorkbook <- R6::R6Class(
         dxfId <- self$styles_mgr$get_dxf_id(smp)
       }
 
-      switch(
-        type,
 
-        expression = {
-          # TODO should we bother to do any conversions or require the text
-          # entered to be exactly as an Excel expression would be written?
-          msg <- "When type == 'expression', "
+      cols <- tapply(cols, cumsum(c(1, diff(cols) != 1)), function(g) {
+        range(g)
+      })
 
-          if (!is.character(rule) || length(rule) != 1L) {
-            stop(msg, "rule must be a single length character vector")
-          }
+      rows <- tapply(rows, cumsum(c(1, diff(rows) != 1)), function(g) {
+        range(g)
+      })
 
-          rule <- gsub("!=", "<>", rule)
-          rule <- gsub("==", "=", rule)
-          rule <- replace_legal_chars(rule) # replaces <>
+      orig_rule <- rule
 
-          if (!grepl("[A-Z]", substr(rule, 1, 2))) {
-            ## formula looks like "operatorX" , attach top left cell to rule
-            rule <- paste0(
-              get_cell_refs(data.frame(min(rows), min(cols), stringsAsFactors = FALSE)),
-              rule
-            )
-          } ## else, there is a letter in the formula and apply as is
+      for (row in rows) {
+        for (col in cols) {
 
-        },
 
-        colorScale = {
-          # - style is a vector of colors with length 2 or 3
-          # - rule specifies the quantiles (numeric vector of length 2 or 3), if NULL min and max are used
-          msg <- "When type == 'colorScale', "
+          switch(
+            type,
 
-          if (!is.character(style)) {
-            stop(msg, "style must be a vector of colors of length 2 or 3.")
-          }
+            expression = {
+              # TODO should we bother to do any conversions or require the text
+              # entered to be exactly as an Excel expression would be written?
+              msg <- "When type == 'expression', "
 
-          if (!length(style) %in% 2:3) {
-            stop(msg, "style must be a vector of length 2 or 3.")
-          }
+              if (!is.character(orig_rule) || length(orig_rule) != 1L) {
+                stop(msg, "rule must be a single length character vector")
+              }
 
-          if (!is.null(rule)) {
-            if (length(rule) != length(style)) {
-              stop(msg, "rule and style must have equal lengths.")
+              rule <- orig_rule
+
+              rule <- gsub("!=", "<>", rule)
+              rule <- gsub("==", "=", rule)
+              rule <- replace_legal_chars(rule) # replaces <>
+
+              if (!grepl("[A-Z]", substr(rule, 1, 2))) {
+                ## formula looks like "operatorX" , attach top left cell to rule
+                rule <- paste0(
+                  get_cell_refs(data.frame(row[1], col[1], stringsAsFactors = FALSE)),
+                  rule
+                )
+              } ## else, there is a letter in the formula and apply as is
+
+            },
+
+            colorScale = {
+              # - style is a vector of colors with length 2 or 3
+              # - rule specifies the quantiles (numeric vector of length 2 or 3), if NULL min and max are used
+              msg <- "When type == 'colorScale', "
+
+              if (!is.character(style)) {
+                stop(msg, "style must be a vector of colors of length 2 or 3.")
+              }
+
+              if (!length(style) %in% 2:3) {
+                stop(msg, "style must be a vector of length 2 or 3.")
+              }
+
+              if (!is.null(rule)) {
+                if (length(rule) != length(style)) {
+                  stop(msg, "rule and style must have equal lengths.")
+                }
+              }
+
+              style <- validate_color(style)
+
+              if (isFALSE(style)) {
+                stop(msg, "style must be valid colors")
+              }
+
+              values <- rule
+              rule <- style
+            },
+
+            dataBar = {
+              # - style is a vector of colors of length 2 or 3
+              # - rule specifies the quantiles (numeric vector of length 2 or 3), if NULL min and max are used
+              msg <- "When type == 'dataBar', "
+              style <- style %||% "#638EC6"
+
+              # TODO use inherits() not class()
+              if (!inherits(style, "character")) {
+                stop(msg, "style must be a vector of colors of length 1 or 2.")
+              }
+
+              if (!length(style) %in% 1:2) {
+                stop(msg, "style must be a vector of length 1 or 2.")
+              }
+
+              if (!is.null(rule)) {
+                if (length(rule) != length(style)) {
+                  stop(msg, "rule and style must have equal lengths.")
+                }
+              }
+
+              ## Additional parameters passed by ...
+              # showValue, gradient, border
+              style <- validate_color(style)
+
+              if (isFALSE(style)) {
+                stop(msg, "style must be valid colors")
+              }
+
+              values <- rule
+              rule <- style
+            },
+
+            iconSet = {
+              # - rule is the iconSet values
+              msg <- "When type == 'iconSet', "
+              values <- rule
+            },
+
+            duplicatedValues = {
+              # type == "duplicatedValues"
+              # - style is a Style object
+              # - rule is ignored
+
+              rule <- style
+            },
+
+            uniqueValues = {
+              # type == "uniqueValues"
+              # - style is a Style object
+              # - rule is ignored
+
+              rule <- style
+            },
+
+            containsBlanks = {
+              # - style is Style object
+              # - rule is cell to check for errors
+              msg <- "When type == 'containsBlanks', "
+
+              rule <- style
+            },
+
+            notContainsBlanks = {
+              # - style is Style object
+              # - rule is cell to check for errors
+              msg <- "When type == 'notContainsBlanks', "
+
+              rule <- style
+            },
+
+            containsErrors = {
+              # - style is Style object
+              # - rule is cell to check for errors
+              msg <- "When type == 'containsErrors', "
+
+              rule <- style
+            },
+
+            notContainsErrors = {
+              # - style is Style object
+              # - rule is cell to check for errors
+              msg <- "When type == 'notContainsErrors', "
+
+              rule <- style
+            },
+
+            containsText = {
+              # - style is Style object
+              # - rule is text to look for
+              msg <- "When type == 'contains', "
+
+              if (!inherits(rule, "character")) {
+                stop(msg, "rule must be a character vector of length 1.")
+              }
+
+              values <- rule
+              rule <- style
+            },
+
+            notContainsText = {
+              # - style is Style object
+              # - rule is text to look for
+              msg <- "When type == 'notContains', "
+
+              if (!inherits(rule, "character")) {
+                stop(msg, "rule must be a character vector of length 1.")
+              }
+
+              values <- rule
+              rule <- style
+            },
+
+            beginsWith = {
+              # - style is Style object
+              # - rule is text to look for
+              msg <- "When type == 'beginsWith', "
+
+              if (!is.character("character")) {
+                stop(msg, "rule must be a character vector of length 1.")
+              }
+
+              values <- rule
+              rule <- style
+            },
+
+            endsWith = {
+              # - style is Style object
+              # - rule is text to look for
+              msg <- "When type == 'endsWith', "
+
+              if (!inherits(rule, "character")) {
+                stop(msg, "rule must be a character vector of length 1.")
+              }
+
+              values <- rule
+              rule <- style
+            },
+
+            between = {
+              rule <- range(rule)
+            },
+
+            topN = {
+              # - rule is ignored
+              # - 'rank' and 'percent' are named params
+
+              ## Additional parameters passed by ...
+              # percent, rank
+
+              values <- params
+              rule <- style
+            },
+
+            bottomN = {
+              # - rule is ignored
+              # - 'rank' and 'percent' are named params
+
+              ## Additional parameters passed by ...
+              # percent, rank
+
+              values <- params
+              rule <- style
             }
-          }
+          )
 
-          style <- validate_color(style)
-
-          if (isFALSE(style)) {
-            stop(msg, "style must be valid colors")
-          }
-
-          values <- rule
-          rule <- style
-        },
-
-        dataBar = {
-          # - style is a vector of colors of length 2 or 3
-          # - rule specifies the quantiles (numeric vector of length 2 or 3), if NULL min and max are used
-          msg <- "When type == 'dataBar', "
-          style <- style %||% "#638EC6"
-
-          # TODO use inherits() not class()
-          if (!inherits(style, "character")) {
-            stop(msg, "style must be a vector of colors of length 1 or 2.")
-          }
-
-          if (!length(style) %in% 1:2) {
-            stop(msg, "style must be a vector of length 1 or 2.")
-          }
-
-          if (!is.null(rule)) {
-            if (length(rule) != length(style)) {
-              stop(msg, "rule and style must have equal lengths.")
-            }
-          }
-
-          ## Additional parameters passed by ...
-          # showValue, gradient, border
-          style <- validate_color(style)
-
-          if (isFALSE(style)) {
-            stop(msg, "style must be valid colors")
-          }
-
-          values <- rule
-          rule <- style
-        },
-
-        iconSet = {
-          # - rule is the iconSet values
-          msg <- "When type == 'iconSet', "
-          values <- rule
-        },
-
-        duplicatedValues = {
-          # type == "duplicatedValues"
-          # - style is a Style object
-          # - rule is ignored
-
-          rule <- style
-        },
-
-        uniqueValues = {
-          # type == "uniqueValues"
-          # - style is a Style object
-          # - rule is ignored
-
-          rule <- style
-        },
-
-        containsBlanks = {
-          # - style is Style object
-          # - rule is cell to check for errors
-          msg <- "When type == 'containsBlanks', "
-
-          rule <- style
-        },
-
-        notContainsBlanks = {
-          # - style is Style object
-          # - rule is cell to check for errors
-          msg <- "When type == 'notContainsBlanks', "
-
-          rule <- style
-        },
-
-        containsErrors = {
-          # - style is Style object
-          # - rule is cell to check for errors
-          msg <- "When type == 'containsErrors', "
-
-          rule <- style
-        },
-
-        notContainsErrors = {
-          # - style is Style object
-          # - rule is cell to check for errors
-          msg <- "When type == 'notContainsErrors', "
-
-          rule <- style
-        },
-
-        containsText = {
-          # - style is Style object
-          # - rule is text to look for
-          msg <- "When type == 'contains', "
-
-          if (!inherits(rule, "character")) {
-            stop(msg, "rule must be a character vector of length 1.")
-          }
-
-          values <- rule
-          rule <- style
-        },
-
-        notContainsText = {
-          # - style is Style object
-          # - rule is text to look for
-          msg <- "When type == 'notContains', "
-
-          if (!inherits(rule, "character")) {
-            stop(msg, "rule must be a character vector of length 1.")
-          }
-
-          values <- rule
-          rule <- style
-        },
-
-        beginsWith = {
-          # - style is Style object
-          # - rule is text to look for
-          msg <- "When type == 'beginsWith', "
-
-          if (!is.character("character")) {
-            stop(msg, "rule must be a character vector of length 1.")
-          }
-
-          values <- rule
-          rule <- style
-        },
-
-        endsWith = {
-          # - style is Style object
-          # - rule is text to look for
-          msg <- "When type == 'endsWith', "
-
-          if (!inherits(rule, "character")) {
-            stop(msg, "rule must be a character vector of length 1.")
-          }
-
-          values <- rule
-          rule <- style
-        },
-
-        between = {
-          rule <- range(rule)
-        },
-
-        topN = {
-          # - rule is ignored
-          # - 'rank' and 'percent' are named params
-
-          ## Additional parameters passed by ...
-          # percent, rank
-
-          values <- params
-          rule <- style
-        },
-
-        bottomN = {
-          # - rule is ignored
-          # - 'rank' and 'percent' are named params
-
-          ## Additional parameters passed by ...
-          # percent, rank
-
-          values <- params
-          rule <- style
+          private$do_conditional_formatting(
+            sheet    = sheet,
+            startRow = row[1],
+            endRow   = row[2],
+            startCol = col[1],
+            endCol   = col[2],
+            dxfId    = dxfId,
+            formula  = rule,
+            type     = type,
+            values   = values,
+            params   = params
+          )
         }
-      )
-
-      private$do_conditional_formatting(
-        sheet    = sheet,
-        startRow = min(rows),
-        endRow   = max(rows),
-        startCol = min(cols),
-        endCol   = max(cols),
-        dxfId    = dxfId,
-        formula  = rule,
-        type     = type,
-        values   = values,
-        params   = params
-      )
+      }
 
       invisible(self)
     },

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5802,8 +5802,8 @@ wbWorkbook <- R6::R6Class(
 
       # as_integer returns a range, but we want to know all columns
       ddims <- dims_to_rowcol(dims, as_integer = FALSE)
-      rows <- as.integer(ddims[["row"]])
-      cols <- col2int(ddims[["col"]])
+      rows <- sort(as.integer(ddims[["row"]]))
+      cols <- sort(col2int(ddims[["col"]]))
 
       if (!is.null(style)) assert_class(style, "character")
       assert_class(type, "character")

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -5804,26 +5804,15 @@ wbWorkbook <- R6::R6Class(
       rows <- ddims[["row"]]
       cols <- ddims[["col"]]
 
-      if (length(cols) > 2 && any(diff(cols) != 1))
+      if (length(cols) > 2 && any(diff(cols) != 1)) {
         warning("cols > 2, will create range from min to max.")
+      }
 
       if (!is.null(style)) assert_class(style, "character")
       assert_class(type, "character")
       assert_class(params, "list")
 
       type <- match.arg(type)
-
-      ## rows and cols
-      if (!is.null(cols) && !is.null(rows)) {
-        if (!is.numeric(cols)) {
-          cols <- col2int(cols)
-        }
-        rows <- as.integer(rows)
-      } else if (!is.null(dims)) {
-        rowcol <- dims_to_rowcol(dims, as_integer = TRUE)
-        rows <- rowcol[["row"]]
-        cols <- rowcol[["col"]]
-      }
 
       ## check valid rule
       dxfId <- NULL

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -10011,13 +10011,13 @@ wbWorkbook <- R6::R6Class(
       nms <- c(names(self$worksheets[[sheet]]$conditionalFormatting), sqref)
       dxfId <- max(dxfId, 0L)
 
-
-      priority <- max(
-      as.integer(
-        openxlsx2:::rbindlist(
-          xml_attr(wb$worksheets[[1]]$conditionalFormatting, "cfRule")
-        )$priority
-      ), 0) + 1L
+      priority <- max(0,
+        as.integer(
+          openxlsx2:::rbindlist(
+            xml_attr(self$worksheets[[sheet]]$conditionalFormatting, "cfRule")
+          )$priority
+        )
+      ) + 1L
 
       # big switch statement
       cfRule <- switch(

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -10008,82 +10008,71 @@ wbWorkbook <- R6::R6Class(
         collapse = ":"
       )
 
-      ## Increment priority of conditional formatting rule
-      for (i in rev(seq_along(self$worksheets[[sheet]]$conditionalFormatting))) {
-        priority <- reg_match0(
-          self$worksheets[[sheet]]$conditionalFormatting[[i]],
-          '(?<=priority=")[0-9]+'
-        )
-        priority_new <- as.integer(priority) + 1L
-        priority_pattern <- sprintf('priority="%s"', priority)
-        priority_new <- sprintf('priority="%s"', priority_new)
-
-        ## now replace
-        self$worksheets[[sheet]]$conditionalFormatting[[i]] <- gsub(
-          priority_pattern,
-          priority_new,
-          self$worksheets[[sheet]]$conditionalFormatting[[i]],
-          fixed = TRUE
-        )
-      }
-
       nms <- c(names(self$worksheets[[sheet]]$conditionalFormatting), sqref)
       dxfId <- max(dxfId, 0L)
+
+
+      priority <- max(
+      as.integer(
+        openxlsx2:::rbindlist(
+          xml_attr(wb$worksheets[[1]]$conditionalFormatting, "cfRule")
+        )$priority
+      ), 0) + 1L
 
       # big switch statement
       cfRule <- switch(
         type,
 
         ## colorScale ----
-        colorScale = cf_create_colorscale(formula, values),
+        colorScale = cf_create_colorscale(priority, formula, values),
 
         ## dataBar ----
-        dataBar = cf_create_databar(self$worksheets[[sheet]]$extLst, formula, params, sqref, values),
+        dataBar = cf_create_databar(priority, self$worksheets[[sheet]]$extLst, formula, params, sqref, values),
 
         ## expression ----
-        expression = cf_create_expression(dxfId, formula),
+        expression = cf_create_expression(priority, dxfId, formula),
 
         ## duplicatedValues ----
-        duplicatedValues = cf_create_duplicated_values(dxfId),
+        duplicatedValues = cf_create_duplicated_values(priority, dxfId),
 
         ## containsText ----
-        containsText = cf_create_contains_text(dxfId, sqref, values),
+        containsText = cf_create_contains_text(priority, dxfId, sqref, values),
 
         ## notContainsText ----
-        notContainsText = cf_create_not_contains_text(dxfId, sqref, values),
+        notContainsText = cf_create_not_contains_text(priority, dxfId, sqref, values),
 
         ## beginsWith ----
-        beginsWith = cf_begins_with(dxfId, sqref, values),
+        beginsWith = cf_begins_with(priority, dxfId, sqref, values),
 
         ## endsWith ----
-        endsWith = cf_ends_with(dxfId, sqref, values),
+        endsWith = cf_ends_with(priority, dxfId, sqref, values),
 
         ## between ----
-        between = cf_between(dxfId, formula),
+        between = cf_between(priority, dxfId, formula),
 
         ## topN ----
-        topN = cf_top_n(dxfId, values),
+        topN = cf_top_n(priority, dxfId, values),
 
         ## bottomN ----
-        bottomN = cf_bottom_n(dxfId, values),
+        bottomN = cf_bottom_n(priority, dxfId, values),
 
         ## uniqueValues ---
-        uniqueValues = cf_unique_values(dxfId),
+        uniqueValues = cf_unique_values(priority, dxfId),
 
         ## iconSet ----
-        iconSet = cf_icon_set(self$worksheets[[sheet]]$extLst, sqref, values, params),
+        iconSet = cf_icon_set(priority, self$worksheets[[sheet]]$extLst, sqref, values, params),
 
         ## containsErrors ----
-        containsErrors = cf_iserror(dxfId, sqref),
+        containsErrors = cf_iserror(priority, dxfId, sqref),
 
         ## notContainsErrors ----
-        notContainsErrors = cf_isnoerror(dxfId, sqref),
+        notContainsErrors = cf_isnoerror(priority, dxfId, sqref),
 
         ## containsBlanks ----
-        containsBlanks = cf_isblank(dxfId, sqref),
+        containsBlanks = cf_isblank(priority, dxfId, sqref),
 
         ## notContainsBlanks ----
-        notContainsBlanks = cf_isnoblank(dxfId, sqref),
+        notContainsBlanks = cf_isnoblank(priority, dxfId, sqref),
 
         # do we have a match.arg() anywhere or will it just be showned in this switch()?
         stop("type `", type, "` is not a valid formatting rule")

--- a/R/conditional_formatting.R
+++ b/R/conditional_formatting.R
@@ -13,7 +13,7 @@ cf_create_colorscale <- function(priority, formula, values) {
     # lengths, if these aren't checked somewhere already?
     if (length(formula) == 2L) {
       cf_rule <- sprintf(
-        '<cfRule type="colorScale" priority="1">
+        '<cfRule type="colorScale" priority="%s">
           <colorScale>
             <cfvo type="min"/>
             <cfvo type="max"/>
@@ -21,12 +21,13 @@ cf_create_colorscale <- function(priority, formula, values) {
             <color rgb="%s"/>
           </colorScale>
         </cfRule>',
+        priority,
         formula[[1]],
         formula[[2]]
       )
     } else if (length(formula) == 3L) {
       cf_rule <- sprintf(
-        '<cfRule type="colorScale" priority="1">
+        '<cfRule type="colorScale" priority="%s">
           <colorScale>
             <cfvo type="min"/>
             <cfvo type="percentile" val="50"/>
@@ -36,6 +37,7 @@ cf_create_colorscale <- function(priority, formula, values) {
             <color rgb="%s"/>
           </colorScale>
         </cfRule>',
+        priority,
         formula[[1]],
         formula[[2]],
         formula[[3]]
@@ -44,7 +46,7 @@ cf_create_colorscale <- function(priority, formula, values) {
   } else {
     if (length(formula) == 2L && length(values) == 2L) {
       cf_rule <- sprintf(
-        '<cfRule type="colorScale" priority="1">
+        '<cfRule type="colorScale" priority="%s">
           <colorScale>
             <cfvo type="num" val="%s"/>
             <cfvo type="num" val="%s"/>
@@ -52,6 +54,7 @@ cf_create_colorscale <- function(priority, formula, values) {
             <color rgb="%s"/>
           </colorScale>
         </cfRule>',
+        priority,
         values[[1]],
         values[[2]],
         formula[[1]],
@@ -59,7 +62,7 @@ cf_create_colorscale <- function(priority, formula, values) {
       )
     } else if (length(formula) == 3L && length(values) == 3L) {
       cf_rule <- sprintf(
-        '<cfRule type="colorScale" priority="1">
+        '<cfRule type="colorScale" priority="%s">
           <colorScale>
             <cfvo type="num" val="%s"/>
             <cfvo type="num" val="%s"/>
@@ -69,6 +72,7 @@ cf_create_colorscale <- function(priority, formula, values) {
             <color rgb="%s"/>
           </colorScale>
         </cfRule>',
+        priority,
         values[[1]],
         values[[2]],
         values[[3]],
@@ -201,7 +205,7 @@ cf_create_duplicated_values <- function(priority, dxfId) {
     '<cfRule type="duplicateValues" dxfId="%s" priority="%s"/>',
     # cfRule
     dxfId,
-    priority,
+    priority
   )
 
   cf_rule
@@ -228,7 +232,7 @@ cf_create_contains_text <- function(priority, dxfId, sqref, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_create_not_contains_text <- function(priority,dxfId, sqref, values) {
+cf_create_not_contains_text <- function(priority, dxfId, sqref, values) {
   cf_rule <- sprintf(
     '<cfRule type="notContainsText" dxfId="%s" priority="%s" operator="notContains" text="%s">
       <formula>ISERROR(SEARCH("%s", %s))</formula>
@@ -247,7 +251,7 @@ cf_create_not_contains_text <- function(priority,dxfId, sqref, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_begins_with <- function(priority,dxfId, sqref, values) {
+cf_begins_with <- function(priority, dxfId, sqref, values) {
   cf_rule <- sprintf(
     '<cfRule type="beginsWith" dxfId="%s" priority="%s" operator="beginsWith" text="%s">
       <formula>LEFT(%s,LEN("%s"))="%s"</formula>
@@ -289,12 +293,13 @@ cf_ends_with <- function(priority, dxfId, sqref, values) {
 #' @noRd
 cf_between <- function(priority, dxfId, formula) {
   cf_rule <- sprintf(
-    '<cfRule type="cellIs" dxfId="%s" priority="1" operator="between">
+    '<cfRule type="cellIs" dxfId="%s" priority="%s" operator="between">
       <formula>%s</formula>
       <formula>%s</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     # formula
     formula[1],
     formula[2]
@@ -307,9 +312,10 @@ cf_between <- function(priority, dxfId, formula) {
 #' @noRd
 cf_top_n <- function(priority, dxfId, values) {
   cf_rule <- sprintf(
-    '<cfRule type="top10" dxfId="%s" priority="1" rank="%s" percent="%s"/>',
+    '<cfRule type="top10" dxfId="%s" priority="%s" rank="%s" percent="%s"/>',
     # cfRule
     dxfId,
+    priority,
     values$rank,
     values$percent
   )
@@ -321,9 +327,10 @@ cf_top_n <- function(priority, dxfId, values) {
 #' @noRd
 cf_bottom_n <- function(priority, dxfId, values) {
   cf_rule <- sprintf(
-    '<cfRule type="top10" dxfId="%s" priority="1" rank="%s" percent="%s" bottom="1"/>',
+    '<cfRule type="top10" dxfId="%s" priority="%s" rank="%s" percent="%s" bottom="1"/>',
     # cfRule
     dxfId,
+    priority,
     values$rank,
     values$percent
   )

--- a/R/conditional_formatting.R
+++ b/R/conditional_formatting.R
@@ -3,7 +3,7 @@
 #' @param formula formula
 #' @param values values
 #' @noRd
-cf_create_colorscale <- function(formula, values) {
+cf_create_colorscale <- function(priority, formula, values) {
 
   ## formula contains the colors
   ## values contains numerics or is NULL
@@ -88,7 +88,7 @@ cf_create_colorscale <- function(formula, values) {
 #' @param params params
 #' @param sqref sqref
 #' @noRd
-cf_create_databar <- function(extLst, formula, params, sqref, values) {
+cf_create_databar <- function(priority, extLst, formula, params, sqref, values) {
   if (length(formula) == 2L) {
     negColor <- formula[[1]]
     posColor <- formula[[2]]
@@ -132,7 +132,7 @@ cf_create_databar <- function(extLst, formula, params, sqref, values) {
 
   if (is.null(values)) {
     cf_rule <- sprintf(
-      '<cfRule type="dataBar" priority="1">
+      '<cfRule type="dataBar" priority="%s">
         <dataBar showValue="%s">
           <cfvo type="min"/>
           <cfvo type="max"/>
@@ -141,6 +141,7 @@ cf_create_databar <- function(extLst, formula, params, sqref, values) {
         %s
       </cfRule>',
       # dataBar
+      priority,
       showValue,
       # color
       posColor,
@@ -149,7 +150,7 @@ cf_create_databar <- function(extLst, formula, params, sqref, values) {
     )
   } else {
     cf_rule <- sprintf(
-      '<cfRule type="dataBar" priority="1">
+      '<cfRule type="dataBar" priority="%s">
         <dataBar showValue="%s">
           <cfvo type="num" val="%s"/>
           <cfvo type="num" val="%s"/>
@@ -158,6 +159,7 @@ cf_create_databar <- function(extLst, formula, params, sqref, values) {
         %s
       </cfRule>',
       # dataBar
+      priority,
       showValue,
       # cfvo
       values[[1]],
@@ -177,13 +179,14 @@ cf_create_databar <- function(extLst, formula, params, sqref, values) {
 #' @param dxfId dxfId
 #' @param formula formula
 #' @noRd
-cf_create_expression <- function(dxfId, formula) {
+cf_create_expression <- function(priority, dxfId, formula) {
   cf_rule <- sprintf(
-    '<cfRule type="expression" dxfId="%s" priority="1">
+    '<cfRule type="expression" dxfId="%s" priority="%s">
       <formula>%s</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     # formula
     formula
   )
@@ -193,11 +196,12 @@ cf_create_expression <- function(dxfId, formula) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_create_duplicated_values <- function(dxfId) {
+cf_create_duplicated_values <- function(priority, dxfId) {
   cf_rule <- sprintf(
-    '<cfRule type="duplicateValues" dxfId="%s" priority="1"/>',
+    '<cfRule type="duplicateValues" dxfId="%s" priority="%s"/>',
     # cfRule
-    dxfId
+    dxfId,
+    priority,
   )
 
   cf_rule
@@ -205,13 +209,14 @@ cf_create_duplicated_values <- function(dxfId) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_create_contains_text <- function(dxfId, sqref, values) {
+cf_create_contains_text <- function(priority, dxfId, sqref, values) {
   cf_rule <- sprintf(
-    '<cfRule type="containsText" dxfId="%s" priority="1" operator="containsText" text="%s">
+    '<cfRule type="containsText" dxfId="%s" priority="%s" operator="containsText" text="%s">
       <formula>NOT(ISERROR(SEARCH("%s", %s)))</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     replace_legal_chars(values),
     # formula
     replace_legal_chars(values),
@@ -223,13 +228,14 @@ cf_create_contains_text <- function(dxfId, sqref, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_create_not_contains_text <- function(dxfId, sqref, values) {
+cf_create_not_contains_text <- function(priority,dxfId, sqref, values) {
   cf_rule <- sprintf(
-    '<cfRule type="notContainsText" dxfId="%s" priority="1" operator="notContains" text="%s">
+    '<cfRule type="notContainsText" dxfId="%s" priority="%s" operator="notContains" text="%s">
       <formula>ISERROR(SEARCH("%s", %s))</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     replace_legal_chars(values),
     # formula
     replace_legal_chars(values),
@@ -241,13 +247,14 @@ cf_create_not_contains_text <- function(dxfId, sqref, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_begins_with <- function(dxfId, sqref, values) {
+cf_begins_with <- function(priority,dxfId, sqref, values) {
   cf_rule <- sprintf(
-    '<cfRule type="beginsWith" dxfId="%s" priority="1" operator="beginsWith" text="%s">
+    '<cfRule type="beginsWith" dxfId="%s" priority="%s" operator="beginsWith" text="%s">
       <formula>LEFT(%s,LEN("%s"))="%s"</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     replace_legal_chars(values),
     # formula
     strsplit(sqref, split = ":")[[1]][1],
@@ -260,13 +267,14 @@ cf_begins_with <- function(dxfId, sqref, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_ends_with <- function(dxfId, sqref, values) {
+cf_ends_with <- function(priority, dxfId, sqref, values) {
   cf_rule <- sprintf(
-    '<cfRule type="endsWith" dxfId="%s" priority="1" operator="endsWith" text="%s">
+    '<cfRule type="endsWith" dxfId="%s" priority="%s" operator="endsWith" text="%s">
       <formula>RIGHT(%s,LEN("%s"))="%s"</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     replace_legal_chars(values),
     # formula
     strsplit(sqref, split = ":")[[1]][1],
@@ -279,7 +287,7 @@ cf_ends_with <- function(dxfId, sqref, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_between <- function(dxfId, formula) {
+cf_between <- function(priority, dxfId, formula) {
   cf_rule <- sprintf(
     '<cfRule type="cellIs" dxfId="%s" priority="1" operator="between">
       <formula>%s</formula>
@@ -297,7 +305,7 @@ cf_between <- function(dxfId, formula) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_top_n <- function(dxfId, values) {
+cf_top_n <- function(priority, dxfId, values) {
   cf_rule <- sprintf(
     '<cfRule type="top10" dxfId="%s" priority="1" rank="%s" percent="%s"/>',
     # cfRule
@@ -311,7 +319,7 @@ cf_top_n <- function(dxfId, values) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_bottom_n <- function(dxfId, values) {
+cf_bottom_n <- function(priority, dxfId, values) {
   cf_rule <- sprintf(
     '<cfRule type="top10" dxfId="%s" priority="1" rank="%s" percent="%s" bottom="1"/>',
     # cfRule
@@ -326,6 +334,7 @@ cf_bottom_n <- function(dxfId, values) {
 #' @rdname cf_rules
 #' @noRd
 cf_icon_set <- function(
+    priority,
     extLst,
     sqref,
     values,
@@ -333,7 +342,6 @@ cf_icon_set <- function(
   ) {
 
   type      <- ifelse(params$percent, "percent", "num")
-  priority  <- "1"
   showValue <- NULL
   reverse   <- NULL
   iconSet   <- NULL
@@ -363,7 +371,7 @@ cf_icon_set <- function(
     paste0(x14_ns, "cfRule"),
     xml_attributes = c(
       type     = "iconSet",
-      priority = priority,
+      priority = as_xml_attr(priority),
       id = guid
     )
   )
@@ -435,10 +443,11 @@ cf_icon_set <- function(
 
 #' @rdname cf_rules
 #' @noRd
-cf_unique_values <- function(dxfId) {
+cf_unique_values <- function(priority, dxfId) {
   cf_rule <- sprintf(
-    '<cfRule type="uniqueValues" dxfId="%s" priority="1"/>',
-    dxfId
+    '<cfRule type="uniqueValues" dxfId="%s" priority="%s"/>',
+    dxfId,
+    priority
   )
 
   cf_rule
@@ -446,13 +455,14 @@ cf_unique_values <- function(dxfId) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_iserror <- function(dxfId, sqref) {
+cf_iserror <- function(priority, dxfId, sqref) {
   cf_rule <- sprintf(
-    '<cfRule type="containsErrors" dxfId="%s" priority="1">
+    '<cfRule type="containsErrors" dxfId="%s" priority="%s">
       <formula>ISERROR(%s)</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     # formula
     sqref
   )
@@ -462,13 +472,14 @@ cf_iserror <- function(dxfId, sqref) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_isnoerror <- function(dxfId, sqref) {
+cf_isnoerror <- function(priority, dxfId, sqref) {
   cf_rule <- sprintf(
-    '<cfRule type="notContainsErrors" dxfId="%s" priority="1">
+    '<cfRule type="notContainsErrors" dxfId="%s" priority="%s">
       <formula>NOT(ISERROR(%s))</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     # formula
     sqref
   )
@@ -478,13 +489,14 @@ cf_isnoerror <- function(dxfId, sqref) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_isblank <- function(dxfId, sqref) {
+cf_isblank <- function(priority, dxfId, sqref) {
   cf_rule <- sprintf(
-    '<cfRule type="containsBlanks" dxfId="%s" priority="1">
+    '<cfRule type="containsBlanks" dxfId="%s" priority="%s">
       <formula>LEN(TRIM(%s))=0</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     # formula
     sqref
   )
@@ -494,13 +506,14 @@ cf_isblank <- function(dxfId, sqref) {
 
 #' @rdname cf_rules
 #' @noRd
-cf_isnoblank <- function(dxfId, sqref) {
+cf_isnoblank <- function(priority, dxfId, sqref) {
   cf_rule <- sprintf(
-    '<cfRule type="notContainsBlanks" dxfId="%s" priority="1">
+    '<cfRule type="notContainsBlanks" dxfId="%s" priority="%s">
       <formula>LEN(TRIM(%s))>0</formula>
     </cfRule>',
     # cfRule
     dxfId,
+    priority,
     # formula
     sqref
   )

--- a/man/wb_add_conditional_formatting.Rd
+++ b/man/wb_add_conditional_formatting.Rd
@@ -59,6 +59,7 @@ openxml uses the alpha channel first then RGB, whereas the usual default is RGBA
 
 Conditional formatting \code{type} accept different parameters. Unless noted,
 unlisted parameters are ignored.
+If an expression is pointing to a cell \code{A1=1}, this cell reference is fluid and not fixed like \verb{$A$1}. It will behave similar to a formula, when \code{dims} is spanning multiple columns or rows (A1, A2, A3 ... in vertical direction, A1, B1, C1 ... in horizontal direction). If \code{dims} is a non consecutive range ("A1:B2,D1:F2"), the expression is applied to each range. For the second \code{dims} range it will be evaluated again as \code{"A1=1"}.
 \describe{
 \item{\code{expression}}{
 \verb{[style]}\cr A \code{Style} object\cr\cr

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -56,8 +56,8 @@ test_that("type = 'expression' work", {
   )
 
   exp <- c(
-    `A1:A11` = '<cfRule type="expression" dxfId="0" priority="2"><formula>A1&lt;&gt;0</formula></cfRule>',
-    `A1:A11` = '<cfRule type="expression" dxfId="1" priority="1"><formula>A1=0</formula></cfRule>'
+    `A1:A11` = '<cfRule type="expression" dxfId="0" priority="1"><formula>A1&lt;&gt;0</formula></cfRule>',
+    `A1:A11` = '<cfRule type="expression" dxfId="1" priority="2"><formula>A1=0</formula></cfRule>'
   )
 
   expect_identical(exp, wb$worksheets[[1]]$conditionalFormatting)
@@ -81,8 +81,8 @@ test_that("type = 'expression' work", {
   )
 
   exp <- c(
-    `A1:B11` = '<cfRule type="expression" dxfId="0" priority="2"><formula>$A1&lt;0</formula></cfRule>',
-    `A1:B11` = '<cfRule type="expression" dxfId="1" priority="1"><formula>$A1&gt;0</formula></cfRule>'
+    `A1:B11` = '<cfRule type="expression" dxfId="0" priority="1"><formula>$A1&lt;0</formula></cfRule>',
+    `A1:B11` = '<cfRule type="expression" dxfId="1" priority="2"><formula>$A1&gt;0</formula></cfRule>'
   )
   expect_identical(exp, wb$worksheets[[2]]$conditionalFormatting)
 
@@ -104,8 +104,8 @@ test_that("type = 'expression' work", {
   )
 
   exp <- c(
-    `A1:B11` = '<cfRule type="expression" dxfId="0" priority="2"><formula>A$1&lt;0</formula></cfRule>',
-    `A1:B11` = '<cfRule type="expression" dxfId="1" priority="1"><formula>A$1&gt;0</formula></cfRule>'
+    `A1:B11` = '<cfRule type="expression" dxfId="0" priority="1"><formula>A$1&lt;0</formula></cfRule>',
+    `A1:B11` = '<cfRule type="expression" dxfId="1" priority="2"><formula>A$1&gt;0</formula></cfRule>'
   )
   expect_identical(exp, wb$worksheets[[3]]$conditionalFormatting)
 
@@ -127,8 +127,8 @@ test_that("type = 'expression' work", {
   )
 
   exp <- c(
-    `A1:B11` = '<cfRule type="expression" dxfId="0" priority="2"><formula>$A$1&lt;0</formula></cfRule>',
-    `A1:B11` = '<cfRule type="expression" dxfId="1" priority="1"><formula>$A$1&gt;0</formula></cfRule>'
+    `A1:B11` = '<cfRule type="expression" dxfId="0" priority="1"><formula>$A$1&lt;0</formula></cfRule>',
+    `A1:B11` = '<cfRule type="expression" dxfId="1" priority="2"><formula>$A$1&gt;0</formula></cfRule>'
   )
   expect_identical(exp, wb$worksheets[[4]]$conditionalFormatting)
 
@@ -149,10 +149,10 @@ test_that("type = 'expression' work", {
   )
 
   exp <- c(
-    `A1:B11`  = '<cfRule type="expression" dxfId="0" priority="4"><formula>$A$1&lt;0</formula></cfRule>',
-    `A1:B11`  = '<cfRule type="expression" dxfId="1" priority="3"><formula>$A$1&gt;0</formula></cfRule>',
-    `A16:A25` = '<cfRule type="expression" dxfId="0" priority="2"><formula>B16&lt;0.5</formula></cfRule>',
-    `A16:A25` = '<cfRule type="expression" dxfId="1" priority="1"><formula>B16&gt;=0.5</formula></cfRule>'
+    `A1:B11`  = '<cfRule type="expression" dxfId="0" priority="1"><formula>$A$1&lt;0</formula></cfRule>',
+    `A1:B11`  = '<cfRule type="expression" dxfId="1" priority="2"><formula>$A$1&gt;0</formula></cfRule>',
+    `A16:A25` = '<cfRule type="expression" dxfId="0" priority="3"><formula>B16&lt;0.5</formula></cfRule>',
+    `A16:A25` = '<cfRule type="expression" dxfId="1" priority="4"><formula>B16&gt;=0.5</formula></cfRule>'
   )
   expect_identical(exp, wb$worksheets[[4]]$conditionalFormatting)
 
@@ -317,8 +317,8 @@ test_that("type = 'topN' works", {
   )
 
   exp <- c(
-    `A2:A11` = '<cfRule type="top10" dxfId="1" priority="2" rank="5" percent="0"/>',
-    `B2:B11` = '<cfRule type="top10" dxfId="1" priority="1" rank="20" percent="1"/>'
+    `A2:A11` = '<cfRule type="top10" dxfId="1" priority="1" rank="5" percent="0"/>',
+    `B2:B11` = '<cfRule type="top10" dxfId="1" priority="2" rank="20" percent="1"/>'
   )
   expect_identical(exp, wb$worksheets[[1]]$conditionalFormatting)
   expect_save(wb)
@@ -348,8 +348,8 @@ test_that("type = 'bottomN' works", {
   )
 
   exp <- c(
-    `A2:A11` = "<cfRule type=\"top10\" dxfId=\"0\" priority=\"2\" rank=\"5\" percent=\"0\" bottom=\"1\"/>",
-    `B2:B11` = "<cfRule type=\"top10\" dxfId=\"0\" priority=\"1\" rank=\"20\" percent=\"1\" bottom=\"1\"/>"
+    `A2:A11` = "<cfRule type=\"top10\" dxfId=\"0\" priority=\"1\" rank=\"5\" percent=\"0\" bottom=\"1\"/>",
+    `B2:B11` = "<cfRule type=\"top10\" dxfId=\"0\" priority=\"2\" rank=\"20\" percent=\"1\" bottom=\"1\"/>"
   )
 
   expect_identical(exp, wb$worksheets[[1]]$conditionalFormatting)
@@ -524,12 +524,12 @@ test_that("extend dataBar tests", {
       params = list(showValue = TRUE, gradient = FALSE)
     )
 
-  exp <- c(`A1:A11` = "<cfRule type=\"dataBar\" priority=\"6\"><dataBar showValue=\"1\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FF638EC6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40000}</x14:id></ext></extLst></cfRule>",
-           `C1:C11` = "<cfRule type=\"dataBar\" priority=\"5\"><dataBar showValue=\"0\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FF638EC6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40001}</x14:id></ext></extLst></cfRule>",
-           `E1:E11` = "<cfRule type=\"dataBar\" priority=\"4\"><dataBar showValue=\"0\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FFA6A6A6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40002}</x14:id></ext></extLst></cfRule>",
-           `G1:G11` = "<cfRule type=\"dataBar\" priority=\"3\"><dataBar showValue=\"1\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FFFF0000\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40003}</x14:id></ext></extLst></cfRule>",
-           `I1:I11` = "<cfRule type=\"dataBar\" priority=\"2\"><dataBar showValue=\"1\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FFA6A6A6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40004}</x14:id></ext></extLst></cfRule>",
-           `K1:K11` = "<cfRule type=\"dataBar\" priority=\"1\"><dataBar showValue=\"1\"><cfvo type=\"num\" val=\"0\"/><cfvo type=\"num\" val=\"5\"/><color rgb=\"FFA6A6A6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40005}</x14:id></ext></extLst></cfRule>"
+  exp <- c(`A1:A11` = "<cfRule type=\"dataBar\" priority=\"1\"><dataBar showValue=\"1\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FF638EC6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40000}</x14:id></ext></extLst></cfRule>",
+           `C1:C11` = "<cfRule type=\"dataBar\" priority=\"2\"><dataBar showValue=\"0\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FF638EC6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40001}</x14:id></ext></extLst></cfRule>",
+           `E1:E11` = "<cfRule type=\"dataBar\" priority=\"3\"><dataBar showValue=\"0\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FFA6A6A6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40002}</x14:id></ext></extLst></cfRule>",
+           `G1:G11` = "<cfRule type=\"dataBar\" priority=\"4\"><dataBar showValue=\"1\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FFFF0000\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40003}</x14:id></ext></extLst></cfRule>",
+           `I1:I11` = "<cfRule type=\"dataBar\" priority=\"5\"><dataBar showValue=\"1\"><cfvo type=\"min\"/><cfvo type=\"max\"/><color rgb=\"FFA6A6A6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40004}</x14:id></ext></extLst></cfRule>",
+           `K1:K11` = "<cfRule type=\"dataBar\" priority=\"6\"><dataBar showValue=\"1\"><cfvo type=\"num\" val=\"0\"/><cfvo type=\"num\" val=\"5\"/><color rgb=\"FFA6A6A6\"/></dataBar><extLst><ext uri=\"{B025F937-C7B1-47D3-B67F-A62EFF666E3E}\" xmlns:x14=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40005}</x14:id></ext></extLst></cfRule>"
   )
   got <- wb$worksheets[[1]]$conditionalFormatting
   expect_equal(exp, got)
@@ -632,8 +632,8 @@ test_that("iconSet works", {
                                 )
 
   exp <- c(
-    "<cfRule type=\"iconSet\" priority=\"2\"><iconSet iconSet=\"5Arrows\" reverse=\"1\"><cfvo type=\"num\" val=\"-67\"/><cfvo type=\"num\" val=\"-33\"/><cfvo type=\"num\" val=\"0\"/><cfvo type=\"num\" val=\"33\"/><cfvo type=\"num\" val=\"67\"/></iconSet></cfRule>",
-    "<cfRule type=\"iconSet\" priority=\"1\"><iconSet iconSet=\"5Arrows\" showValue=\"0\"><cfvo type=\"num\" val=\"-67\"/><cfvo type=\"num\" val=\"-33\"/><cfvo type=\"num\" val=\"0\"/><cfvo type=\"num\" val=\"33\"/><cfvo type=\"num\" val=\"67\"/></iconSet></cfRule>"
+    "<cfRule type=\"iconSet\" priority=\"1\"><iconSet iconSet=\"5Arrows\" reverse=\"1\"><cfvo type=\"num\" val=\"-67\"/><cfvo type=\"num\" val=\"-33\"/><cfvo type=\"num\" val=\"0\"/><cfvo type=\"num\" val=\"33\"/><cfvo type=\"num\" val=\"67\"/></iconSet></cfRule>",
+    "<cfRule type=\"iconSet\" priority=\"2\"><iconSet iconSet=\"5Arrows\" showValue=\"0\"><cfvo type=\"num\" val=\"-67\"/><cfvo type=\"num\" val=\"-33\"/><cfvo type=\"num\" val=\"0\"/><cfvo type=\"num\" val=\"33\"/><cfvo type=\"num\" val=\"67\"/></iconSet></cfRule>"
   )
   got <- as.character(wb$worksheets[[1]]$conditionalFormatting)
   expect_equal(exp, got)
@@ -650,8 +650,8 @@ test_that("containsErrors works", {
   wb$add_conditional_formatting(dims = wb_dims(cols = 2, rows = 1:3), type = "notContainsErrors")
 
   exp <- c(
-    "<cfRule type=\"containsErrors\" dxfId=\"0\" priority=\"2\"><formula>ISERROR(A1:A3)</formula></cfRule>",
-    "<cfRule type=\"notContainsErrors\" dxfId=\"1\" priority=\"1\"><formula>NOT(ISERROR(B1:B3))</formula></cfRule>"
+    "<cfRule type=\"containsErrors\" dxfId=\"0\" priority=\"1\"><formula>ISERROR(A1:A3)</formula></cfRule>",
+    "<cfRule type=\"notContainsErrors\" dxfId=\"1\" priority=\"2\"><formula>NOT(ISERROR(B1:B3))</formula></cfRule>"
   )
   got <- as.character(wb$worksheets[[1]]$conditionalFormatting)
   expect_equal(exp, got)
@@ -668,8 +668,8 @@ test_that("containsBlanks works", {
   wb$add_conditional_formatting(dims = wb_dims(cols = 2, rows = 1:4), type = "notContainsBlanks")
 
   exp <- c(
-    "<cfRule type=\"containsBlanks\" dxfId=\"0\" priority=\"2\"><formula>LEN(TRIM(A1:A4))=0</formula></cfRule>",
-    "<cfRule type=\"notContainsBlanks\" dxfId=\"1\" priority=\"1\"><formula>LEN(TRIM(B1:B4))>0</formula></cfRule>"
+    "<cfRule type=\"containsBlanks\" dxfId=\"0\" priority=\"1\"><formula>LEN(TRIM(A1:A4))=0</formula></cfRule>",
+    "<cfRule type=\"notContainsBlanks\" dxfId=\"1\" priority=\"2\"><formula>LEN(TRIM(B1:B4))>0</formula></cfRule>"
   )
   got <- as.character(wb$worksheets[[1]]$conditionalFormatting)
   expect_equal(exp, got)
@@ -858,15 +858,15 @@ test_that("remove conditional formatting works", {
   got <- wb$worksheets[[1]]$conditionalFormatting
   expect_equal(exp, got)
 
-  exp <- c(`A1:A3` = "<cfRule type=\"expression\" dxfId=\"3\" priority=\"1\"><formula>A1&lt;2</formula></cfRule>")
+  exp <- c(`A1:A3` = "<cfRule type=\"expression\" dxfId=\"3\" priority=\"2\"><formula>A1&lt;2</formula></cfRule>")
   got <- wb$worksheets[[2]]$conditionalFormatting
   expect_equal(exp, got)
 
-  exp <- c(`A1:A3` = "<cfRule type=\"expression\" dxfId=\"5\" priority=\"1\"><formula>A1&lt;2</formula></cfRule>")
+  exp <- c(`A1:A3` = "<cfRule type=\"expression\" dxfId=\"5\" priority=\"2\"><formula>A1&lt;2</formula></cfRule>")
   got <- wb$worksheets[[3]]$conditionalFormatting
   expect_equal(exp, got)
 
-  exp <- c(`A1:A4` = "<cfRule type=\"expression\" dxfId=\"6\" priority=\"2\"><formula>A1&gt;2</formula></cfRule>")
+  exp <- c(`A1:A4` = "<cfRule type=\"expression\" dxfId=\"6\" priority=\"1\"><formula>A1&gt;2</formula></cfRule>")
   got <- wb$worksheets[[4]]$conditionalFormatting
   expect_equal(exp, got)
 })

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -250,7 +250,7 @@ test_that("type = 'colorScale' works", {
   ## If rule is NULL, min and max of cells is used. Rule must be the same length as style or NULL.
   wb$add_conditional_formatting(
     "colourScale",
-    dims = wb_dims(cols = c(1, ncol(df)), rows = seq_len(nrow(df))),
+    dims = wb_dims(cols = seq_along(df), rows = seq_len(nrow(df))),
     style = c("black", "white"),
     rule = c(0, 255),
     type = "colorScale"
@@ -386,7 +386,7 @@ test_that("colorScale", {
   ## If rule is NULL, min and max of cells is used. Rule must be the same length as style or NULL.
   wb$add_conditional_formatting(
     "colourScale1",
-    dims = wb_dims(cols = c(1, ncol(df)), rows = seq_len(nrow(df))),
+    dims = wb_dims(cols = seq_along(df), rows = seq_len(nrow(df))),
     style = c("black", "white"),
     type = "colorScale"
   )
@@ -403,7 +403,7 @@ test_that("colorScale", {
   ## If rule is NULL, min and max of cells is used. Rule must be the same length as style or NULL.
   wb$add_conditional_formatting(
     "colourScale2",
-    dims = wb_dims(cols = c(1, ncol(df)), rows = seq_len(nrow(df))),
+    dims = wb_dims(cols = seq_along(df), rows = seq_len(nrow(df))),
     style = c("blue", "red"),
     rule = c(1, 255),
     type = "colorScale"
@@ -421,7 +421,7 @@ test_that("colorScale", {
   ## If rule is NULL, min and max of cells is used. Rule must be the same length as style or NULL.
   wb$add_conditional_formatting(
     "colourScale3",
-    dims = wb_dims(cols = c(1, ncol(df)), rows = seq_len(nrow(df))),
+    dims = wb_dims(cols = seq_along(df), rows = seq_len(nrow(df))),
     style = c("red", "green", "blue"),
     type = "colorScale"
   )
@@ -441,7 +441,7 @@ test_that("colorScale", {
   ## If rule is NULL, min and max of cells is used. Rule must be the same length as style or NULL.
   wb$add_conditional_formatting(
     "colourScale4",
-    dims = wb_dims(cols = c(1, ncol(df)), rows = seq_len(nrow(df))),
+    dims = wb_dims(cols = seq_along(df), rows = seq_len(nrow(df))),
     style = c("red", "green", "blue"),
     rule = c(1, 155, 255),
     type = "colorScale"
@@ -678,13 +678,12 @@ test_that("containsBlanks works", {
 
 test_that("warning on cols > 2 and dims", {
   wb <- wb_workbook()$add_worksheet()$add_data(x = mtcars)
-  expect_warning(
+  expect_silent(
     wb$add_conditional_formatting(
       dims = wb_dims(rows = seq_len(nrow(mtcars)), cols = c(2, 4, 6)),
       type = "between",
       rule = c(2, 4)
-    ),
-    "cols > 2, will create range from min to max."
+    )
   )
 
   wb <- wb_workbook()$add_worksheet()$add_data(x = mtcars)

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -772,8 +772,8 @@ test_that("wb_add_dxfs_style() works", {
     )
 
   exp <- c(
-    `A1:A11` = "<cfRule type=\"expression\" dxfId=\"0\" priority=\"2\"><formula>A1&lt;&gt;0</formula></cfRule>",
-    `A1:A11` = "<cfRule type=\"expression\" dxfId=\"1\" priority=\"1\"><formula>A1=0</formula></cfRule>"
+    `A1:A11` = "<cfRule type=\"expression\" dxfId=\"0\" priority=\"1\"><formula>A1&lt;&gt;0</formula></cfRule>",
+    `A1:A11` = "<cfRule type=\"expression\" dxfId=\"1\" priority=\"2\"><formula>A1=0</formula></cfRule>"
   )
   got <- wb$worksheets[[1]]$conditionalFormatting
   expect_equal(exp, got)


### PR DESCRIPTION
This is a working implementation of #1346, but it reveals a major breakage.

Previously, the following would draw a mesh over the entire dimension, even though the `dims` argument itself would indicate indicate that only columns A and K are required. I'm not sure that I want this and probably, this would require a warning, whenever two columns are selected.

```R
df <- mtcars
wb_dims(cols = c(1, ncol(df)), rows = seq_len(nrow(df)))
#> "A1:A32,K1:K32"
```

Also this probably would require some further testing, I only tested the case below:

```R
library(openxlsx2)

set.seed(123)

wb <- wb_workbook()$add_worksheet()$
  add_data(x = matrix(sample(c(0, 1), replace = TRUE, size = 100), ncol = 10, nrow = 10),
           row_names = FALSE
  )

# highlight column
wb$add_fill(dims = openxlsx2::wb_dims(rows = 1, cols = seq(from = 1, to = 10, by = 2)), color = wb_color("magenta"))

wb$add_dxfs_style(
  name = "red", bg_fill = openxlsx2::wb_color("red")
)

wb$add_conditional_formatting(
  dims = openxlsx2::wb_dims(rows = c(2, 4:5, 8), cols = seq(from = 1, to = 10, by = 2)),
  rule = "==1",
  style = "red"
)

if (interactive()) wb$open()
```