### PR TITLE
[misc] treat sheets that are factors as characters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openxlsx2 (development version)
 
+## New features
+
+* If a sheet name is a factor, it will be treated as character. [1436](https://github.com/JanMarvin/openxlsx2/pull/1436)
+
 ## Fixes
 
 * The speedup of the style functions caused a bug, where adding borders on a cell range with different cell styles, assigned the inner cell styles in an arbitrary order. [1431](https://github.com/JanMarvin/openxlsx2/pull/1431)

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -9763,6 +9763,10 @@ wbWorkbook <- R6::R6Class(
         return(NA_integer_)
       }
 
+      if (is.factor(sheet)) {
+        sheet <- as.character(sheet)
+      }
+
       if (is.character(sheet)) {
         sheet <- tolower(sheet)
         m1 <- match(sheet, tolower(self$sheet_names))

--- a/R/read.R
+++ b/R/read.R
@@ -274,6 +274,10 @@ wb_to_df <- function(
     sheet <- 1
   }
 
+  if (is.factor(sheet)) {
+    sheet <- as.character(sheet)
+  }
+
   if (is.character(sheet)) {
     sheet <- wb_validate_sheet(wb, sheet)
   }

--- a/tests/testthat/test-read_from_created_wb.R
+++ b/tests/testthat/test-read_from_created_wb.R
@@ -366,3 +366,25 @@ test_that("reading with start_col/start_row works", {
   expect_equal(exp, got)
 
 })
+
+test_that("factors are treated as character", {
+  ffs <- factor(x = c(2, 1), levels = c(1, 2), labels = c("cars", "mtcars"))
+
+  wb <- wb_workbook()
+
+  fun <- function(x, y) {
+    wb$add_worksheet(sheet = x)
+    wb$add_data(sheet = x, x = y)
+  }
+
+  Map(f = fun, x = ffs, y = list(mtcars, cars))
+
+  exp <- c("mtcars", "cars")
+  got <- unname(wb$get_sheet_names())
+  expect_equal(exp, got)
+
+  exp <- c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb")
+  got <- names(wb$to_df(sheet = ffs[[1]]))
+  expect_equal(exp, got)
+
+})


### PR DESCRIPTION
closes #1435

``` r
library(openxlsx2)

ffs <- factor(x = c(2, 1), levels = c(1, 2), labels = c("cars", "mtcars"))

wb <- wb_workbook()

fun <- function(x, y) {
  wb$add_worksheet(sheet = x)
  wb$add_data(sheet = x, x = y)
}

Map(f = fun, x = ffs, y = list(mtcars, cars))
#> [[1]]
#> A Workbook object.
#>  
#> Worksheets:
#>  Sheets: mtcars, cars 
#>  Write order: 1, 2
#> [[2]]
#> A Workbook object.
#>  
#> Worksheets:
#>  Sheets: mtcars, cars 
#>  Write order: 1, 2

if (interactive()) wb$open()
```