### PR TITLE
[cf] fix rule leaking from block to block with non consecutive dims

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Fixes
 
 * A logic bug in `apply_numfmts()` was fixed that occured in combination with `cols` used via `wb_set_col_widths()`. In addition automatic sizing can now be tweaked via an offset `"auto+n"`. [#1683](https://github.com/JanMarvin/openxlsx2/pull/1683)
-* `wb_add_conditional_formatting()` no longer builds every block but the first from the previous block's leftovers when `dims` is non consecutive. `rule` was overwritten inside the loop over the blocks, so a `"colorScale"` got the colors as `cfvo` values, a `"containsText"` searched for the style name and a `"dataBar"` failed with `subscript out of bounds` (broken for every type but `"expression"` since [#1347](https://github.com/JanMarvin/openxlsx2/pull/1347), @SchmidtPaul).
+* `wb_add_conditional_formatting()` no longer builds every block but the first from the previous block's leftovers when `dims` is non consecutive. `rule` was overwritten inside the loop over the blocks, so a `"colorScale"` got the colors as `cfvo` values, a `"containsText"` searched for the style name and a `"dataBar"` failed with `subscript out of bounds`. Broken for every type but `"expression"` since [#1347](https://github.com/JanMarvin/openxlsx2/pull/1347) ([#1684](https://github.com/JanMarvin/openxlsx2/pull/1684), @SchmidtPaul).
 
 
 ***************************************************************************

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 * A logic bug in `apply_numfmts()` was fixed that occured in combination with `cols` used via `wb_set_col_widths()`. In addition automatic sizing can now be tweaked via an offset `"auto+n"`. [#1683](https://github.com/JanMarvin/openxlsx2/pull/1683)
+* `wb_add_conditional_formatting()` no longer builds every block but the first from the previous block's leftovers when `dims` is non consecutive. `rule` was overwritten inside the loop over the blocks, so a `"colorScale"` got the colors as `cfvo` values, a `"containsText"` searched for the style name and a `"dataBar"` failed with `subscript out of bounds` (broken for every type but `"expression"` since [#1347](https://github.com/JanMarvin/openxlsx2/pull/1347), @SchmidtPaul).
 
 
 ***************************************************************************

--- a/R/class-workbook.R
+++ b/R/class-workbook.R
@@ -6182,6 +6182,10 @@ wbWorkbook <- R6::R6Class(
       for (row in rows) {
         for (col in cols) {
 
+          # branches below overwrite `rule`; every block must start from the
+          # user input, not from the previous iteration
+          rule <- orig_rule
+
           switch(
             type,
 
@@ -6190,11 +6194,9 @@ wbWorkbook <- R6::R6Class(
               # entered to be exactly as an spreadsheet expression would be written?
               msg <- "When type == 'expression', "
 
-              if (!is.character(orig_rule) || length(orig_rule) != 1L) {
+              if (!is.character(rule) || length(rule) != 1L) {
                 stop(msg, "rule must be a single length character vector")
               }
-
-              rule <- orig_rule
 
               rule <- gsub("!=", "<>", rule)
               rule <- gsub("==", "=", rule)

--- a/tests/testthat/test-conditional_formatting.R
+++ b/tests/testthat/test-conditional_formatting.R
@@ -1078,6 +1078,164 @@ test_that("warning on cols > 2 and dims", {
 
 })
 
+test_that("colorScale is reset for each block of non consecutive dims", {
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(v = 1:5))
+  wb$add_conditional_formatting(
+    dims  = wb_dims(rows = c(2, 3, 5), cols = 1),
+    type  = "colorScale",
+    style = c("#FFFFFF", "#63BE7B")
+  )
+
+  exp <- data.frame(
+    sqref = c("A2:A3", "A5:A5"),
+    cf = c(
+      '<cfRule type="colorScale" priority="1"><colorScale><cfvo type="min"/><cfvo type="max"/><color rgb="FFFFFFFF"/><color rgb="FF63BE7B"/></colorScale></cfRule>',
+      '<cfRule type="colorScale" priority="2"><colorScale><cfvo type="min"/><cfvo type="max"/><color rgb="FFFFFFFF"/><color rgb="FF63BE7B"/></colorScale></cfRule>'
+    ),
+    stringsAsFactors = FALSE
+  )
+  got <- wb$worksheets[[1]]$conditionalFormatting
+  expect_identical(exp, got)
+  expect_save(wb)
+
+  # an explicit rule must not be replaced by the colors either
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(v = 1:5))
+  wb$add_conditional_formatting(
+    dims  = wb_dims(rows = c(2, 3, 5), cols = 1),
+    type  = "colorScale",
+    style = c("#FFFFFF", "#63BE7B"),
+    rule  = c(1, 5)
+  )
+
+  exp <- data.frame(
+    sqref = c("A2:A3", "A5:A5"),
+    cf = c(
+      '<cfRule type="colorScale" priority="1"><colorScale><cfvo type="num" val="1"/><cfvo type="num" val="5"/><color rgb="FFFFFFFF"/><color rgb="FF63BE7B"/></colorScale></cfRule>',
+      '<cfRule type="colorScale" priority="2"><colorScale><cfvo type="num" val="1"/><cfvo type="num" val="5"/><color rgb="FFFFFFFF"/><color rgb="FF63BE7B"/></colorScale></cfRule>'
+    ),
+    stringsAsFactors = FALSE
+  )
+  got <- wb$worksheets[[1]]$conditionalFormatting
+  expect_identical(exp, got)
+
+  # a gap in the rows and in the columns gives four blocks, all of them equal
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(a = 1:5, b = 1:5, c = 1:5))
+  wb$add_conditional_formatting(
+    dims  = wb_dims(rows = c(2, 3, 5), cols = c(1, 3)),
+    type  = "colorScale",
+    style = c("#FFFFFF", "#FFEB84", "#63BE7B")
+  )
+
+  exp <- c("A2:A3", "C2:C3", "A5:A5", "C5:C5")
+  got <- wb$worksheets[[1]]$conditionalFormatting$sqref
+  expect_identical(exp, got)
+
+  exp <- '<colorScale><cfvo type="min"/><cfvo type="percentile" val="50"/><cfvo type="max"/><color rgb="FFFFFFFF"/><color rgb="FFFFEB84"/><color rgb="FF63BE7B"/></colorScale>'
+  got <- unique(gsub("^<cfRule[^>]*>|</cfRule>$", "", wb$worksheets[[1]]$conditionalFormatting$cf))
+  expect_identical(exp, got)
+
+})
+
+test_that("dataBar is reset for each block of non consecutive dims", {
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(v = 1:5))
+  wb$add_conditional_formatting(
+    dims  = wb_dims(rows = c(2, 3, 5), cols = 1),
+    type  = "dataBar",
+    style = c("#FFFFFF", "#63BE7B")
+  )
+
+  exp <- data.frame(
+    sqref = c("A2:A3", "A5:A5"),
+    cf = c(
+      '<cfRule type="dataBar" priority="1"><dataBar showValue="1"><cfvo type="min"/><cfvo type="max"/><color rgb="FF63BE7B"/></dataBar><extLst><ext uri="{B025F937-C7B1-47D3-B67F-A62EFF666E3E}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40000}</x14:id></ext></extLst></cfRule>',
+      '<cfRule type="dataBar" priority="2"><dataBar showValue="1"><cfvo type="min"/><cfvo type="max"/><color rgb="FF63BE7B"/></dataBar><extLst><ext uri="{B025F937-C7B1-47D3-B67F-A62EFF666E3E}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"><x14:id>{F7189283-14F7-4DE0-9601-54DE9DB40001}</x14:id></ext></extLst></cfRule>'
+    ),
+    stringsAsFactors = FALSE
+  )
+  got <- wb$worksheets[[1]]$conditionalFormatting
+  expect_identical(exp, got)
+  expect_save(wb)
+
+  # a single color used to end up as a length one rule and error out. The
+  # result is the same as above, the second color is not part of the cfRule
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(v = 1:5))
+  expect_silent(
+    wb$add_conditional_formatting(
+      dims  = wb_dims(rows = c(2, 3, 5), cols = 1),
+      type  = "dataBar",
+      style = "#63BE7B"
+    )
+  )
+
+  got <- wb$worksheets[[1]]$conditionalFormatting
+  expect_identical(exp, got)
+
+})
+
+test_that("text rules are reset for each block of non consecutive dims", {
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(a = "b", b = "b", c = "b"))
+  wb$add_dxfs_style(name = "hit", bg_fill = wb_color("red"))
+  wb$add_conditional_formatting(
+    dims  = wb_dims(rows = 2, cols = c(1, 3)),
+    type  = "containsText",
+    rule  = "b",
+    style = "hit"
+  )
+
+  exp <- data.frame(
+    sqref = c("A2:A2", "C2:C2"),
+    cf = c(
+      '<cfRule type="containsText" dxfId="0" priority="1" operator="containsText" text="b"><formula>NOT(ISERROR(SEARCH("b", A2)))</formula></cfRule>',
+      '<cfRule type="containsText" dxfId="0" priority="2" operator="containsText" text="b"><formula>NOT(ISERROR(SEARCH("b", C2)))</formula></cfRule>'
+    ),
+    stringsAsFactors = FALSE
+  )
+  got <- wb$worksheets[[1]]$conditionalFormatting
+  expect_identical(exp, got)
+  expect_save(wb)
+
+  # the neighboring types read the rule the same way
+  for (type in c("notContainsText", "beginsWith", "endsWith")) {
+    wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(a = "b", b = "b", c = "b"))
+    wb$add_dxfs_style(name = "hit", bg_fill = wb_color("red"))
+    wb$add_conditional_formatting(
+      dims  = wb_dims(rows = 2, cols = c(1, 3)),
+      type  = type,
+      rule  = "b",
+      style = "hit"
+    )
+
+    exp <- c("b", "b")
+    got <- gsub('.* text="([^"]*)".*', "\\1", wb$worksheets[[1]]$conditionalFormatting$cf)
+    expect_identical(exp, got, info = type)
+  }
+
+})
+
+test_that("expression is anchored to each block of non consecutive dims", {
+
+  wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(a = 1, b = 1, c = 1))
+  wb$add_conditional_formatting(
+    dims = wb_dims(rows = 2, cols = c(1, 3)),
+    rule = "<0"
+  )
+
+  exp <- data.frame(
+    sqref = c("A2:A2", "C2:C2"),
+    cf = c(
+      '<cfRule type="expression" dxfId="0" priority="1"><formula>A2&lt;0</formula></cfRule>',
+      '<cfRule type="expression" dxfId="0" priority="2"><formula>C2&lt;0</formula></cfRule>'
+    ),
+    stringsAsFactors = FALSE
+  )
+  got <- wb$worksheets[[1]]$conditionalFormatting
+  expect_identical(exp, got)
+
+})
+
 test_that("un_list works", {
 
   tmp <- temp_xlsx()


### PR DESCRIPTION
`wb_add_conditional_formatting()` still writes wrong rules for a non consecutive `dims`, which is the complaint of #1346 ("I ended up with broken xlsx instead of failing quickly"). #1347 [split `dims` into consecutive row and column blocks and looped over them](https://github.com/JanMarvin/openxlsx2/blob/6a391297c375ca1021d7bf73bf64e6f98cd12994/R/class-workbook.R#L6172-L6183) and does solve the `expression` case that #1346 actually reported, but only that one branch inside the loop was made re-entrant. For every other `type` the second and any further block is built from what the previous iteration left behind.

I ran into it while porting the Excel helpers of my own package from openxlsx to openxlsx2: a color scale over a set of rows with gaps renders as a scale for the first block and flat for the rest.

Six branches read `rule` into `values` and then overwrite it with `style` ([`colorScale`](https://github.com/JanMarvin/openxlsx2/blob/6a391297c375ca1021d7bf73bf64e6f98cd12994/R/class-workbook.R#L6238-L6239), `dataBar`, `containsText`, `notContainsText`, `beginsWith`, `endsWith`), and only `expression` restores it from [`orig_rule`](https://github.com/JanMarvin/openxlsx2/blob/6a391297c375ca1021d7bf73bf64e6f98cd12994/R/class-workbook.R#L6180). The other branches that assign `rule <- style` never read `rule`, so for them it is idempotent. Gaps in rows and gaps in columns both trigger it. Introduced with #1347 (v1.16), which is where the loop came in; before that a non consecutive `dims` was reduced to its bounding box.

```r
library(openxlsx2)

wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(v = 1:5))
wb$add_conditional_formatting(
  dims  = wb_dims(rows = c(2, 3, 5), cols = 1),
  type  = "colorScale",
  style = c("#FFFFFF", "#63BE7B")
)
wb$worksheets[[1]]$conditionalFormatting$cf[2]
#> main:    <cfRule type="colorScale" priority="2"><colorScale><cfvo type="num" val="FFFFFFFF"/><cfvo type="num" val="FF63BE7B"/><color rgb="FFFFFFFF"/><color rgb="FF63BE7B"/></colorScale></cfRule>
#> this PR: <cfRule type="colorScale" priority="2"><colorScale><cfvo type="min"/><cfvo type="max"/><color rgb="FFFFFFFF"/><color rgb="FF63BE7B"/></colorScale></cfRule>

wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(a = "b", b = "b", c = "b"))
wb$add_dxfs_style(name = "hit", bg_fill = wb_color("red"))
wb$add_conditional_formatting(
  dims  = wb_dims(rows = 2, cols = c(1, 3)),
  type  = "containsText",
  rule  = "b",
  style = "hit"
)
wb$worksheets[[1]]$conditionalFormatting$cf[2]
#> main:    <cfRule type="containsText" dxfId="0" priority="2" operator="containsText" text="hit"><formula>NOT(ISERROR(SEARCH("hit", C2)))</formula></cfRule>
#> this PR: <cfRule type="containsText" dxfId="0" priority="2" operator="containsText" text="b"><formula>NOT(ISERROR(SEARCH("b", C2)))</formula></cfRule>

wb <- wb_workbook()$add_worksheet()$add_data(x = data.frame(v = 1:5))
wb$add_conditional_formatting(
  dims  = wb_dims(rows = c(2, 3, 5), cols = 1),
  type  = "dataBar",
  style = "#63BE7B"
)
#> main:    Error in values[[2]] : subscript out of bounds
wb$worksheets[[1]]$conditionalFormatting$cf[2]
#> this PR: <cfRule type="dataBar" priority="2"><dataBar showValue="1"><cfvo type="min"/><cfvo type="max"/><color rgb="FF63BE7B"/></dataBar>...
```

The fix moves the reset out of the `expression` branch to the top of the loop, so every block starts from what the user passed. The one behaviour change beyond that: with an invalid `rule` the per block validation now runs per block, so `type = "between"` with `rule = NULL` warns four times instead of two.

The `switch()` is loop invariant except for the cell reference that `expression` builds, so hoisting it out of the loop would make this class of leak structurally impossible. That is a refactor of a 200 line function though, so I kept it out of a fix that should be safe for a patch release. Happy to open it separately if you want it.

Not affected, and left alone: `between` (`range()` is idempotent), `topN`/`bottomN` (their values come from `params`), `iconSet` (never reassigns `rule`), and the `*Blanks`/`*Errors`/`duplicatedValues`/`uniqueValues` branches. I ran all 17 types against both builds: the six above are the only ones whose second block changes, and the first block is byte identical for every one of them, so nothing changes for a consecutive `dims`. The block loop is also the only one of its kind here - `merge_cells()` got its non consecutive `dims` in #1357 by splitting the `dims` string and treating each piece on its own, so it has no per block state to leak.

Changed files:

* `R/class-workbook.R` - reset `rule` from `orig_rule` at the top of the block loop instead of inside the `expression` branch
* `tests/testthat/test-conditional_formatting.R` - one regression test per affected family (`colorScale` including an explicit `rule` and a four block `dims`, `dataBar`, the four text types), plus an `expression` case, which passes on `main` and is there to pin the reset that used to live in that branch
* `NEWS.md`

Verified against real source builds of `main` and this branch: on `main` the new tests produce 8 failures and 1 error, on this branch `test-conditional_formatting.R` is green, and `R CMD check` shows the same result as `main` (one unrelated pre-existing test failure over a missing `testfiles/loadExample.xlsx`).
