### PR TITLE
[load] drop dangling pageSetup printerSettings r:id on load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Fixes
 
+* `wb_load()` no longer drops all but the last worksheet's `vmlDrawing*.vml.rels` on a load + save round-trip. The `wb$vml_rels` initialisation was inside the read loop and wiped on every iteration ([#1641](https://github.com/JanMarvin/openxlsx2/pull/1641), @SchmidtPaul).
+
 * Build vignette if `encharter` is not available.
 * Enhanced `df_to_xml()` speed and prevented double-escaping of XML entities, resolving an issue where hyperlinks with ampersands (`&`) were broken. [#1636](https://github.com/JanMarvin/openxlsx2/pull/1636), [#1637](https://github.com/JanMarvin/openxlsx2/pull/1637)
 * It is now possible to pass custom formula arguments to total rows when writing data tables. [#1638](https://github.com/JanMarvin/openxlsx2/pull/1638)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Enhanced `df_to_xml()` speed and prevented double-escaping of XML entities, resolving an issue where hyperlinks with ampersands (`&`) were broken. [#1636](https://github.com/JanMarvin/openxlsx2/pull/1636), [#1637](https://github.com/JanMarvin/openxlsx2/pull/1637)
 * It is now possible to pass custom formula arguments to total rows when writing data tables. [#1638](https://github.com/JanMarvin/openxlsx2/pull/1638)
 * Add `builtins` argument to `wb_get_named_regions()`. [#1639](https://github.com/JanMarvin/openxlsx2/pull/1639)
+* `wb_load()` now drops the `pageSetup` `r:id` reference pointing to the intentionally unshipped `printerSettings` binary blob, avoiding a dangling relationship that triggered a repair prompt on round-trip. [#1640](https://github.com/JanMarvin/openxlsx2/issues/1640)
 
 ## Breaking changes
 

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -929,6 +929,12 @@ wb_load <- function(
         ws[[node]] <- xml_node(chartsheet_xml, "chartsheet", node)
       }
 
+      # printerSettings binary blobs are intentionally not kept (see the
+      # sheet rels handling below), so a pageSetup r:id would dangle and
+      # trigger a repair prompt in spreadsheet software. Drop the reference.
+      if (length(ws$pageSetup))
+        ws$pageSetup <- xml_attr_mod(ws$pageSetup, xml_attributes = c(`r:id` = ""))
+
     } else {
       worksheet_xml <- read_xml(sheets$target[i])
 
@@ -948,6 +954,12 @@ wb_load <- function(
         for (node in standard_nodes) {
           ws[[node]] <- xml_node(worksheet_xml, "worksheet", node)
         }
+
+        # printerSettings binary blobs are intentionally not kept (see the
+        # sheet rels handling below), so a pageSetup r:id would dangle and
+        # trigger a repair prompt in spreadsheet software. Drop the reference.
+        if (length(ws$pageSetup))
+          ws$pageSetup <- xml_attr_mod(ws$pageSetup, xml_attributes = c(`r:id` = ""))
 
         ws$colBreaks <- xml_node(worksheet_xml, "worksheet", "colBreaks", "brk")
         ws$rowBreaks <- xml_node(worksheet_xml, "worksheet", "rowBreaks", "brk")

--- a/R/wb_load.R
+++ b/R/wb_load.R
@@ -1386,8 +1386,10 @@ wb_load <- function(
         wb$vml[vml_file] <- read_xml(vml, pointer = FALSE)
       }
 
-      for (vml_rel in vmlDrawingRelsXML) {
+      if (length(vmlDrawingRelsXML))
         wb$vml_rels <- rep(list(""), vml_len) # vector("list", vml_len)
+
+      for (vml_rel in vmlDrawingRelsXML) {
 
         vml_file <- cdigit(basename(vml_rel), as_integer = TRUE)
 

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -32,6 +32,7 @@ Miriam Rainers
 Moritz Lell
 Noam Ross
 olivroy
+Paul Schmidt
 Philipp Schauberger
 Reinhold Kainhofer
 Renaud

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -742,3 +742,43 @@ test_that("has_drawings is defunct", {
     "argument \"has_drawing\" was removed"
   )
 })
+
+test_that("loading keeps every vmlDrawing.vml.rels (#1557 regression)", {
+
+  # A comment with a background image produces a vmlDrawing*.vml.rels per
+  # sheet. wb$vml_rels used to be re-initialised inside the load loop, so all
+  # but the last sheet's .vml.rels were dropped on a load + save round-trip,
+  # leaving dangling o:relid references (Excel repair prompt).
+  img <- system.file("extdata", "einstein.jpg", package = "openxlsx2")
+
+  wb <- wb_workbook()
+  for (i in 1:3) {
+    wb$add_worksheet(paste0("S", i))
+    wb$add_comment(
+      sheet   = i,
+      dims    = "B2",
+      comment = wb_comment(text = paste("comment", i), author = "x"),
+      file    = img
+    )
+  }
+
+  count_vmlrels <- function(f) {
+    sum(grepl("xl/drawings/_rels/vmlDrawing.*\\.vml\\.rels$",
+              unzip(f, list = TRUE)$Name))
+  }
+
+  tmp1 <- temp_xlsx()
+  on.exit(unlink(tmp1), add = TRUE)
+  wb$save(tmp1)
+  expect_equal(count_vmlrels(tmp1), 3)
+
+  wb2 <- wb_load(tmp1)
+  # all three entries survive the load (previously only the last was kept)
+  expect_equal(sum(vapply(wb2$vml_rels, function(x) !all(x == ""), NA)), 3)
+
+  tmp2 <- temp_xlsx()
+  on.exit(unlink(tmp2), add = TRUE)
+  wb2$save(tmp2)
+  expect_equal(count_vmlrels(tmp2), 3)
+
+})

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -782,3 +782,25 @@ test_that("loading keeps every vmlDrawing.vml.rels (#1557 regression)", {
   expect_equal(count_vmlrels(tmp2), 3)
 
 })
+
+test_that("dangling pageSetup printerSettings r:id is dropped on load (#1640)", {
+
+  # worksheets in this file carry a pageSetup r:id pointing to printerSettings
+  # binary blobs. openxlsx2 intentionally does not keep those blobs, so the
+  # reference dangled and triggered a repair prompt on round-trip.
+  fl <- testfile_path("unemployment-nrw202208.xlsx")
+  tmp <- temp_xlsx()
+  on.exit(unlink(tmp), add = TRUE)
+
+  has_rid <- function(wb) {
+    ps <- vapply(wb$worksheets, function(ws) paste0(ws$pageSetup, collapse = ""), NA_character_)
+    any(grepl("r:id", ps, fixed = TRUE))
+  }
+
+  wb <- wb_load(fl)
+  expect_false(has_rid(wb))
+
+  expect_silent(wb$save(tmp))
+  expect_false(has_rid(wb_load(tmp)))
+
+})


### PR DESCRIPTION
Fixes the `pageSetup r:id` half of #1640, following your preference in the issue
thread to remove the reference rather than ship the printer blob.

`wb_load()` keeps the worksheet/chartsheet `pageSetup` node verbatim, including
its `r:id`. That `r:id` only ever points at a `printerSettings*.bin` blob, which
openxlsx2 intentionally does not keep (the printerSettings relationship is
already dropped in the sheet rels handling). On `wb_save()` the `r:id` is written
back out, so it dangles and triggers Excel's repair prompt. Not a regression -
this has been the case since the rels filtering was introduced.

The fix strips the `r:id` from `pageSetup` right after the node is read, in both
the worksheet and the chartsheet load paths (both share the rels filtering that
removes printerSettings).

Minimal reprex (uses your `unemployment-nrw202208.xlsx`, which has 22 sheets each
carrying a `pageSetup r:id`):

```r
library(openxlsx2)
fl <- "unemployment-nrw202208.xlsx"  # from JanMarvin/openxlsx-data

count_rid <- function(f)
  sum(grepl("<pageSetup[^>]*r:id",
            vapply(grep("xl/worksheets/sheet", unzip(f, list = TRUE)$Name, value = TRUE),
                   function(s) paste(readLines(unz(f, s), warn = FALSE), collapse = ""),
                   character(1))))

f2 <- temp_xlsx(); wb_load(fl)$save(f2)
count_rid(fl)  # 22
count_rid(f2)  # before: 22 (dangling), after: 0
```

* `R/wb_load.R` - strip the `pageSetup` `r:id` on load (worksheet + chartsheet).
* `tests/testthat/test-loading_workbook.R` - round-trip regression test using
  `unemployment-nrw202208.xlsx`.
* `NEWS.md` - entry under Fixes.

This branch is stacked on top of #1641, so the diff shown until #1641 is merged
includes that commit too; once #1641 lands this collapses to the single
pageSetup commit. Merging in order #1641 -> this PR is conflict-free.

Co-Authored-By: Claude Opus 4.8