### PR TITLE
[misc] Update print method for workbook objects

### DIFF
--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -7421,7 +7421,7 @@ wbWorkbook <- R6::R6Class(
           ))
       }
 
-      cat(unlist(showText))
+      cat(unlist(showText), "\n")
       invisible(self)
     },
 

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -12,6 +12,7 @@ David Gohel
 david-f1976
 debarros
 Evan Cortens
+Felix Ventura de Oliveira
 Florian Weimer
 Gregory Fiumara
 Gregory Warnes

--- a/tests/testthat/test-class-workbook.R
+++ b/tests/testthat/test-class-workbook.R
@@ -1129,7 +1129,7 @@ test_that("wbWorkbook print works", {
            " ",
            "Worksheets:",
            " Sheets: Sheet 1, Sheet 1 (1), Sheet & NoSheet ",
-           " Write order: 1, 2, 3")
+           " Write order: 1, 2, 3 ")
   got <- capture.output(wb)
   expect_equal(got, exp)
 


### PR DESCRIPTION
Hi,

first of all thank you for maintaining this great package! I've been using it a lot lately. However, what bugged me a bit is that the print method for workbook objects does not print a newline character at the end. So while the current method generates this output:

```r
>   wb <- wb_workbook()$
+     add_worksheet("Sheet 1")$
+     add_worksheet("Sheet 1 (1)")$
+     add_worksheet("Sheet & NoSheet")
> print(wb)
A Workbook object.
 
Worksheets:
 Sheets: Sheet 1, Sheet 1 (1), Sheet & NoSheet 
 Write order: 1, 2, 3> 
```

the changes in this PR just add a newline to the end (Note how the prompt `>` is set to the next line).

```r
> print(wb)
A Workbook object.
 
Worksheets:
 Sheets: Sheet 1, Sheet 1 (1), Sheet & NoSheet 
 Write order: 1, 2, 3 
> 
```