### PR TITLE
[args] warn on unknown arguments in CF, merge_cells, set_base_colors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,8 @@
 * `wb_load()` no longer drops all but the last worksheet's `vmlDrawing*.vml.rels` on a load + save round-trip. The `wb$vml_rels` initialisation was inside the read loop and wiped on every iteration ([#1641](https://github.com/JanMarvin/openxlsx2/pull/1641), @SchmidtPaul).
 * `wb_load()` now drops the `pageSetup` `r:id` reference pointing to the intentionally unshipped `printerSettings` binary blob, avoiding a dangling relationship that triggered a repair prompt on round-trip ([#1640](https://github.com/JanMarvin/openxlsx2/issues/1640), @SchmidtPaul)
 * `wb_add_font(update = )` no longer corrupts the worksheet when the targeted range spans two or more distinct cell styles. The loop over styles reused the `sel` variable for the font-element selector, clobbering the numeric cell index it also depends on (regression from [#1625](https://github.com/JanMarvin/openxlsx2/pull/1625), @SchmidtPaul).
-* `wb_color(name = , format = "RGBA")` no longer returns the wrong colour. `name` and `hex` are alternative inputs, but both `validate_color()` calls fired, applying the RGBA alpha-swap twice (e.g. `name = "blue"` came out as red); the calls are now mutually exclusive (regression from [#1341](https://github.com/JanMarvin/openxlsx2/pull/1341), @SchmidtPaul).
+* `wb_color(name = , format = "RGBA")` no longer returns the wrong colour. `name` and `hex` are alternative inputs, but both `validate_color()` calls fired, applying the RGBA alpha-swap twice (e.g. `name = "blue"` came out as red); the calls are now mutually exclusive ([#1649](https://github.com/JanMarvin/openxlsx2/pull/1649), @SchmidtPaul).
+* `wb_add_conditional_formatting()`, `wb_merge_cells()`, `wb_unmerge_cells()` and `wb_set_base_colors()` now warn about unknown or misspelled arguments instead of silently dropping them, bringing them in line with the other `wb_add_*` functions ([#1646](https://github.com/JanMarvin/openxlsx2/issues/1646), @SchmidtPaul).
 
 ## Breaking changes
 

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -4518,6 +4518,10 @@ wbWorkbook <- R6::R6Class(
     #' @return The `wbWorkbook` object
     set_base_colors = function(theme = "Office", ...) {
 
+      # warn on unknown/misspelled arguments; xml is the only extra key consumed
+      arguments <- c(ls(), "xml")
+      standardize_case_names(..., arguments = arguments)
+
       xml <- list(...)$xml
 
       if (is.null(xml)) {
@@ -5613,6 +5617,10 @@ wbWorkbook <- R6::R6Class(
     #' @return The `wbWorkbook` object, invisibly
     merge_cells = function(sheet = current_sheet(), dims = NULL, solve = FALSE, direction = NULL, ...) {
 
+      # warn on unknown/misspelled arguments; cols/rows are the deprecated keys
+      arguments <- c(ls(), "cols", "rows")
+      standardize_case_names(..., arguments = arguments)
+
       cols <- list(...)[["cols"]]
       rows <- list(...)[["rows"]]
 
@@ -5630,6 +5638,10 @@ wbWorkbook <- R6::R6Class(
     #' Removes cell merging for a sheet
     #' @return The `wbWorkbook` object, invisibly
     unmerge_cells = function(sheet = current_sheet(), dims = NULL, ...) {
+
+      # warn on unknown/misspelled arguments; cols/rows are the deprecated keys
+      arguments <- c(ls(), "cols", "rows")
+      standardize_case_names(..., arguments = arguments)
 
       cols <- list(...)[["cols"]]
       rows <- list(...)[["rows"]]
@@ -6088,6 +6100,10 @@ wbWorkbook <- R6::R6Class(
         ),
         ...
     ) {
+
+      # warn on unknown/misspelled arguments; cols/rows are the deprecated keys
+      arguments <- c(ls(), "cols", "rows")
+      standardize_case_names(..., arguments = arguments)
 
       cols <- list(...)[["cols"]]
       rows <- list(...)[["rows"]]

--- a/R/standardize.R
+++ b/R/standardize.R
@@ -83,7 +83,7 @@ standardize_case_names <- function(..., return = FALSE, arguments = NULL) {
 
   sel <- !got %in% arguments
   if (any(sel)) {
-    warning("unused arguments (", paste(got[sel], collapse = ", "), ")")
+    warning("unused arguments (", paste(got[sel], collapse = ", "), ")", call. = sys.call(1))
   }
 
   if (return) args

--- a/tests/testthat/test-standardize.R
+++ b/tests/testthat/test-standardize.R
@@ -33,3 +33,31 @@ test_that("deprecation warning works", {
   )
 
 })
+
+test_that("functions consuming ... warn on unknown arguments (#1646)", {
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = mtcars[1:3, ])
+
+  # these used to absorb unknown arguments silently (no warning at all).
+  # NB: use names that are not prefixes of a real argument, otherwise R's
+  # partial matching would bind them before they reach `...`.
+  expect_warning(
+    wb$add_conditional_formatting(dims = "A2:A4", rule = ">3", nonexistent = 1),
+    "unused arguments \\(nonexistent\\)"
+  )
+  expect_warning(
+    wb$merge_cells(dims = "A1:B1", directon = "row"),
+    "unused arguments \\(directon\\)"
+  )
+  expect_warning(
+    wb$unmerge_cells(dims = "A1:B1", nonexistent = 1),
+    "unused arguments \\(nonexistent\\)"
+  )
+  expect_warning(
+    wb$set_base_colors(nonexistent = 1),
+    "unused arguments \\(nonexistent\\)"
+  )
+
+  # a valid argument is not flagged
+  expect_no_warning(wb$merge_cells(dims = "F2:G2"))
+})


### PR DESCRIPTION
Refs #1648

`wb_add_conditional_formatting()`, `wb_merge_cells()`, `wb_unmerge_cells()` and `wb_set_base_colors()` pull individual legacy keys (`cols`/`rows`, `xml`) out of `...` but never call `standardize_case_names()`, so any other argument is absorbed without a warning - unlike the `wb_add_*` functions. This is the silent-absorption case from #1646.

```r
library(openxlsx2)
wb <- wb_workbook()$add_worksheet()$add_data(x = mtcars[1:3, ])

wb$merge_cells(dims = "A1:B1", directon = "row")   # typo of 'direction'
#> before: (silent)   after: Warning: unused arguments (directon)
wb$set_base_colors(nonexistent = 1)
#> before: (silent)   after: Warning: unused arguments (nonexistent)
```

Fix: add the established `standardize_case_names(..., arguments = c(ls(), <legacy keys>))` guard at the top of each function (same pattern as `add_image()`). The deprecated `cols`/`rows`/`xml` keys keep working.

Scope note: R's partial matching already binds prefix typos (`solv`->`solve`, `styl`->`style`), so only non-prefix typos and genuinely unknown names were dropped silently - those now warn. `wb_set_last_modified_by()` is left out deliberately (its legacy key `LastModifiedBy` is camelCase and would be rewritten by `standardize_case_names()`, needing special handling) - happy to add it separately.

Changed: `R/class-workbook.R`, `tests/testthat/test-standardize.R`, `NEWS.md`. Verified against a source build (silent before / warn after; standardize + conditional_formatting + class-workbook tests green).
