### PR TITLE
[read] fix reading single uninitialized cell

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,15 +2,18 @@
 
 ## New features
 
-* Provide new SHA base password hash based on `openssl`. This will be used if `openssl` is installed, otherwise the legacy implementation will be used.
+* Provide new SHA base password hash based on `openssl`. This will be used if `openssl` is installed, otherwise the legacy implementation will be used. [#1538](https://github.com/JanMarvin/openxlsx2/pull/1538)
 
 ## Fixes
 
 * In certain environments a zip tool is available via `Sys.which("zip")`, but `Sys.getenv("R_ZIPCMD")` is not configured. When writing, we would detect the first and continue trying `utils::zip()`, but never passed `Sys.which("zip")`. This has been corrected. [#1533](https://github.com/JanMarvin/openxlsx2/pull/1533)
+* Fix reading uninitialized cells [#1546](https://github.com/JanMarvin/openxlsx2/pull/1546)
 
 ## Internal Changes
 
 * Cleanup and remove `waldo` from `testthat` helper functions
+* Update many manual pages
+
 
 ***************************************************************************
 

--- a/R/read.R
+++ b/R/read.R
@@ -538,14 +538,14 @@ wb_to_df <- function(
   origin <- get_date_origin(wb)
 
   # dates
-  if (!is.null(cc$c_s)) {
+  if (NROW(cc) && !is.null(cc$c_s)) {
 
     # if a cell is t="s" the content is a sst and not da date
     if (detect_dates && missing(types)) {
       uccs <- unique(cc$c_s)
       ucct <- unique(cc$c_t)
 
-      cc$is_string <- FALSE
+      cc$is_string <- rep_len(FALSE, nrow(cc))
       strings <-  c("s", "str", "b", "inlineStr")
       if (!is.null(cc$c_t) && any(ucct %in% strings))
         cc$is_string <- cc$c_t %in% strings

--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -539,3 +539,29 @@ test_that("read file with data types", {
   expect_equal(18, length(wb$Content_Types))
 
 })
+
+test_that("reading unintialized cells", {
+  fl <- system.file("extdata", "openxlsx2_example.xlsx", package = "openxlsx2")
+  wb <- wb_load(file = fl)
+
+  got <- rownames(wb$to_df(dims = "A12", col_names = FALSE))
+  expect_equal(got, "12")
+
+  got <- rownames(wb$to_df(dims = "A+", col_names = FALSE))
+  expect_equal(got, "12")
+
+  got <- rownames(wb$to_df(dims = "Z3:AA3", col_names = FALSE))
+  expect_equal(got, "3")
+
+
+  wb <- wb_workbook()$add_worksheet()$add_data(dims = "B2", x = mtcars)
+
+  got <- rownames(wb$to_df(dims = "A12", col_names = FALSE))
+  expect_equal(got, "12")
+
+  got <- rownames(wb$to_df(dims = "A+", col_names = FALSE))
+  expect_equal(got, "34")
+
+  got <- rownames(wb$to_df(dims = "Z3:AA3", col_names = FALSE))
+  expect_equal(got, "3")
+})


### PR DESCRIPTION
This is reducing `cc` to zero rows and now `cc$is_string <- FALSE` fails.

```R
# reduce data to selected cases only
  if (has_dims && length(keep_rows) && length(keep_cols))
    cc <- cc[cc$row_r %in% keep_rows & cc$c_r %in% keep_cols, ]
```

At least an error was thrown and with `detect_dates = FALSE` it should have been possible to circumvent the error