### PR TITLE
[docs] wb_dims(): rows = 0 never selected only the column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * `wb_add_font(update = )` no longer corrupts the worksheet when the targeted range spans two or more distinct cell styles. The loop over styles reused the `sel` variable for the font-element selector, clobbering the numeric cell index it also depends on (regression from [#1625](https://github.com/JanMarvin/openxlsx2/pull/1625), @SchmidtPaul).
 * `wb_color(name = , format = "RGBA")` no longer returns the wrong colour. `name` and `hex` are alternative inputs, but both `validate_color()` calls fired, applying the RGBA alpha-swap twice (e.g. `name = "blue"` came out as red); the calls are now mutually exclusive ([#1649](https://github.com/JanMarvin/openxlsx2/pull/1649), @SchmidtPaul).
 * `wb_add_conditional_formatting()`, `wb_merge_cells()`, `wb_unmerge_cells()` and `wb_set_base_colors()` now warn about unknown or misspelled arguments instead of silently dropping them, bringing them in line with the other `wb_add_*` functions ([#1646](https://github.com/JanMarvin/openxlsx2/issues/1646), @SchmidtPaul).
+* The `wb_dims()` documentation stated that `rows = 0` would affect only the column names, but that combination has always raised an error; the line now points to `select = "col_names"` instead ([#1651](https://github.com/JanMarvin/openxlsx2/pull/1651)@SchmidtPaul).
 
 ## Breaking changes
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -583,7 +583,7 @@ determine_select_valid <- function(args, select = NULL) {
 #' * `from_row` / `from_col` / `from_dims` the starting position of `x`
 #'   (The `dims` returned will assume that the top left corner of `x` is at `from_row / from_col`
 #' * `rows` Optional Which row span in `x` should this apply to.
-#'   If `rows` = 0, only column names will be affected.
+#'   To affect only the column names, use `select = "col_names"`.
 #' * `cols` a range of columns id in `x`, or one of the column names of `x`
 #'   (length 1 only accepted for column names of `x`.)
 #' * `row_names` A logical, this is to let `wb_dims()` know that `x` has row names or not.

--- a/man/wb_dims.Rd
+++ b/man/wb_dims.Rd
@@ -41,7 +41,7 @@ If you need another behavior, use \code{wb_dims()} without supplying \code{x}.
 \item \code{from_row} / \code{from_col} / \code{from_dims} the starting position of \code{x}
 (The \code{dims} returned will assume that the top left corner of \code{x} is at \code{from_row / from_col}
 \item \code{rows} Optional Which row span in \code{x} should this apply to.
-If \code{rows} = 0, only column names will be affected.
+To affect only the column names, use \code{select = "col_names"}.
 \item \code{cols} a range of columns id in \code{x}, or one of the column names of \code{x}
 (length 1 only accepted for column names of \code{x}.)
 \item \code{row_names} A logical, this is to let \code{wb_dims()} know that \code{x} has row names or not.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -96,6 +96,11 @@ test_that("`wb_dims()` works/errors as expected with unnamed arguments", {
   expect_error(wb_dims(rows = c(1), cols = c(-1)), "You must supply positive values to `cols`")
   expect_error(wb_dims(rows = c(-1), cols = c(1)), "You must supply positive values to `rows`")
 
+  # `rows = 0` is rejected; `select = "col_names"` is the documented way to
+  # target only the header row
+  expect_error(wb_dims(x = mtcars, rows = 0), "You must supply positive values to `rows`")
+  expect_no_error(wb_dims(x = mtcars, select = "col_names"))
+
   expect_error(wb_dims(1, 2, 3))
 })
 


### PR DESCRIPTION
Refs #1648

The `wb_dims()` documentation states: *"If `rows` = 0, only column names will be affected."* But `rows = 0` has always hit the `min(rows) < 1L` guard:

```r
wb_dims(x = mtcars, rows = 0)
#> Error: You must supply positive values to `rows`.
```

There has never been any `rows == 0` special-casing (since the line was added in #702), so the documented behaviour is unreachable. The working way to target only the header is `select = "col_names"`. This points the doc line there and adds a test pinning both the error and the working path. Docs only, no behaviour change.

Changed: `R/utils.R`, `man/wb_dims.Rd`, `tests/testthat/test-utils.R`, `NEWS.md`.
