### PR TITLE
[pugi] traverse

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -205,16 +205,8 @@ xml_node_create <- function(xml_name, xml_children = NULL, xml_attributes = NULL
     .Call(`_openxlsx2_xml_node_create`, xml_name, xml_children, xml_attributes, escapes, declaration)
 }
 
-xml_append_child1 <- function(node, child, pointer) {
-    .Call(`_openxlsx2_xml_append_child1`, node, child, pointer)
-}
-
-xml_append_child2 <- function(node, child, level1, pointer) {
-    .Call(`_openxlsx2_xml_append_child2`, node, child, level1, pointer)
-}
-
-xml_append_child3 <- function(node, child, level1, level2, pointer) {
-    .Call(`_openxlsx2_xml_append_child3`, node, child, level1, level2, pointer)
+xml_append_child_path <- function(node, child, path, pointer) {
+    .Call(`_openxlsx2_xml_append_child_path`, node, child, path, pointer)
 }
 
 xml_remove_child1 <- function(node, child, which, pointer) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -124,16 +124,8 @@ getXMLXPtrValPath <- function(doc, path) {
     .Call(`_openxlsx2_getXMLXPtrValPath`, doc, path)
 }
 
-getXMLXPtr1attr <- function(doc, child) {
-    .Call(`_openxlsx2_getXMLXPtr1attr`, doc, child)
-}
-
-getXMLXPtr2attr <- function(doc, level1, child) {
-    .Call(`_openxlsx2_getXMLXPtr2attr`, doc, level1, child)
-}
-
-getXMLXPtr3attr <- function(doc, level1, level2, child) {
-    .Call(`_openxlsx2_getXMLXPtr3attr`, doc, level1, level2, child)
+getXMLXPtrAttrPath <- function(doc, path) {
+    .Call(`_openxlsx2_getXMLXPtrAttrPath`, doc, path)
 }
 
 printXPtr <- function(doc, indent, raw, attr_indent) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -100,16 +100,8 @@ is_xml <- function(str) {
     .Call(`_openxlsx2_is_xml`, str)
 }
 
-getXMLXPtrName1 <- function(doc) {
-    .Call(`_openxlsx2_getXMLXPtrName1`, doc)
-}
-
-getXMLXPtrName2 <- function(doc, level1) {
-    .Call(`_openxlsx2_getXMLXPtrName2`, doc, level1)
-}
-
-getXMLXPtrName3 <- function(doc, level1, level2) {
-    .Call(`_openxlsx2_getXMLXPtrName3`, doc, level1, level2)
+getXMLXPtrNamePath <- function(doc, path) {
+    .Call(`_openxlsx2_getXMLXPtrNamePath`, doc, path)
 }
 
 getXMLXPtrPath <- function(doc, path) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -112,24 +112,8 @@ getXMLXPtrName3 <- function(doc, level1, level2) {
     .Call(`_openxlsx2_getXMLXPtrName3`, doc, level1, level2)
 }
 
-getXMLXPtr0 <- function(doc) {
-    .Call(`_openxlsx2_getXMLXPtr0`, doc)
-}
-
-getXMLXPtr1 <- function(doc, child) {
-    .Call(`_openxlsx2_getXMLXPtr1`, doc, child)
-}
-
-getXMLXPtr2 <- function(doc, level1, child) {
-    .Call(`_openxlsx2_getXMLXPtr2`, doc, level1, child)
-}
-
-getXMLXPtr3 <- function(doc, level1, level2, child) {
-    .Call(`_openxlsx2_getXMLXPtr3`, doc, level1, level2, child)
-}
-
-unkgetXMLXPtr3 <- function(doc, level1, child) {
-    .Call(`_openxlsx2_unkgetXMLXPtr3`, doc, level1, child)
+getXMLXPtrPath <- function(doc, path) {
+    .Call(`_openxlsx2_getXMLXPtrPath`, doc, path)
 }
 
 getXMLPtr1con <- function(doc) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -120,16 +120,8 @@ getXMLPtr1con <- function(doc) {
     .Call(`_openxlsx2_getXMLPtr1con`, doc)
 }
 
-getXMLXPtr1val <- function(doc, child) {
-    .Call(`_openxlsx2_getXMLXPtr1val`, doc, child)
-}
-
-getXMLXPtr2val <- function(doc, level1, child) {
-    .Call(`_openxlsx2_getXMLXPtr2val`, doc, level1, child)
-}
-
-getXMLXPtr3val <- function(doc, level1, level2, child) {
-    .Call(`_openxlsx2_getXMLXPtr3val`, doc, level1, level2, child)
+getXMLXPtrValPath <- function(doc, path) {
+    .Call(`_openxlsx2_getXMLXPtrValPath`, doc, path)
 }
 
 getXMLXPtr1attr <- function(doc, child) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -209,16 +209,8 @@ xml_append_child_path <- function(node, child, path, pointer) {
     .Call(`_openxlsx2_xml_append_child_path`, node, child, path, pointer)
 }
 
-xml_remove_child1 <- function(node, child, which, pointer) {
-    .Call(`_openxlsx2_xml_remove_child1`, node, child, which, pointer)
-}
-
-xml_remove_child2 <- function(node, child, level1, which, pointer) {
-    .Call(`_openxlsx2_xml_remove_child2`, node, child, level1, which, pointer)
-}
-
-xml_remove_child3 <- function(node, child, level1, level2, which, pointer) {
-    .Call(`_openxlsx2_xml_remove_child3`, node, child, level1, level2, which, pointer)
+xml_remove_child_path <- function(node, child, path, which, pointer) {
+    .Call(`_openxlsx2_xml_remove_child_path`, node, child, path, which, pointer)
 }
 
 is_to_txt <- function(is_vec) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -108,8 +108,8 @@ getXMLXPtrPath <- function(doc, path) {
     .Call(`_openxlsx2_getXMLXPtrPath`, doc, path)
 }
 
-getXMLPtr1con <- function(doc) {
-    .Call(`_openxlsx2_getXMLPtr1con`, doc)
+getXMLXPtrContent <- function(doc, path) {
+    .Call(`_openxlsx2_getXMLXPtrContent`, doc, path)
 }
 
 getXMLXPtrValPath <- function(doc, path) {

--- a/R/class-worksheet.R
+++ b/R/class-worksheet.R
@@ -995,7 +995,7 @@ wbWorksheet <- R6::R6Class(
       if (l_name == "x14:dataValidations") {
 
         outer <- xml_attr(ext, "ext")
-        inner <- getXMLPtr1con(read_xml(ext))
+        inner <- getXMLXPtrContent(read_xml(ext), character())
 
         xdv <- grepl(l_name, inner)
         inner <- xml_attr_mod(

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -107,6 +107,7 @@ xml_node <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL, ...) {
     if (!all(is.character(lvl)))
       stop("levels must be character vectors")
   }
+  if (is.null(lvl)) lvl <- character()
 
   z <- NULL
 
@@ -115,11 +116,7 @@ xml_node <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL, ...) {
 
 
   if (inherits(xml, "pugi_xml")) {
-    if (length(lvl) == 0) z <- getXMLXPtr0(xml)
-    if (length(lvl) == 1) z <- getXMLXPtr1(xml, level1)
-    if (length(lvl) == 2) z <- getXMLXPtr2(xml, level1, level2)
-    if (length(lvl) == 3) z <- getXMLXPtr3(xml, level1, level2, level3)
-    if (length(lvl) == 3 && level2 == "*") z <- unkgetXMLXPtr3(xml, level1, level3)
+    z <- getXMLXPtrPath(xml, lvl)
   }
 
   z

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -310,19 +310,11 @@ xml_add_child <- function(xml_node, xml_child, level, pointer = FALSE, ...) {
 
   xml_child <- read_xml(xml_child, ...)
 
-  if (missing(level)) {
-    z <- xml_append_child1(xml_node, xml_child, pointer)
-  } else {
+  if (missing(level)) level <- character()
 
-    if (length(level) == 1)
-      z <- xml_append_child2(xml_node, xml_child, level[[1]], pointer)
+  z <- xml_append_child_path(xml_node, xml_child, level, pointer)
 
-    if (length(level) == 2)
-      z <- xml_append_child3(xml_node, xml_child, level[[1]], level[[2]], pointer)
-
-  }
-
-  return(z)
+  z
 }
 
 

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -122,11 +122,9 @@ xml_node <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL, ...) {
 #' @export
 xml_node_name <- function(xml, level1 = NULL, level2 = NULL, ...) {
   lvl <- c(level1, level2)
+  if (is.null(lvl)) lvl <- character()
   if (!inherits(xml, "pugi_xml")) xml <- read_xml(xml, ...)
-  if (length(lvl) == 0) z <- getXMLXPtrName1(xml)
-  if (length(lvl) == 1) z <- getXMLXPtrName2(xml, level1)
-  if (length(lvl) == 2) z <- getXMLXPtrName3(xml, level1, level2)
-  z
+  getXMLXPtrNamePath(xml, lvl)
 }
 
 #' xml_value

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -188,15 +188,15 @@ xml_attr <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL,  ...) {
   if (!all(is.character(lvl)))
     stop("levels must be character vectors")
 
+  if (is.null(lvl)) lvl <- character()
+
   z <- NULL
 
   if (!inherits(xml, "pugi_xml"))
     xml <- read_xml(xml, ...)
 
   if (inherits(xml, "pugi_xml")) {
-    if (length(lvl) == 1) z <- getXMLXPtr1attr(xml, level1)
-    if (length(lvl) == 2) z <- getXMLXPtr2attr(xml, level1, level2)
-    if (length(lvl) == 3) z <- getXMLXPtr3attr(xml, level1, level2, level3)
+    z <- getXMLXPtrAttrPath(xml, lvl)
   }
 
   z

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -109,17 +109,10 @@ xml_node <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL, ...) {
   }
   if (is.null(lvl)) lvl <- character()
 
-  z <- NULL
-
   if (!inherits(xml, "pugi_xml"))
     xml <- read_xml(xml, ...)
 
-
-  if (inherits(xml, "pugi_xml")) {
-    z <- getXMLXPtrPath(xml, lvl)
-  }
-
-  z
+  getXMLXPtrPath(xml, lvl)
 }
 
 #' @rdname pugixml
@@ -155,16 +148,10 @@ xml_value <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL, ...) {
 
   if (is.null(lvl)) lvl <- character()
 
-  z <- NULL
-
   if (!inherits(xml, "pugi_xml"))
     xml <- read_xml(xml, ...)
 
-  if (inherits(xml, "pugi_xml")) {
-    z <- getXMLXPtrValPath(xml, lvl)
-  }
-
-  z
+  getXMLXPtrValPath(xml, lvl)
 }
 
 #' @rdname pugixml
@@ -190,16 +177,10 @@ xml_attr <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL,  ...) {
 
   if (is.null(lvl)) lvl <- character()
 
-  z <- NULL
-
   if (!inherits(xml, "pugi_xml"))
     xml <- read_xml(xml, ...)
 
-  if (inherits(xml, "pugi_xml")) {
-    z <- getXMLXPtrAttrPath(xml, lvl)
-  }
-
-  z
+  getXMLXPtrAttrPath(xml, lvl)
 }
 
 #' print pugi_xml
@@ -312,9 +293,7 @@ xml_add_child <- function(xml_node, xml_child, level, pointer = FALSE, ...) {
 
   if (missing(level)) level <- character()
 
-  z <- xml_append_child_path(xml_node, xml_child, level, pointer)
-
-  z
+  xml_append_child_path(xml_node, xml_child, level, pointer)
 }
 
 
@@ -349,17 +328,7 @@ xml_rm_child <- function(xml_node, xml_child, level, which = 0, pointer = FALSE,
 
   which <- which - 1
 
-  if (missing(level)) {
-    z <- xml_remove_child1(xml_node, xml_child, which, pointer)
-  } else {
+  if (missing(level)) level <- character()
 
-    if (length(level) == 1)
-      z <- xml_remove_child2(xml_node, xml_child, level[[1]], which, pointer)
-
-    if (length(level) == 2)
-      z <- xml_remove_child3(xml_node, xml_child, level[[1]], level[[2]], which, pointer)
-
-  }
-
-  return(z)
+  xml_remove_child_path(xml_node, xml_child, level, which, pointer)
 }

--- a/R/pugixml.R
+++ b/R/pugixml.R
@@ -153,15 +153,15 @@ xml_value <- function(xml, level1 = NULL, level2 = NULL, level3 = NULL, ...) {
   if (!all(is.character(lvl)))
     stop("levels must be character vectors")
 
+  if (is.null(lvl)) lvl <- character()
+
   z <- NULL
 
   if (!inherits(xml, "pugi_xml"))
     xml <- read_xml(xml, ...)
 
   if (inherits(xml, "pugi_xml")) {
-    if (length(lvl) == 1) z <- getXMLXPtr1val(xml, level1)
-    if (length(lvl) == 2) z <- getXMLXPtr2val(xml, level1, level2)
-    if (length(lvl) == 3) z <- getXMLXPtr3val(xml, level1, level2, level3)
+    z <- getXMLXPtrValPath(xml, lvl)
   }
 
   z

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -349,45 +349,13 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// getXMLXPtr1val
-SEXP getXMLXPtr1val(XPtrXML doc, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr1val(SEXP docSEXP, SEXP childSEXP) {
+// getXMLXPtrValPath
+SEXP getXMLXPtrValPath(XPtrXML doc, std::vector<std::string> path);
+RcppExport SEXP _openxlsx2_getXMLXPtrValPath(SEXP docSEXP, SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr1val(doc, child));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtr2val
-SEXP getXMLXPtr2val(XPtrXML doc, std::string level1, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr2val(SEXP docSEXP, SEXP level1SEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr2val(doc, level1, child));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtr3val
-SEXP getXMLXPtr3val(XPtrXML doc, std::string level1, std::string level2, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr3val(SEXP docSEXP, SEXP level1SEXP, SEXP level2SEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr3val(doc, level1, level2, child));
-    return rcpp_result_gen;
-END_RCPP
-}
 // getXMLXPtr1attr
 SEXP getXMLXPtr1attr(XPtrXML doc, std::string child);
 RcppExport SEXP _openxlsx2_getXMLXPtr1attr(SEXP docSEXP, SEXP childSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -290,39 +290,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// getXMLXPtrName1
-SEXP getXMLXPtrName1(XPtrXML doc);
-RcppExport SEXP _openxlsx2_getXMLXPtrName1(SEXP docSEXP) {
+// getXMLXPtrNamePath
+SEXP getXMLXPtrNamePath(XPtrXML doc, std::vector<std::string> path);
+RcppExport SEXP _openxlsx2_getXMLXPtrNamePath(SEXP docSEXP, SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtrName1(doc));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtrName2
-SEXP getXMLXPtrName2(XPtrXML doc, std::string level1);
-RcppExport SEXP _openxlsx2_getXMLXPtrName2(SEXP docSEXP, SEXP level1SEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtrName2(doc, level1));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtrName3
-SEXP getXMLXPtrName3(XPtrXML doc, std::string level1, std::string level2);
-RcppExport SEXP _openxlsx2_getXMLXPtrName3(SEXP docSEXP, SEXP level1SEXP, SEXP level2SEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtrName3(doc, level1, level2));
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
+    rcpp_result_gen = Rcpp::wrap(getXMLXPtrNamePath(doc, path));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -870,9 +846,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_loadvals", (DL_FUNC) &_openxlsx2_loadvals, 2},
     {"_openxlsx2_readXML", (DL_FUNC) &_openxlsx2_readXML, 8},
     {"_openxlsx2_is_xml", (DL_FUNC) &_openxlsx2_is_xml, 1},
-    {"_openxlsx2_getXMLXPtrName1", (DL_FUNC) &_openxlsx2_getXMLXPtrName1, 1},
-    {"_openxlsx2_getXMLXPtrName2", (DL_FUNC) &_openxlsx2_getXMLXPtrName2, 2},
-    {"_openxlsx2_getXMLXPtrName3", (DL_FUNC) &_openxlsx2_getXMLXPtrName3, 3},
+    {"_openxlsx2_getXMLXPtrNamePath", (DL_FUNC) &_openxlsx2_getXMLXPtrNamePath, 2},
     {"_openxlsx2_getXMLXPtrPath", (DL_FUNC) &_openxlsx2_getXMLXPtrPath, 2},
     {"_openxlsx2_getXMLPtr1con", (DL_FUNC) &_openxlsx2_getXMLPtr1con, 1},
     {"_openxlsx2_getXMLXPtrValPath", (DL_FUNC) &_openxlsx2_getXMLXPtrValPath, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -326,66 +326,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// getXMLXPtr0
-SEXP getXMLXPtr0(XPtrXML doc);
-RcppExport SEXP _openxlsx2_getXMLXPtr0(SEXP docSEXP) {
+// getXMLXPtrPath
+SEXP getXMLXPtrPath(XPtrXML doc, std::vector<std::string> path);
+RcppExport SEXP _openxlsx2_getXMLXPtrPath(SEXP docSEXP, SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr0(doc));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtr1
-SEXP getXMLXPtr1(XPtrXML doc, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr1(SEXP docSEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr1(doc, child));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtr2
-SEXP getXMLXPtr2(XPtrXML doc, std::string level1, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr2(SEXP docSEXP, SEXP level1SEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr2(doc, level1, child));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtr3
-SEXP getXMLXPtr3(XPtrXML doc, std::string level1, std::string level2, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr3(SEXP docSEXP, SEXP level1SEXP, SEXP level2SEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr3(doc, level1, level2, child));
-    return rcpp_result_gen;
-END_RCPP
-}
-// unkgetXMLXPtr3
-SEXP unkgetXMLXPtr3(XPtrXML doc, std::string level1, std::string child);
-RcppExport SEXP _openxlsx2_unkgetXMLXPtr3(SEXP docSEXP, SEXP level1SEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(unkgetXMLXPtr3(doc, level1, child));
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
+    rcpp_result_gen = Rcpp::wrap(getXMLXPtrPath(doc, path));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1036,18 +985,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_getXMLXPtrName1", (DL_FUNC) &_openxlsx2_getXMLXPtrName1, 1},
     {"_openxlsx2_getXMLXPtrName2", (DL_FUNC) &_openxlsx2_getXMLXPtrName2, 2},
     {"_openxlsx2_getXMLXPtrName3", (DL_FUNC) &_openxlsx2_getXMLXPtrName3, 3},
-    {"_openxlsx2_getXMLXPtr0", (DL_FUNC) &_openxlsx2_getXMLXPtr0, 1},
-    {"_openxlsx2_getXMLXPtr1", (DL_FUNC) &_openxlsx2_getXMLXPtr1, 2},
-    {"_openxlsx2_getXMLXPtr2", (DL_FUNC) &_openxlsx2_getXMLXPtr2, 3},
-    {"_openxlsx2_getXMLXPtr3", (DL_FUNC) &_openxlsx2_getXMLXPtr3, 4},
-    {"_openxlsx2_unkgetXMLXPtr3", (DL_FUNC) &_openxlsx2_unkgetXMLXPtr3, 3},
+    {"_openxlsx2_getXMLXPtrPath", (DL_FUNC) &_openxlsx2_getXMLXPtrPath, 2},
     {"_openxlsx2_getXMLPtr1con", (DL_FUNC) &_openxlsx2_getXMLPtr1con, 1},
-    {"_openxlsx2_getXMLXPtr1val", (DL_FUNC) &_openxlsx2_getXMLXPtr1val, 2},
-    {"_openxlsx2_getXMLXPtr2val", (DL_FUNC) &_openxlsx2_getXMLXPtr2val, 3},
-    {"_openxlsx2_getXMLXPtr3val", (DL_FUNC) &_openxlsx2_getXMLXPtr3val, 4},
-    {"_openxlsx2_getXMLXPtr1attr", (DL_FUNC) &_openxlsx2_getXMLXPtr1attr, 2},
-    {"_openxlsx2_getXMLXPtr2attr", (DL_FUNC) &_openxlsx2_getXMLXPtr2attr, 3},
-    {"_openxlsx2_getXMLXPtr3attr", (DL_FUNC) &_openxlsx2_getXMLXPtr3attr, 4},
+    {"_openxlsx2_getXMLXPtrValPath", (DL_FUNC) &_openxlsx2_getXMLXPtrValPath, 2},
+    {"_openxlsx2_getXMLXPtrAttrPath", (DL_FUNC) &_openxlsx2_getXMLXPtrAttrPath, 2},
     {"_openxlsx2_printXPtr", (DL_FUNC) &_openxlsx2_printXPtr, 4},
     {"_openxlsx2_write_xml_file", (DL_FUNC) &_openxlsx2_write_xml_file, 2},
     {"_openxlsx2_xml_attr_mod", (DL_FUNC) &_openxlsx2_xml_attr_mod, 5},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -443,48 +443,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// xml_remove_child1
-SEXP xml_remove_child1(XPtrXML node, std::string child, int32_t which, bool pointer);
-RcppExport SEXP _openxlsx2_xml_remove_child1(SEXP nodeSEXP, SEXP childSEXP, SEXP whichSEXP, SEXP pointerSEXP) {
+// xml_remove_child_path
+SEXP xml_remove_child_path(XPtrXML node, std::string child, std::vector<std::string> path, int32_t which, bool pointer);
+RcppExport SEXP _openxlsx2_xml_remove_child_path(SEXP nodeSEXP, SEXP childSEXP, SEXP pathSEXP, SEXP whichSEXP, SEXP pointerSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
     Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
     Rcpp::traits::input_parameter< int32_t >::type which(whichSEXP);
     Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_remove_child1(node, child, which, pointer));
-    return rcpp_result_gen;
-END_RCPP
-}
-// xml_remove_child2
-SEXP xml_remove_child2(XPtrXML node, std::string child, std::string level1, int32_t which, bool pointer);
-RcppExport SEXP _openxlsx2_xml_remove_child2(SEXP nodeSEXP, SEXP childSEXP, SEXP level1SEXP, SEXP whichSEXP, SEXP pointerSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< int32_t >::type which(whichSEXP);
-    Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_remove_child2(node, child, level1, which, pointer));
-    return rcpp_result_gen;
-END_RCPP
-}
-// xml_remove_child3
-SEXP xml_remove_child3(XPtrXML node, std::string child, std::string level1, std::string level2, int32_t which, bool pointer);
-RcppExport SEXP _openxlsx2_xml_remove_child3(SEXP nodeSEXP, SEXP childSEXP, SEXP level1SEXP, SEXP level2SEXP, SEXP whichSEXP, SEXP pointerSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
-    Rcpp::traits::input_parameter< int32_t >::type which(whichSEXP);
-    Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_remove_child3(node, child, level1, level2, which, pointer));
+    rcpp_result_gen = Rcpp::wrap(xml_remove_child_path(node, child, path, which, pointer));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -912,9 +882,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_xml_attr_mod", (DL_FUNC) &_openxlsx2_xml_attr_mod, 5},
     {"_openxlsx2_xml_node_create", (DL_FUNC) &_openxlsx2_xml_node_create, 5},
     {"_openxlsx2_xml_append_child_path", (DL_FUNC) &_openxlsx2_xml_append_child_path, 4},
-    {"_openxlsx2_xml_remove_child1", (DL_FUNC) &_openxlsx2_xml_remove_child1, 4},
-    {"_openxlsx2_xml_remove_child2", (DL_FUNC) &_openxlsx2_xml_remove_child2, 5},
-    {"_openxlsx2_xml_remove_child3", (DL_FUNC) &_openxlsx2_xml_remove_child3, 6},
+    {"_openxlsx2_xml_remove_child_path", (DL_FUNC) &_openxlsx2_xml_remove_child_path, 5},
     {"_openxlsx2_is_to_txt", (DL_FUNC) &_openxlsx2_is_to_txt, 1},
     {"_openxlsx2_si_to_txt", (DL_FUNC) &_openxlsx2_si_to_txt, 1},
     {"_openxlsx2_txt_to_is", (DL_FUNC) &_openxlsx2_txt_to_is, 4},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -429,45 +429,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// xml_append_child1
-SEXP xml_append_child1(XPtrXML node, XPtrXML child, bool pointer);
-RcppExport SEXP _openxlsx2_xml_append_child1(SEXP nodeSEXP, SEXP childSEXP, SEXP pointerSEXP) {
+// xml_append_child_path
+SEXP xml_append_child_path(XPtrXML node, XPtrXML child, std::vector<std::string> path, bool pointer);
+RcppExport SEXP _openxlsx2_xml_append_child_path(SEXP nodeSEXP, SEXP childSEXP, SEXP pathSEXP, SEXP pointerSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
     Rcpp::traits::input_parameter< XPtrXML >::type child(childSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
     Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_append_child1(node, child, pointer));
-    return rcpp_result_gen;
-END_RCPP
-}
-// xml_append_child2
-SEXP xml_append_child2(XPtrXML node, XPtrXML child, std::string level1, bool pointer);
-RcppExport SEXP _openxlsx2_xml_append_child2(SEXP nodeSEXP, SEXP childSEXP, SEXP level1SEXP, SEXP pointerSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
-    Rcpp::traits::input_parameter< XPtrXML >::type child(childSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_append_child2(node, child, level1, pointer));
-    return rcpp_result_gen;
-END_RCPP
-}
-// xml_append_child3
-SEXP xml_append_child3(XPtrXML node, XPtrXML child, std::string level1, std::string level2, bool pointer);
-RcppExport SEXP _openxlsx2_xml_append_child3(SEXP nodeSEXP, SEXP childSEXP, SEXP level1SEXP, SEXP level2SEXP, SEXP pointerSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type node(nodeSEXP);
-    Rcpp::traits::input_parameter< XPtrXML >::type child(childSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
-    Rcpp::traits::input_parameter< bool >::type pointer(pointerSEXP);
-    rcpp_result_gen = Rcpp::wrap(xml_append_child3(node, child, level1, level2, pointer));
+    rcpp_result_gen = Rcpp::wrap(xml_append_child_path(node, child, path, pointer));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -939,9 +911,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_write_xml_file", (DL_FUNC) &_openxlsx2_write_xml_file, 2},
     {"_openxlsx2_xml_attr_mod", (DL_FUNC) &_openxlsx2_xml_attr_mod, 5},
     {"_openxlsx2_xml_node_create", (DL_FUNC) &_openxlsx2_xml_node_create, 5},
-    {"_openxlsx2_xml_append_child1", (DL_FUNC) &_openxlsx2_xml_append_child1, 3},
-    {"_openxlsx2_xml_append_child2", (DL_FUNC) &_openxlsx2_xml_append_child2, 4},
-    {"_openxlsx2_xml_append_child3", (DL_FUNC) &_openxlsx2_xml_append_child3, 5},
+    {"_openxlsx2_xml_append_child_path", (DL_FUNC) &_openxlsx2_xml_append_child_path, 4},
     {"_openxlsx2_xml_remove_child1", (DL_FUNC) &_openxlsx2_xml_remove_child1, 4},
     {"_openxlsx2_xml_remove_child2", (DL_FUNC) &_openxlsx2_xml_remove_child2, 5},
     {"_openxlsx2_xml_remove_child3", (DL_FUNC) &_openxlsx2_xml_remove_child3, 6},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -356,42 +356,20 @@ BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-// getXMLXPtr1attr
-SEXP getXMLXPtr1attr(XPtrXML doc, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr1attr(SEXP docSEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr1attr(doc, child));
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
+    rcpp_result_gen = Rcpp::wrap(getXMLXPtrValPath(doc, path));
     return rcpp_result_gen;
 END_RCPP
 }
-// getXMLXPtr2attr
-Rcpp::List getXMLXPtr2attr(XPtrXML doc, std::string level1, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr2attr(SEXP docSEXP, SEXP level1SEXP, SEXP childSEXP) {
+// getXMLXPtrAttrPath
+SEXP getXMLXPtrAttrPath(XPtrXML doc, std::vector<std::string> path);
+RcppExport SEXP _openxlsx2_getXMLXPtrAttrPath(SEXP docSEXP, SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr2attr(doc, level1, child));
-    return rcpp_result_gen;
-END_RCPP
-}
-// getXMLXPtr3attr
-SEXP getXMLXPtr3attr(XPtrXML doc, std::string level1, std::string level2, std::string child);
-RcppExport SEXP _openxlsx2_getXMLXPtr3attr(SEXP docSEXP, SEXP level1SEXP, SEXP level2SEXP, SEXP childSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    Rcpp::traits::input_parameter< std::string >::type level1(level1SEXP);
-    Rcpp::traits::input_parameter< std::string >::type level2(level2SEXP);
-    Rcpp::traits::input_parameter< std::string >::type child(childSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLXPtr3attr(doc, level1, level2, child));
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
+    rcpp_result_gen = Rcpp::wrap(getXMLXPtrAttrPath(doc, path));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -314,14 +314,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// getXMLPtr1con
-SEXP getXMLPtr1con(XPtrXML doc);
-RcppExport SEXP _openxlsx2_getXMLPtr1con(SEXP docSEXP) {
+// getXMLXPtrContent
+SEXP getXMLXPtrContent(XPtrXML doc, std::vector<std::string> path);
+RcppExport SEXP _openxlsx2_getXMLXPtrContent(SEXP docSEXP, SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrXML >::type doc(docSEXP);
-    rcpp_result_gen = Rcpp::wrap(getXMLPtr1con(doc));
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type path(pathSEXP);
+    rcpp_result_gen = Rcpp::wrap(getXMLXPtrContent(doc, path));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -848,7 +849,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_is_xml", (DL_FUNC) &_openxlsx2_is_xml, 1},
     {"_openxlsx2_getXMLXPtrNamePath", (DL_FUNC) &_openxlsx2_getXMLXPtrNamePath, 2},
     {"_openxlsx2_getXMLXPtrPath", (DL_FUNC) &_openxlsx2_getXMLXPtrPath, 2},
-    {"_openxlsx2_getXMLPtr1con", (DL_FUNC) &_openxlsx2_getXMLPtr1con, 1},
+    {"_openxlsx2_getXMLXPtrContent", (DL_FUNC) &_openxlsx2_getXMLXPtrContent, 2},
     {"_openxlsx2_getXMLXPtrValPath", (DL_FUNC) &_openxlsx2_getXMLXPtrValPath, 2},
     {"_openxlsx2_getXMLXPtrAttrPath", (DL_FUNC) &_openxlsx2_getXMLXPtrAttrPath, 2},
     {"_openxlsx2_printXPtr", (DL_FUNC) &_openxlsx2_printXPtr, 4},

--- a/src/pugi.cpp
+++ b/src/pugi.cpp
@@ -68,38 +68,30 @@ Rcpp::LogicalVector is_xml(std::string str) {
 }
 
 // [[Rcpp::export]]
-SEXP getXMLXPtrName1(XPtrXML doc) {
-  vec_string res;
+SEXP getXMLXPtrNamePath(XPtrXML doc, std::vector<std::string> path) {
+  std::vector<pugi::xml_node> nodes = { *doc }; // Start from the root node
+  std::vector<pugi::xml_node> next_nodes;
 
-  for (auto lvl0 : doc->children()) {
-    res.push_back(lvl0.name());
-  }
-
-  return Rcpp::wrap(res);
-}
-
-// [[Rcpp::export]]
-SEXP getXMLXPtrName2(XPtrXML doc, std::string level1) {
-  vec_string res;
-
-  for (auto lvl0 : doc->children(level1.c_str())) {
-    for (auto lvl1 : lvl0.children()) {
-      res.push_back(lvl1.name());
-    }
-  }
-
-  return Rcpp::wrap(res);
-}
-
-// [[Rcpp::export]]
-SEXP getXMLXPtrName3(XPtrXML doc, std::string level1, std::string level2) {
-  vec_string res;
-
-  for (auto lvl0 : doc->children(level1.c_str())) {
-    for (auto lvl1 : lvl0.children()) {
-      for (auto lvl2 : lvl1.children()) {
-        res.push_back(lvl2.name());
+  for (const auto& tag : path) {
+    next_nodes.clear();
+    for (const auto& node : nodes) {
+      if (tag == "*") {
+        for (auto ch : node.children()) {
+          next_nodes.push_back(ch);
+        }
+      } else {
+        for (auto ch : node.children(tag.c_str())) {
+          next_nodes.push_back(ch);
+        }
       }
+    }
+    nodes = next_nodes;
+  }
+
+  vec_string res;
+  for (const auto& node : nodes) {
+    for (auto ch : node.children()) {
+      res.push_back(ch.name());
     }
   }
 

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -178,10 +178,10 @@ test_that("is_xml", {
 
 })
 
-test_that("getXMLPtr1con", {
+test_that("getXMLXPtrContent", {
 
   xml <- "<xml><a/><a/><b/></xml>"
-  got <- getXMLPtr1con(read_xml(xml))
+  got <- getXMLXPtrContent(read_xml(xml), character())
   exp <- c("<a/>", "<a/>", "<b/>")
   expect_equal(got, exp)
 

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -56,15 +56,15 @@ test_that("xml_value", {
 
   xml_str <- "<a>1</a>"
   xml <- read_xml(xml_str)
-  expect_equal(exp, getXMLXPtr1val(xml, "a"))
+  expect_equal(exp, getXMLXPtrValPath(xml, "a"))
 
   xml_str <- "<a><b>1</b></a>"
   xml <- read_xml(xml_str)
-  expect_equal(exp, getXMLXPtr2val(xml, "a", "b"))
+  expect_equal(exp, getXMLXPtrValPath(xml, c("a", "b")))
 
   xml_str <- "<a><b><c>1</c></b></a>"
   xml <- read_xml(xml_str)
-  expect_equal(exp, getXMLXPtr3val(xml, "a", "b", "c"))
+  expect_equal(exp, getXMLXPtrValPath(xml, c("a", "b", "c")))
 
 })
 

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -36,16 +36,17 @@ test_that("xml_node", {
 
   exp <- xml_str
   expect_equal("a", getXMLXPtrName1(xml))
-  expect_equal(exp, getXMLXPtr0(xml))
-  expect_equal(exp, getXMLXPtr1(xml, "a"))
+  expect_equal(exp, getXMLXPtrPath(xml, character()))
+  expect_equal(exp, getXMLXPtrPath(xml, "a"))
 
   exp <- "<b><c><d><e/></d></c></b>"
-  expect_equal(exp, getXMLXPtr2(xml, "a", "b"))
+  expect_equal(exp, getXMLXPtrPath(xml, c("a", "b")))
 
   exp <- "<c><d><e/></d></c>"
-  expect_equal(exp, getXMLXPtr3(xml, "a", "b", "c"))
+  expect_equal(exp, getXMLXPtrPath(xml, c("a", "b", "c")))
+
   # bit cheating, this test returns the same, but not the actual feature of "*"
-  expect_equal(exp, unkgetXMLXPtr3(xml, "a", "c"))
+  expect_equal(exp, getXMLXPtrPath(xml, c("a", "*", "c")))
 
 })
 

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -74,15 +74,15 @@ test_that("xml_attr", {
 
   xml_str <- "<a a=\"1\"/>"
   xml <- read_xml(xml_str)
-  expect_equal(getXMLXPtr1attr(xml, "a"), exp)
+  expect_equal(getXMLXPtrAttrPath(xml, "a"), exp)
 
   xml_str <- "<b><a a=\"1\"/></b>"
   xml <- read_xml(xml_str)
-  expect_equal(getXMLXPtr2attr(xml, "b", "a"), exp)
+  expect_equal(getXMLXPtrAttrPath(xml, c("b", "a")), exp)
 
   xml_str <- "<c><b><a a=\"1\"/></b></c>"
   xml <- read_xml(xml_str)
-  expect_equal(getXMLXPtr3attr(xml, "c", "b", "a"), exp)
+  expect_equal(getXMLXPtrAttrPath(xml, c("c", "b", "a")), exp)
 
 })
 

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -35,7 +35,7 @@ test_that("xml_node", {
   xml <- read_xml(xml_str)
 
   exp <- xml_str
-  expect_equal("a", getXMLXPtrName1(xml))
+  expect_equal("a", getXMLXPtrNamePath(xml, character()))
   expect_equal(exp, getXMLXPtrPath(xml, character()))
   expect_equal(exp, getXMLXPtrPath(xml, "a"))
 

--- a/tests/testthat/test-pugi_cpp.R
+++ b/tests/testthat/test-pugi_cpp.R
@@ -91,50 +91,54 @@ test_that("xml_append_child", {
   xml_node <- read_xml("<node><child1/><child2/></node>")
   xml_child <- read_xml("<new_child>&</new_child>")
   exp <- "<node><child1/><child2/><new_child>&</new_child></node>"
-  expect_equal(xml_append_child1(xml_node, xml_child, pointer = FALSE), exp)
+  level <- character()
+  expect_equal(xml_append_child_path(xml_node, xml_child, level, pointer = FALSE), exp)
 
   # xml_node sets the flags for both
   xml_node <- read_xml("<node><child1/><child2/></node>", escapes = TRUE)
   xml_child <- read_xml("<new_child>&</new_child>")
   exp <- "<node><child1/><child2/><new_child>&amp;</new_child></node>"
-  expect_equal(xml_append_child1(xml_node, xml_child, pointer = FALSE), exp)
+  level <- character()
+  expect_equal(xml_append_child_path(xml_node, xml_child, level, pointer = FALSE), exp)
 
 
   xml_node <- "<a><b/></a>"
   xml_child <- read_xml("<c/>")
+  level <- character()
 
-  xml_node <- xml_append_child1(read_xml(xml_node), xml_child, pointer = FALSE)
+  xml_node <- xml_append_child_path(read_xml(xml_node), xml_child, level, pointer = FALSE)
   expect_equal(xml_node, "<a><b/><c/></a>")
 
-  xml_node <- xml_append_child2(read_xml(xml_node), xml_child, level1 = "b", pointer = FALSE)
+  xml_node <- xml_append_child_path(read_xml(xml_node), xml_child, c(level1 = "b"), pointer = FALSE)
   expect_equal(xml_node, "<a><b><c/></b><c/></a>")
 
-  xml_node <- xml_append_child3(read_xml(xml_node), read_xml("<d/>"), level1 = "b", level2 = "c", pointer = FALSE)
+  xml_node <- xml_append_child_path(read_xml(xml_node), read_xml("<d/>"), c(level1 = "b", level2 = "c"), pointer = FALSE)
   expect_equal(xml_node, "<a><b><c><d/></c></b><c/></a>")
 
 
   # check that escapes does not throw a warning
   xml_node <- "<a><b/></a>"
   xml_child <- read_xml("<c>a&b</c>", escapes = FALSE)
+  level <- character()
 
-  xml_node <- xml_append_child1(read_xml(xml_node, escapes = TRUE), xml_child, pointer = FALSE)
+  xml_node <- xml_append_child_path(read_xml(xml_node, escapes = TRUE), xml_child, level, pointer = FALSE)
   expect_equal(xml_node, "<a><b/><c>a&amp;b</c></a>")
 
-  xml_node <- xml_append_child2(read_xml(xml_node, escapes = TRUE), xml_child, level1 = "b", pointer = FALSE)
+  xml_node <- xml_append_child_path(read_xml(xml_node, escapes = TRUE), xml_child, c(level1 = "b"), pointer = FALSE)
   expect_equal(xml_node, "<a><b><c>a&amp;b</c></b><c>a&amp;b</c></a>")
 
-  xml_node <- xml_append_child3(read_xml(xml_node, escapes = TRUE), read_xml("<d/>"), level1 = "b", level2 = "c", pointer = FALSE)
+  xml_node <- xml_append_child_path(read_xml(xml_node, escapes = TRUE), read_xml("<d/>"), c(level1 = "b", level2 = "c"), pointer = FALSE)
   expect_equal(xml_node, "<a><b><c>a&amp;b<d/></c></b><c>a&amp;b</c></a>")
 
   # check that pointer is valid
-  expect_s3_class(xml_append_child1(read_xml(xml_node), xml_child, pointer = TRUE), "pugi_xml")
-  expect_s3_class(xml_append_child1(read_xml(xml_node), xml_child, pointer = TRUE), "pugi_xml")
+  expect_s3_class(xml_append_child_path(read_xml(xml_node), xml_child, level, pointer = TRUE), "pugi_xml")
+  expect_s3_class(xml_append_child_path(read_xml(xml_node), xml_child, level, pointer = TRUE), "pugi_xml")
 
-  expect_s3_class(xml_append_child2(read_xml(xml_node), xml_child, level1 = "a", pointer = TRUE), "pugi_xml")
-  expect_s3_class(xml_append_child2(read_xml(xml_node), xml_child, level1 = "a", pointer = TRUE), "pugi_xml")
+  expect_s3_class(xml_append_child_path(read_xml(xml_node), xml_child, c(level1 = "a"), pointer = TRUE), "pugi_xml")
+  expect_s3_class(xml_append_child_path(read_xml(xml_node), xml_child, c(level1 = "a"), pointer = TRUE), "pugi_xml")
 
-  expect_s3_class(xml_append_child3(read_xml(xml_node), xml_child, level1 = "a", level2 = "b", pointer = TRUE), "pugi_xml")
-  expect_s3_class(xml_append_child3(read_xml(xml_node), xml_child, level1 = "a", level2 = "b", pointer = TRUE), "pugi_xml")
+  expect_s3_class(xml_append_child_path(read_xml(xml_node), xml_child, c(level1 = "a", level2 = "b"), pointer = TRUE), "pugi_xml")
+  expect_s3_class(xml_append_child_path(read_xml(xml_node), xml_child, c(level1 = "a", level2 = "b"), pointer = TRUE), "pugi_xml")
 
 })
 

--- a/tests/testthat/test-pugixml.R
+++ b/tests/testthat/test-pugixml.R
@@ -98,7 +98,7 @@ test_that("xml_node", {
   expect_error(xml_node(x, 1))
 
   expect_equal(xml_node(x, "a", "b"), "<b/>")
-
+  expect_equal(xml_node(x, c("a", "b")), "<b/>")
 
   expect_equal(xml_node("<a><b/></a>", "a"), xml)
 


### PR DESCRIPTION
Lifts the limit of three levels. Allows more wildcards. Needs more reviews and probably more cleanups.

``` r
library(openxlsx2)
x <- read_xml("<a><b><c><d/></c></b></a>")
xml_node(x)
#> [1] "<a><b><c><d/></c></b></a>"
xml_node(x, c("a"))
#> [1] "<a><b><c><d/></c></b></a>"
xml_node(x, c("a", "b"))
#> [1] "<b><c><d/></c></b>"
xml_node(x, c("a", "b", "c"))
#> [1] "<c><d/></c>"
xml_node(x, c("a", "b", "c", "d"))
#> [1] "<d/>"
xml_node(x, c("a", "*", "*", "d"))
#> [1] "<d/>"
```