### PR TITLE
[read] convert `tt` to integer

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -72,6 +72,10 @@ create_char_dataframe <- function(colnames, n) {
     .Call(`_openxlsx2_create_char_dataframe`, colnames, n)
 }
 
+create_int_dataframe <- function(char_df) {
+    .Call(`_openxlsx2_create_int_dataframe`, char_df)
+}
+
 read_xml2df <- function(xml, vec_name, vec_attrs, vec_chlds) {
     .Call(`_openxlsx2_read_xml2df`, xml, vec_name, vec_attrs, vec_chlds)
 }

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4927,7 +4927,7 @@ wbWorkbook <- R6::R6Class(
         # To avoid this, we have to check character vectors for potentially
         # unconverted numerics and have to apply something like format(as.numeric(...))
         tt  <- attr(df, "tt")
-        sel <- tt == "n" & !is.na(df)
+        sel <- tt == 1L & !is.na(df)
 
         df[sel]   <- vapply(df[sel], function(x) format(as.numeric(x)), NA_character_)
         col_width <- vapply(df, function(x) max(nchar(format(x))), NA_real_)

--- a/R/wb_functions.R
+++ b/R/wb_functions.R
@@ -143,7 +143,7 @@ guess_col_type <- function(tt) {
   # Identify the unique types present in the data frame
   uu <- lapply(tt, unique)
   unique_types <- unique(unlist(uu))
-  unique_types[is.na(unique_types)] <- "n"
+  unique_types[is.na(unique_types)] <- 1L
 
   # Function to check column type
   check_col_type <- function(x, type_char) {
@@ -153,34 +153,34 @@ guess_col_type <- function(tt) {
   check_type <- function(x) vapply(uu, check_col_type, NA, type_char = x)
 
   # Check for each type and update types vector accordingly
-  if ("n" %in% unique_types) {
-    col_num <- check_type("n")
-    types[col_num] <- 1
+  if (1L %in% unique_types) {
+    col_num <- check_type(1L)
+    types[col_num] <- 1L
   }
 
-  if ("d" %in% unique_types) {
-    col_dte <- check_type("d")
-    types[col_dte & types == 0] <- 2
+  if (2L %in% unique_types) {
+    col_dte <- check_type(2L)
+    types[col_dte & types == 0] <- 2L
   }
 
-  if ("p" %in% unique_types) {
-    col_posix <- check_type("p")
-    types[col_posix & types == 0] <- 3
+  if (3L %in% unique_types) {
+    col_posix <- check_type(3L)
+    types[col_posix & types == 0] <- 3L
   }
 
-  if ("b" %in% unique_types) {
-    col_log <- check_type("b")
-    types[col_log & types == 0] <- 4
+  if (4L %in% unique_types) {
+    col_log <- check_type(4L)
+    types[col_log & types == 0] <- 4L
   }
 
-  if ("h" %in% unique_types) {
-    col_hms <- check_type("h")
-    types[col_hms & types == 0] <- 5
+  if (5L %in% unique_types) {
+    col_hms <- check_type(5L)
+    types[col_hms & types == 0] <- 5L
   }
 
-  if ("f" %in% unique_types) {
-    col_fml <- check_type("f")
-    types[col_fml & types == 0] <- 6
+  if (6L %in% unique_types) {
+    col_fml <- check_type(6L)
+    types[col_fml & types == 0] <- 6L
   }
 
   types

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -199,6 +199,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// create_int_dataframe
+Rcpp::DataFrame create_int_dataframe(const Rcpp::DataFrame& char_df);
+RcppExport SEXP _openxlsx2_create_int_dataframe(SEXP char_dfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::DataFrame& >::type char_df(char_dfSEXP);
+    rcpp_result_gen = Rcpp::wrap(create_int_dataframe(char_df));
+    return rcpp_result_gen;
+END_RCPP
+}
 // read_xml2df
 Rcpp::DataFrame read_xml2df(XPtrXML xml, std::string vec_name, std::vector<std::string> vec_attrs, std::vector<std::string> vec_chlds);
 RcppExport SEXP _openxlsx2_read_xml2df(SEXP xmlSEXP, SEXP vec_nameSEXP, SEXP vec_attrsSEXP, SEXP vec_chldsSEXP) {
@@ -817,6 +828,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_openxlsx2_is_charnum", (DL_FUNC) &_openxlsx2_is_charnum, 1},
     {"_openxlsx2_wide_to_long", (DL_FUNC) &_openxlsx2_wide_to_long, 14},
     {"_openxlsx2_create_char_dataframe", (DL_FUNC) &_openxlsx2_create_char_dataframe, 2},
+    {"_openxlsx2_create_int_dataframe", (DL_FUNC) &_openxlsx2_create_int_dataframe, 1},
     {"_openxlsx2_read_xml2df", (DL_FUNC) &_openxlsx2_read_xml2df, 4},
     {"_openxlsx2_write_df2xml", (DL_FUNC) &_openxlsx2_write_df2xml, 4},
     {"_openxlsx2_col_to_df", (DL_FUNC) &_openxlsx2_col_to_df, 1},

--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -554,11 +554,11 @@ void long_to_wide(Rcpp::DataFrame z, Rcpp::DataFrame tt, Rcpp::DataFrame zz) {
   Rcpp::IntegerVector cols = zz["cols"];
   Rcpp::IntegerVector rows = zz["rows"];
   Rcpp::CharacterVector vals = zz["val"];
-  Rcpp::CharacterVector typs = zz["typ"];
+  Rcpp::IntegerVector typs = zz["typ"];
 
   // Cache all column vectors to avoid repeated coercion
   std::vector<Rcpp::CharacterVector> z_cols(static_cast<size_t>(z.size()));
-  std::vector<Rcpp::CharacterVector> tt_cols(static_cast<size_t>(tt.size()));
+  std::vector<Rcpp::IntegerVector> tt_cols(static_cast<size_t>(tt.size()));
 
   for (R_xlen_t j = 0; j < z.size(); ++j) {
     z_cols[static_cast<size_t>(j)] = z[j];
@@ -571,7 +571,7 @@ void long_to_wide(Rcpp::DataFrame z, Rcpp::DataFrame tt, Rcpp::DataFrame zz) {
 
     if (row != NA_INTEGER && col != NA_INTEGER) {
       SET_STRING_ELT(z_cols[static_cast<size_t>(col)], row, STRING_ELT(vals, i));
-      SET_STRING_ELT(tt_cols[static_cast<size_t>(col)], row, STRING_ELT(typs, i));
+      INTEGER(tt_cols[static_cast<size_t>(col)])[row] = INTEGER(typs)[i];
     }
   }
 }
@@ -832,6 +832,25 @@ Rcpp::DataFrame create_char_dataframe(Rcpp::CharacterVector colnames, R_xlen_t n
   df.attr("class") = "data.frame";
 
   return df;
+}
+
+// [[Rcpp::export]]
+Rcpp::DataFrame create_int_dataframe(const Rcpp::DataFrame& char_df) {
+  int32_t n_rows = char_df.nrow();
+  int32_t n_cols = static_cast<int32_t>(char_df.ncol());
+
+  Rcpp::CharacterVector col_names = char_df.names();
+  Rcpp::List int_list(n_cols);
+
+  for (int32_t i = 0; i < n_cols; ++i) {
+    SET_VECTOR_ELT(int_list, i, Rcpp::IntegerVector(n_rows, NA_INTEGER));
+  }
+
+  int_list.attr("row.names") = Rcpp::IntegerVector::create(NA_INTEGER, -n_rows);
+  int_list.attr("names") = col_names;
+  int_list.attr("class") = "data.frame";
+
+  return int_list;
 }
 
 // TODO styles_xml.cpp should be converted to use these functions

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -57,7 +57,7 @@ test_that("convert hms works", {
 
   z <- wb_to_df(wb, col_names = FALSE, keep_attributes = TRUE)
   expect_equal(z$A, "12:13:14")
-  expect_equal(attr(z, "tt")$A, "h")
+  expect_equal(attr(z, "tt")$A, 5L)
 
 })
 

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -95,7 +95,7 @@ test_that("encoding", {
 
   exp <- structure(list("hähä" = "ÄÖÜ", "höhö" = "äöüß"),
                    row.names = 2L, class = "data.frame",
-                   tt = structure(list("hähä" = "s", "höhö" = "s"),
+                   tt = structure(list("hähä" = 0L, "höhö" = 0L),
                                   row.names = 2L, class = "data.frame"),
                    types = c(A = 0, B = 0))
 

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -215,7 +215,7 @@ test_that("writing NA, NaN and Inf", {
   wb$add_worksheet("Test2")$add_data_table(x = x, na.strings = "N/A")$save(tmp)
   wb$add_worksheet("Test3")$add_data(x = x, na.strings = "N/A")$save(tmp)
 
-  exp <- c(NA, "s", "s", "s")
+  exp <- c(NA, 0L, 0L, 0L)
   got <- unname(unlist(attr(wb_to_df(tmp, "Test1", keep_attributes = TRUE), "tt")))
   expect_equal(exp, got)
 
@@ -226,7 +226,7 @@ test_that("writing NA, NaN and Inf", {
   wb$clone_worksheet("Test1", "Clone1")$add_data(x = x, na.strings = NULL)$save(tmp)
   wb$clone_worksheet("Test3", "Clone3")$add_data(x = x, na.strings = "N/A")$save(tmp)
 
-  exp <- c(NA, "s", "s", "s")
+  exp <- c(NA, 0L, 0L, 0L)
   got <- unname(unlist(attr(wb_to_df(tmp, "Test1", keep_attributes = TRUE), "tt")))
   expect_equal(exp, got)
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -246,7 +246,7 @@ test_that("write_rownames", {
     row.names = 1:2,
     class = "data.frame",
     tt = structure(
-      list(A = c(NA, "s"), B = c("s", "n")),
+      list(A = c(NA, 0L), B = c(0L, 1L)),
       row.names = 1:2,
       class = "data.frame"),
     types = c(A = 0, B = 0)
@@ -259,7 +259,7 @@ test_that("write_rownames", {
     row.names = 1:2,
     class = "data.frame",
     tt = structure(
-      list(A = c("s", "s"), B = c("s", "n")),
+      list(A = c(0L, 0L), B = c(0L, 1L)),
       row.names = 1:2,
       class = "data.frame"),
     types = c(A = 0, B = 0)


### PR DESCRIPTION
The `tt` data frame matches the size the output of `wb_to_df()` and contains a celltype information for each cell. In early development it made sense to have this in a readable fashion, now this appears less useful, due to the size of character data frames.