### PR TITLE
[dims] remove more unreached code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,11 +10,12 @@
 ## Fixes
 
 * It is now possible to add filters via `write_xlsx()` without tables. [#1495](https://github.com/JanMarvin/openxlsx2/pull/1495)
-* Improve hms detection in cases where a hms style was mistaken as a datetime. This also fixes a case, where a hms value exceeds a day. In this case, spreadsheet software will handle it as a datetime starting in 1900-01-01. With format `"[h]:mm:ss"` the value `42.5` becomes a `1900-02-11 12:00:00`.
+* Improve time detection in cases where a time style was mistaken as a datetime. This also fixes a case, where a time value exceeds a day. In this case, spreadsheet software will handle it as a datetime starting in 1900-01-01. With format `"[h]:mm:ss"` the value `42.5` now becomes `1900-02-11 12:00:00`.
 
 ## Internal Changes
 
 * C++ functions used in loading and writing files have seen another round of cleanups.
+* Cleanups in `wb_dims()` to increase coverage and to be more precise in error messages.
 
 ***************************************************************************
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -392,19 +392,6 @@ check_wb_dims_args <- function(args, select = NULL) {
 
   x_has_colnames <- !is.null(colnames(args$x))
 
-  if (is.character(args$rows) && !is.null(args$rows) && x_has_colnames) {
-    # Not checking whether it's a row name, not supported.
-    is_rows_a_colname <- args$rows %in% colnames(args$x)
-
-    if (any(is_rows_a_colname)) {
-      stop(
-        "`rows` is the incorrect argument in this case\n",
-        "Use `cols` instead. Subsetting rows by name is not supported.",
-        call. = FALSE
-      )
-    }
-  }
-
   if (is.character(args$cols) && x_has_colnames) {
     # Checking whether cols is character, and error if it is not the col names of x
     missing_cols <- args$cols[!(args$cols %in% colnames(args$x))]

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -894,9 +894,16 @@ test_that("fuzzing wb_dims", {
 
   res <- wb_dims(x = mtcars[1:3, 1:3], row_names = TRUE, select = "data")
   expect_equal(res, "B2:D4")
-
   expect_equal(wb_dims(cols = c(1, 3), rows = 1), c("A1,C1"))
-
+  expect_error(wb_dims(list(1, 2), from_row = 1), "The first argument must either be named or be a vector.")
+  expect_equal(wb_dims(x = mtcars, row_names = TRUE, select = "data"), "B2:L33")
+  expect_equal(wb_dims(x = mtcars, row_names = TRUE, select = "col_names"), "B1:L1")
+  expect_equal(wb_dims(x = mtcars, row_names = TRUE, cols = c(1, 3), select = "data"), "B2:B33,D2:D33")
+  expect_equal(wb_dims(rows = c(1, 3), cols = c(1, 3)), "A1,C1,A3,C3")
+  expect_equal(wb_dims(rows = 1:2, cols = c(1, 3)), "A1:A2,C1:C2")
+  expect_equal(wb_dims(rows = c(1, 3), cols = 1:2), "A1:B1,A3:B3")
+  expect_equal(wb_dims(rows = 1:2, cols = 1:2), "A1:B2")
+  expect_equal(wb_dims(rows = 2:3, cols = 2:3), "B2:C3")
 })
 
 test_that("wb_dims warns when coordinates are out of bounds", {


### PR DESCRIPTION
Try to increase coverage once again

@olivroy FYI: I'm not entirely happy with my refactoring of `wb_dims()`,  now that the code checks for valid rows and cols arguments are spread across two functions. But this way it was easier to make sense out of it. IMHO a few of these checks are overengineered. But at least I wanted to increase the coverage for the entire `utils.R` file including `wb_dims()`.