### PR TITLE
[color] wb_color(name=) applies the RGBA alpha-swap twice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * `wb_load()` no longer drops all but the last worksheet's `vmlDrawing*.vml.rels` on a load + save round-trip. The `wb$vml_rels` initialisation was inside the read loop and wiped on every iteration ([#1641](https://github.com/JanMarvin/openxlsx2/pull/1641), @SchmidtPaul).
 * `wb_load()` now drops the `pageSetup` `r:id` reference pointing to the intentionally unshipped `printerSettings` binary blob, avoiding a dangling relationship that triggered a repair prompt on round-trip ([#1640](https://github.com/JanMarvin/openxlsx2/issues/1640), @SchmidtPaul)
 * `wb_add_font(update = )` no longer corrupts the worksheet when the targeted range spans two or more distinct cell styles. The loop over styles reused the `sel` variable for the font-element selector, clobbering the numeric cell index it also depends on (regression from [#1625](https://github.com/JanMarvin/openxlsx2/pull/1625), @SchmidtPaul).
+* `wb_color(name = , format = "RGBA")` no longer returns the wrong colour. `name` and `hex` are alternative inputs, but both `validate_color()` calls fired, applying the RGBA alpha-swap twice (e.g. `name = "blue"` came out as red); the calls are now mutually exclusive (regression from [#1341](https://github.com/JanMarvin/openxlsx2/pull/1341), @SchmidtPaul).
 
 ## Breaking changes
 

--- a/R/class-color.R
+++ b/R/class-color.R
@@ -73,8 +73,14 @@ wb_color <- function(
   ) {
   format <- match.arg(format)
 
-  if (!is.null(name)) hex <-  validate_color(name, format = format)
-  if (!is.null(hex))  hex <-  validate_color(hex, format = format)
+  # `name` and `hex` are alternative inputs: validate exactly once. If both
+  # branches ran, validate_color() would re-apply the RGBA alpha-swap to the
+  # already-ARGB value (e.g. name = "blue" -> FF0000FF -> FFFF0000). See #1341.
+  if (!is.null(name)) {
+    hex <- validate_color(name, format = format)
+  } else if (!is.null(hex)) {
+    hex <- validate_color(hex, format = format)
+  }
 
   z <- c(
     auto    = as_xml_attr(auto),

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -446,6 +446,19 @@ test_that("validate_colors() works", {
   expect_equal(got, exp)
 })
 
+test_that("wb_color() applies the alpha format only once (#1341)", {
+
+  # `name` is an alternative to `hex`; the format must be applied only once.
+  # Regression guard: both validate_color() calls used to fire, swapping the
+  # RGBA alpha a second time (blue: FF0000FF -> FFFF0000 = red).
+  expect_equal(wb_color(name = "blue", format = "RGBA")[["rgb"]], "FF0000FF")
+  expect_equal(wb_color(name = "red",  format = "RGBA")[["rgb"]], "FFFF0000")
+
+  # ARGB default and the hex= path stay correct (single swap)
+  expect_equal(wb_color(name = "blue")[["rgb"]], "FF0000FF")
+  expect_equal(wb_color(hex = "FF0000FF", format = "RGBA")[["rgb"]], "FFFF0000")
+})
+
 test_that("basename2() works", {
 
   long_path <- paste0(


### PR DESCRIPTION
Refs #1648

`wb_color(name = "blue", format = "RGBA")` returns red (`FFFF0000` instead of `FF0000FF`). Every named colour is silently corrupted under `format = "RGBA"`, and the wrong colour is written verbatim into the file - no error, no warning.

`name` and `hex` are alternative inputs, but `wb_color()` runs both guard lines (`R/class-color.R:76-77`):

```r
if (!is.null(name)) hex <- validate_color(name, format = format)
if (!is.null(hex))  hex <- validate_color(hex, format = format)
```

The first line assigns `hex`, so the second always fires too and `validate_color()` runs a second time. For `format = "RGBA"` its alpha-swap (`helper-functions.R:138-142`, triggered on `nchar == 8`) is re-applied to the already-ARGB value: `blue -> FF0000FF -> FFFF0000`. Making the two branches mutually exclusive (`if/else`) validates each input exactly once.

Regression from #1341 (RGBA option, `1b399870`), first shipped in **v1.16**. Before that both lines ran without `format` (always ARGB), so the second call was a no-op. The default `format = "ARGB"` path is unaffected (the swap only runs for RGBA) and the `hex=` path is unchanged - this only stops the second, destructive re-interpretation, it does not change what `RGBA` means.

```r
library(openxlsx2)

wb_color(name = "blue", format = "RGBA")[["rgb"]]
#> before: "FFFF0000"   (red!)    after: "FF0000FF"   (blue, == the ARGB default)

wb <- wb_workbook()$add_worksheet()$add_data(x = 1)
wb$add_fill(dims = "A1", color = wb_color(name = "blue", format = "RGBA"))
#> before: <fgColor rgb="FFFF0000"/>    after: <fgColor rgb="FF0000FF"/>

wb_color(hex = "FF0000FF", format = "RGBA")[["rgb"]]
#> before & after: "FFFF0000"   (single swap, unchanged)
```

Changed: `R/class-color.R`, `tests/testthat/test-helper-functions.R`, `NEWS.md`. Affected: only `wb_color(name = , format = "RGBA")` (and `wb_colour`); ARGB default, `hex=`, `theme=`, `indexed=` unchanged. Verified against a source build (fail-before / pass-after, `test-helper-functions.R` green).