### PR TITLE
[styles] fix add_font(update=) over a multi-style range

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Add `builtins` argument to `wb_get_named_regions()`. [#1639](https://github.com/JanMarvin/openxlsx2/pull/1639)
 * `wb_load()` no longer drops all but the last worksheet's `vmlDrawing*.vml.rels` on a load + save round-trip. The `wb$vml_rels` initialisation was inside the read loop and wiped on every iteration ([#1641](https://github.com/JanMarvin/openxlsx2/pull/1641), @SchmidtPaul).
 * `wb_load()` now drops the `pageSetup` `r:id` reference pointing to the intentionally unshipped `printerSettings` binary blob, avoiding a dangling relationship that triggered a repair prompt on round-trip ([#1640](https://github.com/JanMarvin/openxlsx2/issues/1640), @SchmidtPaul)
+* `wb_add_font(update = )` no longer corrupts the worksheet when the targeted range spans two or more distinct cell styles. The loop over styles reused the `sel` variable for the font-element selector, clobbering the numeric cell index it also depends on (regression from [#1625](https://github.com/JanMarvin/openxlsx2/pull/1625), @SchmidtPaul).
 
 ## Breaking changes
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -9090,7 +9090,9 @@ wbWorkbook <- R6::R6Class(
               underline = "u",
               vert_align = "vertAlign"
             )
-            sel <- font_properties[update]
+            # font-element selector: keep this separate from `sel`, which holds
+            # the numeric cell index reused as `dim_sel <- sel[...]` each iteration
+            font_sel <- font_properties[update]
 
             font_id  <- as.integer(vapply(xml_attr(xf_prev, "xf"), "[[", "fontId", FUN.VALUE = NA_character_)) + 1L
             font_xml <- self$styles_mgr$styles$fonts[[font_id]]
@@ -9100,15 +9102,15 @@ wbWorkbook <- R6::R6Class(
             new_font <- read_font(read_xml(new_font))
 
             # update elements
-            old_font[sel] <- new_font[sel]
+            old_font[font_sel] <- new_font[font_sel]
 
             # write as xml font
 
-            sel <- c(
+            font_sel <- c(
               "b", "i", "strike", "condense", "extend", "outline", "shadow",
               "u", "vertAlign", "sz", "color", "name", "family", "charset", "scheme"
             )
-            new_font <- write_font(old_font[sel])
+            new_font <- write_font(old_font[font_sel])
           }
 
           self$styles_mgr$add(new_font, new_font)

--- a/tests/testthat/test-wb_styles.R
+++ b/tests/testthat/test-wb_styles.R
@@ -948,6 +948,30 @@ test_that("update font works", {
 
 })
 
+test_that("add_font(update=) handles a range spanning multiple cell styles", {
+
+  # B3 and B4 get different number formats, so the targeted range B3:B5 spans
+  # two distinct cell styles. The loop over styles must keep the numeric cell
+  # index intact across iterations (regression: the update= branch reused `sel`).
+  df <- data.frame(a = 1:5, b = c(1.1, 2.2, 3.3, 4.4, 5.5))
+  wb <- wb_workbook()$add_worksheet("S")
+  wb$add_data("S", df, start_row = 1)
+  wb$add_numfmt("S", dims = wb_dims(rows = 3, cols = 2), numfmt = "0.0")
+  wb$add_numfmt("S", dims = wb_dims(rows = 4, cols = 2), numfmt = "0.000")
+
+  expect_no_error(
+    wb$add_font("S", dims = wb_dims(rows = 3:5, cols = 2),
+                color = wb_color("A0A0A0"), update = "color")
+  )
+
+  # every targeted cell keeps its own base style and receives a style id
+  cc <- wb$worksheets[[1]]$sheet_data$cc
+  stys <- cc$c_s[cc$r %in% c("B3", "B4", "B5")]
+  expect_length(stys, 3)
+  expect_false(any(is.na(stys) | stys == ""))
+
+})
+
 test_that("adding bg_color and diagonal borders work", {
 
   wb <- wb_workbook()$


### PR DESCRIPTION
`wb_add_font(..., update = "color")` (or `update = TRUE`) errors and leaves the workbook unusable when the targeted cells span two or more distinct cell styles. A single style on the range works.

The loop over distinct styles in `add_font()` reuses the variable `sel` for the font-element selector inside the `update=` branch, while `dim_sel <- sel[cc$c_s == style]` at the top of each iteration relies on `sel` being the numeric cell index. From the second iteration on, `dim_sel` is character, `set_cell_style_sel()` appends named elements to `cc$c_s`, and the over-long column is rejected. Regression from #1625 (v1.27), which introduced the index-based `dim_sel <- sel[...]` pattern; it was added to the other restyle methods too, but only `add_font()` also reassigns `sel`. v1.26 and earlier are unaffected (they used `set_cell_style(sheet, dim, ...)`).

The fix renames the font-element selector to `font_sel` so the numeric `sel` survives the loop.

Minimal reprex (self-contained, synthetic):

```r
library(openxlsx2)
df <- data.frame(a = 1:5, b = c(1.1, 2.2, 3.3, 4.4, 5.5))
wb <- wb_workbook()$add_worksheet("S")
wb$add_data("S", df, start_row = 1)
# B3 and B4 get different number formats -> B3:B5 spans two cell styles
wb$add_numfmt("S", dims = wb_dims(rows = 3, cols = 2), numfmt = "0.0")
wb$add_numfmt("S", dims = wb_dims(rows = 4, cols = 2), numfmt = "0.000")

wb$add_font("S", dims = wb_dims(rows = 3:5, cols = 2),
            color = wb_color("A0A0A0"), update = "color")
#> before: Error in `$<-.data.frame`(...) : replacement has 17 rows, data has 12
#> after:  OK; B3,B4,B5 each keep their base style and get the colour merged in
```

* `R/class-workbook.R` - rename the `update=` font-element selector `sel` -> `font_sel` (+ a guard comment).
* `tests/testthat/test-wb_styles.R` - regression test covering a range spanning two cell styles.
* `NEWS.md` - entry under Fixes.

Confirmed against a source build: the test fails before the rename, passes after, and the full `test-wb_styles.R` is green. No separate issue since this is a clean regression with a ready fix - happy to open one or adjust anything.

Co-Authored-By: Claude Opus 4.8
