### PR TITLE
[load] fix wb$vml_rels re-init inside loop dropping all but last .vml.rels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Fixes
 
+* `wb_load()` no longer drops all but the last worksheet's `vmlDrawing*.vml.rels` on a load + save round-trip. The `wb$vml_rels` initialisation was inside the read loop and wiped on every iteration ([#1641](https://github.com/JanMarvin/openxlsx2/pull/1641), @SchmidtPaul).
+
 * Build vignette if `encharter` is not available.
 * Enhanced `df_to_xml()` speed and prevented double-escaping of XML entities, resolving an issue where hyperlinks with ampersands (`&`) were broken. [#1636](https://github.com/JanMarvin/openxlsx2/pull/1636), [#1637](https://github.com/JanMarvin/openxlsx2/pull/1637)
 * It is now possible to pass custom formula arguments to total rows when writing data tables. [#1638](https://github.com/JanMarvin/openxlsx2/pull/1638)

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -1386,8 +1386,10 @@ wb_load <- function(
         wb$vml[vml_file] <- read_xml(vml, pointer = FALSE)
       }
 
-      for (vml_rel in vmlDrawingRelsXML) {
+      if (length(vmlDrawingRelsXML))
         wb$vml_rels <- rep(list(""), vml_len) # vector("list", vml_len)
+
+      for (vml_rel in vmlDrawingRelsXML) {
 
         vml_file <- cdigit(basename(vml_rel), as_integer = TRUE)
 

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -32,6 +32,7 @@ Miriam Rainers
 Moritz Lell
 Noam Ross
 olivroy
+Paul Schmidt
 Philipp Schauberger
 Reinhold Kainhofer
 Renaud

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -742,3 +742,43 @@ test_that("has_drawings is defunct", {
     "argument \"has_drawing\" was removed"
   )
 })
+
+test_that("loading keeps every vmlDrawing.vml.rels (#1557 regression)", {
+
+  # A comment with a background image produces a vmlDrawing*.vml.rels per
+  # sheet. wb$vml_rels used to be re-initialised inside the load loop, so all
+  # but the last sheet's .vml.rels were dropped on a load + save round-trip,
+  # leaving dangling o:relid references (Excel repair prompt).
+  img <- system.file("extdata", "einstein.jpg", package = "openxlsx2")
+
+  wb <- wb_workbook()
+  for (i in 1:3) {
+    wb$add_worksheet(paste0("S", i))
+    wb$add_comment(
+      sheet   = i,
+      dims    = "B2",
+      comment = wb_comment(text = paste("comment", i), author = "x"),
+      file    = img
+    )
+  }
+
+  count_vmlrels <- function(f) {
+    sum(grepl("xl/drawings/_rels/vmlDrawing.*\\.vml\\.rels$",
+              unzip(f, list = TRUE)$Name))
+  }
+
+  tmp1 <- temp_xlsx()
+  on.exit(unlink(tmp1), add = TRUE)
+  wb$save(tmp1)
+  expect_equal(count_vmlrels(tmp1), 3)
+
+  wb2 <- wb_load(tmp1)
+  # all three entries survive the load (previously only the last was kept)
+  expect_equal(sum(vapply(wb2$vml_rels, function(x) !all(x == ""), NA)), 3)
+
+  tmp2 <- temp_xlsx()
+  on.exit(unlink(tmp2), add = TRUE)
+  wb2$save(tmp2)
+  expect_equal(count_vmlrels(tmp2), 3)
+
+})


### PR DESCRIPTION
Fixes the `vmlDrawing*.vml.rels` half of #1640 .

`wb_load()` re-initialised `wb$vml_rels` on every iteration of the
`vmlDrawingRelsXML` loop, so only the last worksheet's `vmlDrawing*.vml.rels`
survived a `wb_load()` + `wb_save()` round-trip. The other entries were dropped
and their `o:relid` references left dangling, which triggers Excel's repair
prompt. Regression from #1557 (v1.24), which moved the allocation into the loop;
the deferral was correct, the line just landed one block too deep.

The fix moves the (length-guarded) initialisation out of the loop, mirroring the
`wb$vml` init a few lines above.

Minimal reprex:

```r
library(openxlsx2)
img <- system.file("extdata", "einstein.jpg", package = "openxlsx2")

wb <- wb_workbook()
for (i in 1:3) {
  wb$add_worksheet()
  wb$add_comment(sheet = i, dims = "B2",
                 comment = wb_comment(text = "x", author = "x"), file = img)
}

count_vmlrels <- function(f)
  sum(grepl("vmlDrawing.*\\.vml\\.rels$", unzip(f, list = TRUE)$Name))

f1 <- temp_xlsx(); wb$save(f1)
f2 <- temp_xlsx(); wb_load(f1)$save(f2)
count_vmlrels(f1)  # 3
count_vmlrels(f2)  # before: 1, after: 3
```

* `R/wb_load.R` - init `wb$vml_rels` before the loop (length-guarded).
* `tests/testthat/test-loading_workbook.R` - regression test covering the
  three-`.vml.rels` round-trip.
* `NEWS.md` - entry under Fixes.

The dangling `pageSetup r:id` (the other half of #1640 ) is left out on
purpose - it is a design question raised in the issue and not a regression.

Co-Authored-By: Claude Opus 4.8