### PR TITLE
Add c2i()

### DIFF
--- a/R/converters.R
+++ b/R/converters.R
@@ -30,7 +30,7 @@
 #' * Non-integer numeric values will typically be coerced or truncated; however,
 #'     infinite values will trigger an error to prevent invalid coordinate
 #'     generation.
-#' @seealso [col2int()]
+#' @seealso [col2int()] for inverse operation
 #'
 #' @examples
 #' # Convert a single index
@@ -93,7 +93,9 @@ check_range <- function(x) {
 #' * In compliance with spreadsheet software standards, the function validates
 #'     that indices do not exceed the maximum allowable column limit.
 #'
-#' @seealso [int2col()]
+#' @seealso 
+#' [int2col()] for inverse operation
+#' [c2i()] for short interface
 #'
 #' @examples
 #' # Convert standard labels

--- a/R/converters.R
+++ b/R/converters.R
@@ -137,6 +137,43 @@ col2int <- function(x) {
   col_to_int(x)
 }
 
+#' Short way of converting spreadsheet column notations to integers
+#'
+#' @description
+#' `c2i()` is a wrapper for `col2int()` to supply one short string of spreadsheet-style
+#' column identifiers separated by spaces (e.g., "A:C F P:AD") and convert them into
+#' corresponding integer indices. `col2int()` supports range notation like "A:Z",
+#' treats lower and upper case letters interchangeably and accepts mixing numeric
+#' and alphabetic characters.
+#'
+#' @param x One non-empty character string.
+#'
+#' @return An integer vector representing the column indices.
+#'
+#' @seealso [col2int()]
+#'
+#' @examples
+#' # Convert standard labels and ranges
+#' c2i("B:G X AF:AK BH")
+#'
+#' # Mix different alphabetic and numeric identifiers
+#' c2i("1 d:H 12:p Z DH")
+#'
+#' @export
+c2i <- function(x) {
+  if (!is.character(x)) {
+    stop("x must be character")
+  }
+  if (length(x) != 1) {
+    stop("x must be one string")
+  }
+  if (x == "") {
+    stop("x must be non-empty string")
+  }
+  x_split <- strsplit(x, split=" ", fixed=TRUE)[[1]]
+  col2int(x_split)
+}
+
 #' Converter spreadsheet row to integer
 #'
 #' Converts character row to integer and checks that the range is valid

--- a/tests/testthat/test-converters.R
+++ b/tests/testthat/test-converters.R
@@ -19,6 +19,20 @@ test_that("col2int", {
 
 })
 
+test_that("c2i", {
+  expect_equal(c2i("a"), 1)
+  expect_equal(c2i("1"), 1)
+  expect_equal(c2i("A"), 1)
+  expect_equal(c2i("A C:D"), c(1, 3, 4))
+  expect_equal(c2i("1 C:D K"), c(1, 3, 4, 11))
+  expect_equal(c2i("A C:D K AA:AD"), c(1, 3, 4, 11, 27, 28, 29, 30))
+
+  expect_error(c2i(list()), "x must be character")
+  expect_error(c2i(1:4), "x must be character")
+  expect_error(c2i(""), "x must be non-empty string")
+  expect_error(c2i(c("A B", "C D")), "x must be one string")
+})
+
 test_that("get_cell_refs", {
 
   got <- get_cell_refs(data.frame(1:3, 2:4))


### PR DESCRIPTION
It adds `c2i()` as short interface to `col2int()` following [this discussion](https://github.com/ycphs/openxlsx/issues/273#issuecomment-951192885) to original openxlsx. I compared `col2int()` in openxlsx and openxlsx2 and see that the new version is significantly more advanced, so it doesn't make much sense to add this to openxlsx. Despite `c2i()` is a very short wrapper, I've also tried to add meaningful unittests.

I see the doubt about whitespaces as separators in the original discussion, but to my opinion they seem like the most short and readable option. They, of course, can be changed to commas or semicolumns if some style must be maintained.