### PR TITLE
[read] keep order of `rows`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * It is now possible to save a newly created workbook as `.xlsm` and it will open in spreadsheet software. [1453](https://github.com/JanMarvin/openxlsx2/pull/1453)
 * Add missing `interactive` argument to `wb_open()`.
 
+## Internal Changes
+
+* The `tt` data frame that is created with `wb_to_df()` to support column type guessing is now using integer columns instead of characters. This should reduce the memory footprint of the function. [1459](https://github.com/JanMarvin/openxlsx2/pull/1459)
+
 ## Breaking changes
 
 * Wrapper functions were never intended to alter workbooks. This is now tested and various functions that were unintentionally altering workbooks were corrected. [1454](https://github.com/JanMarvin/openxlsx2/pull/1454)
@@ -22,7 +26,7 @@ wb <- wb_add_fill(wb, dims = wb_dims(x = mtcars))
 ```
 
 * Previously deprecated functions `write_data()`, `write_datatable()`, `write_formula()` are now defunct.
-
+* If a `row` vector is passed to `wb_to_df()`, this will set the order of the output. The behavior is now matching the one of `cols`. [1460](https://github.com/JanMarvin/openxlsx2/pull/1460)
 
 ***************************************************************************
 

--- a/R/read.R
+++ b/R/read.R
@@ -357,8 +357,9 @@ wb_to_df <- function(
   if (!is.null(start_row)) {
     keep_rows <- as.character(seq(start_row, maxRow))
     if (start_row <= maxRow) {
-      z  <- z[rownames(z) %in% keep_rows, , drop = FALSE]
-      tt <- tt[rownames(tt) %in% keep_rows, , drop = FALSE]
+      sel <- rownames(z) %in% keep_rows
+      z  <- z[sel, , drop = FALSE]
+      tt <- tt[sel, , drop = FALSE]
     } else {
       keep_rows <- as.character(start_row)
       z  <- z[keep_rows, , drop = FALSE]
@@ -372,23 +373,24 @@ wb_to_df <- function(
   if (!is.null(rows)) {
     keep_rows <- as.character(as.integer(rows))
 
-    if (all(keep_rows %in% rownames(z))) {
-      z  <- z[rownames(z) %in% keep_rows, , drop = FALSE]
-      tt <- tt[rownames(tt) %in% keep_rows, , drop = FALSE]
+    if (!anyNA(sel <- match(keep_rows, rownames(z)))) {
+      z  <- z[sel, , drop = FALSE]
+      tt <- tt[sel, , drop = FALSE]
     } else {
       z  <- z[keep_rows, , drop = FALSE]
       tt <- tt[keep_rows, , drop = FALSE]
 
-      rownames(z)  <- as.integer(keep_rows)
-      rownames(tt) <- as.integer(keep_rows)
+      ints <- as.integer(keep_rows)
+      rownames(z)  <- ints
+      rownames(tt) <- ints
     }
   }
 
   if (!is.null(start_col)) {
     keep_cols <- int2col(seq(col2int(start_col), maxCol))
 
-    if (!all(keep_cols %in% colnames(z))) {
-      keep_col <- keep_cols[!keep_cols %in% colnames(z)]
+    if (!all(sel <- keep_cols %in% colnames(z))) {
+      keep_col <- keep_cols[!sel]
 
       z[keep_col]  <- NA_character_
       tt[keep_col] <- NA_integer_
@@ -397,8 +399,9 @@ wb_to_df <- function(
       tt <- tt[keep_cols]
     }
 
-    z  <- z[, match(keep_cols, colnames(z)), drop = FALSE]
-    tt <- tt[, match(keep_cols, colnames(tt)), drop = FALSE]
+    sel <- match(keep_cols, colnames(z))
+    z  <- z[, sel, drop = FALSE]
+    tt <- tt[, sel, drop = FALSE]
   }
 
   if (!is.null(cols)) {
@@ -411,8 +414,9 @@ wb_to_df <- function(
       tt[keep_col] <- NA_integer_
     }
 
-    z  <- z[, match(keep_cols, colnames(z)), drop = FALSE]
-    tt <- tt[, match(keep_cols, colnames(tt)), drop = FALSE]
+    sel <- match(keep_cols, colnames(z))
+    z  <- z[, sel, drop = FALSE]
+    tt <- tt[, sel, drop = FALSE]
   }
 
   keep_rows <- keep_rows[keep_rows %in% rnams]

--- a/tests/testthat/test-read_from_created_wb.R
+++ b/tests/testthat/test-read_from_created_wb.R
@@ -388,3 +388,38 @@ test_that("factors are treated as character", {
   expect_equal(exp, got)
 
 })
+
+test_that("wb_to_df respects the row order", {
+
+  ## select rows 1 and 2 while the column names are in row 2
+  got <- wb_workbook() |>
+    wb_add_worksheet() |>
+    wb_add_data(
+      x = letters,
+      dims = "A2:Z2",
+      col_names = FALSE
+    ) |>
+    wb_add_data(
+      x = 1:26,
+      dims = "A1:Z1",
+      col_names = FALSE
+    ) |>
+    wb_to_df(
+      rows = 2:1
+    )
+
+  exp <- data.frame(t(1:26))
+  names(exp) <- letters
+
+  expect_equal(exp, got)
+
+  ## select arbitrary row order of input matrix
+  mm <- as.data.frame(matrix(1:6, nrow = 6, ncol = 6))
+  names(mm) <- LETTERS[1:6]
+  wb <- wb_workbook()$add_worksheet()$add_data(x = mm, col_names = FALSE)
+
+  exp <- mm[c(2, 3, 1, 5, 6, 4), ]
+  got <- wb$to_df(rows = c(2, 3, 1, 5, 6, 4), col_names = FALSE)
+
+  expect_equal(exp, got)
+})


### PR DESCRIPTION
Realized this, while working on a real world example for the book. The Order in the spreadsheet is slightly different. US above Euro Area, but previously we would return them in a sorted order stemming from `%in%` instead of `match()`.

``` r
library(openxlsx2)

fl <- "https://www.cpb.nl/system/files/cpbmedia/cpb-world-trade-monitor-august-2025_0.xlsx"

wb <- wb_load(fl)

cols <- wb$to_df(cols = "B")

date  <- as.numeric(rownames(cols[which(cols == "Volumes, seasonally adjusted"), , drop = FALSE])) - 2
# value <- as.numeric(rownames(cols[which(cols == "World trade")[1], , drop = FALSE]))

value <- as.numeric(rownames(cols[match(c("United States", "Euro Area"), trimws(unlist(cols))), , drop = FALSE]))

rows <- c(date, value); rows
#> [1]  4 13 12

nms <- trimws(c(unname(unclass(t(wb$to_df(rows = rows, cols = "B"))))))
df <- wb$to_df(rows = rows, start_col = "F", skip_empty_cols = TRUE)

df <- as.data.frame(t(df))
names(df) <- nms

df$date <- as.Date(paste0(rownames(df),"-01"), format = "%Ym%m-%d")

head(df)
#>         United States Euro Area       date
#> 2000m01      54.28793  83.37869 2000-01-01
#> 2000m02      54.38818  83.84159 2000-02-01
#> 2000m03      56.13292  84.68927 2000-03-01
#> 2000m04      56.96863  84.37047 2000-04-01
#> 2000m05      57.02972  89.44435 2000-05-01
#> 2000m06      58.13346  84.63110 2000-06-01


plot(df$date, df$`Euro Area`, type = "l", panel.first = grid(),
     ylim = range(c(df$`Euro Area`, df$`United States`)),
     main = "CPB World Trade Monitor", xlab = "", ylab = "Imports")
lines(df$date, df$`United States`, lty = "dashed")
legend(
  "bottomright",
  legend = names(df)[1:2],
  lty = c(1, 2)
)
```

![](https://i.imgur.com/BN9W7w7.png)<!-- -->