### PR TITLE
[read] add ooxml_format() to apply numfmt

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Check valid ranges and inputs in `col2int()` and `int2row()`. [#1491](https://github.com/JanMarvin/openxlsx2/pull/1491)
 * With `validate_dims()`, a new validation helper for `dims` has been added. [#1498](https://github.com/JanMarvin/openxlsx2/pull/1498)
 * The argument `na` replaces `na.strings` and `na.numbers` in read and write functions. Per default this is either a waiver in write functions or a character vector in read functions. If strings and numbers should be passed to a read function `na = list(strings = ..., numbers = ...)` should be used. In addition a matching option was added `option("openxlsx2.na")`. The previous default values and option remain for the foreseeable future. [#1499](https://github.com/JanMarvin/openxlsx2/pull/1499)
+* It is now possible to apply numeric formats via `wb_to_df(apply_numfmts = TRUE)` to preview numeric formats. The function is still experimental and incomplete. There is no support for builtin styles yet. But this should improve setting the automatic column width for worksheets with numeric styles. [#1501](https://github.com/JanMarvin/openxlsx2/pull/1501)
 
 ## Fixes
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -2832,6 +2832,7 @@ wbWorkbook <- R6::R6Class(
     #' @param keep_attributes If TRUE additional attributes are returned. (These are used internally to define a cell type.)
     #' @param check_names If TRUE then the names of the variables in the data frame are checked to ensure that they are syntactically valid variable names.
     #' @param show_hyperlinks If `TRUE` instead of the displayed text, hyperlink targets are shown.
+    #' @param apply_numfmts If `TRUE` numeric formats are applied if detected.
     #' @return a data frame
     to_df = function(
       sheet,
@@ -2856,6 +2857,7 @@ wbWorkbook <- R6::R6Class(
       keep_attributes   = FALSE,
       check_names       = FALSE,
       show_hyperlinks   = FALSE,
+      apply_numfmts     = FALSE,
       ...
     ) {
 
@@ -2890,6 +2892,7 @@ wbWorkbook <- R6::R6Class(
         keep_attributes   = keep_attributes,
         check_names       = check_names,
         show_hyperlinks   = show_hyperlinks,
+        apply_numfmts     = apply_numfmts,
         ...               = ...
       )
     },
@@ -4850,7 +4853,6 @@ wbWorkbook <- R6::R6Class(
       invisible(self)
     },
 
-    # TODO wb_group_rows() and group_cols() are very similiar.  Can problem turn
     #' @description Set column widths
     #' @param cols cols
     #' @param widths Width of columns
@@ -4914,7 +4916,9 @@ wbWorkbook <- R6::R6Class(
       base_font <- wb_get_base_font(self)
 
       if (any(widths == "auto")) {
-        df <- wb_to_df(self, sheet = sheet, cols = cols, col_names = FALSE, keep_attributes = TRUE)
+        df <- wb_to_df(
+          self, sheet = sheet, cols = cols, col_names = FALSE, keep_attributes = TRUE, apply_numfmts = TRUE
+        )
         # exclude merged cells from width calculation.
         # adapted from wb_to_df(fill_merged_cells = TRUE)
         mc <- self$worksheets[[sheet]]$mergeCells
@@ -4967,7 +4971,7 @@ wbWorkbook <- R6::R6Class(
 
     ## rows ----
 
-    # TODO groupRows() and groupCols() are very similiar.  Can problem turn
+    # TODO wb_group_rows() and group_cols() are very similiar. Can probably turn
     # these into some wrappers for another method
 
     #' @description Group rows

--- a/R/illegal-characters.R
+++ b/R/illegal-characters.R
@@ -71,9 +71,26 @@ replaceXMLEntities <- function(x) {
 }
 
 # for dateFormats
-escape_forward_slashes <- function(string) {
-  if (!grepl("\\\\/", string)) {
-    string <- gsub("/", "\\\\/", string)
+escape_format_code <- function(formatCode) {
+
+  formatCode <- replace_legal_chars(replaceXMLEntities(formatCode))
+
+  # Check if it's a date/time format
+  is_date_time <- grepl("(y{2,4}|m{1,4}|d{1,2}|h{1,2}|s{1,2})", tolower(formatCode))
+
+  if (is_date_time && grepl("/", formatCode)) {
+    # Use a placeholder for AM/PM
+    has_ampm <- grepl("AM/PM", formatCode, ignore.case = TRUE)
+    has_ap   <- grepl("A/P", formatCode, ignore.case = TRUE)
+
+    if (has_ampm) formatCode <- gsub("AM/PM", "@@AMPM@@", formatCode, ignore.case = TRUE)
+    if (has_ap)   formatCode <- gsub("A/P", "@@AP@@", formatCode, ignore.case = TRUE)
+
+    formatCode <- gsub("(?<!\\\\)/", "\\\\/", formatCode, perl = TRUE)
+
+    if (has_ampm) formatCode <- gsub("@@AMPM@@", "AM/PM", formatCode)
+    if (has_ap)   formatCode <- gsub("@@AP@@", "A/P", formatCode)
   }
-  string
+
+  formatCode
 }

--- a/man/wbWorkbook.Rd
+++ b/man/wbWorkbook.Rd
@@ -1014,6 +1014,7 @@ to_df
   keep_attributes = FALSE,
   check_names = FALSE,
   show_hyperlinks = FALSE,
+  apply_numfmts = FALSE,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -1065,6 +1066,8 @@ or a named list: list(strings = ..., numbers = ...). Blank cells are always conv
 \item{\code{check_names}}{If TRUE then the names of the variables in the data frame are checked to ensure that they are syntactically valid variable names.}
 
 \item{\code{show_hyperlinks}}{If \code{TRUE} instead of the displayed text, hyperlink targets are shown.}
+
+\item{\code{apply_numfmts}}{If \code{TRUE} numeric formats are applied if detected.}
 
 \item{\code{...}}{additional arguments}
 }

--- a/man/wb_to_df.Rd
+++ b/man/wb_to_df.Rd
@@ -30,6 +30,7 @@ wb_to_df(
   keep_attributes = FALSE,
   check_names = FALSE,
   show_hyperlinks = FALSE,
+  apply_numfmts = FALSE,
   ...
 )
 
@@ -125,6 +126,8 @@ If no sheet is selected, the first appearance will be selected. See \code{\link[
 
 \item{show_hyperlinks}{If \code{TRUE} instead of the displayed text, hyperlink targets are shown.}
 
+\item{apply_numfmts}{If \code{TRUE} numeric formats are applied if detected.}
+
 \item{...}{additional arguments}
 }
 \description{
@@ -181,6 +184,10 @@ You can use wildcards for all available columns or rows in \code{dims} by using
 first row in column A through the last column in row 9. This makes it
 unnecessary to update dimensions when working with files whose sizes change
 frequently.
+
+The function to apply numeric formats was not extensively tested for numeric
+equality with spreadsheet software. There might be differences and the function
+is lacking support for builtin styles.
 }
 \examples{
 ###########################################################################


### PR DESCRIPTION
Related to
* https://github.com/JanMarvin/openxlsx2/discussions/1238
* https://github.com/JanMarvin/openxlsx2/issues/1282

Fixes creation of numfmt with AM/PM

``` r
library(openxlsx2)
df <- data.frame(
  is_active  = c(TRUE, FALSE, TRUE, NA, FALSE),
  count      = c(10L, 25L, NA, 7L, 15L),
  measure    = c(1.23, NA, 4.56, 7.89, 0.01),
  event_date = as.Date(c("2023-01-01", "2023-02-15", NA, "2023-05-20", "2023-12-31")),
  timestamp  = as.POSIXct(c("2023-01-01 10:00:00", NA, "2023-03-10 14:30:00",
                            "2023-06-01 08:15:00", "2023-12-25 12:00:00"), tz = "UTC"),
  # Manual hms without loading the library:
  daily_time = structure(c(30600, 35100, NA, 40500, 43200), units = "secs", class = c("hms", "difftime")),
  category   = c("A", "B", "C", NA, "E"),
  stringsAsFactors = FALSE
)

wb <- wb_workbook()$
  add_worksheet()$
  add_data(x = df)

wb$add_numfmt(dims = wb_dims(x = df, cols = "count"), numfmt = "$0")
wb$add_numfmt(dims = wb_dims(x = df, cols = "measure"), numfmt = "0.0")
wb$add_numfmt(dims = wb_dims(x = df, cols = "event_date"), numfmt = "m/d/yyyy")
wb$add_numfmt(dims = wb_dims(x = df, cols = "timestamp"), numfmt = "yy-mmm-dd HH:mm:ss")
wb$add_numfmt(dims = wb_dims(x = df, cols = "daily_time"), numfmt = "hh:mm:ss AM/PM")
wb$add_numfmt(dims = wb_dims(x = df, cols = "category"), numfmt = "cat: @")

wb$to_df(apply_numfmts = TRUE)
#>   is_active count measure event_date          timestamp  daily_time category
#> 2      TRUE   $10     1.2   1/1/2023 23-Jan-01 10:00:00 08:30:00 AM   cat: A
#> 3     FALSE   $25    <NA>  2/15/2023               <NA> 09:45:00 AM   cat: B
#> 4      TRUE  <NA>     4.6       <NA> 23-Mar-10 14:30:00        <NA>   cat: C
#> 5      <NA>    $7     7.9  5/20/2023 23-Jun-01 08:15:00 11:15:00 AM     <NA>
#> 6     FALSE   $15     0.0 12/31/2023 23-Dec-25 12:00:00 12:00:00 PM   cat: E

if (interactive()) wb$open()
```